### PR TITLE
Feature/updating lavergne20 c4

### DIFF
--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1708,25 +1708,24 @@ class CalcOptimalChi:
     def lavergne20_c4(self) -> None:
         r"""Calculate soil moisture corrected :math:`\chi` for C4 plants.
 
-        This method applies the same calculations described in the
-        :meth:`~pyrealm.pmodel.CalcOptimalChi.lavergne20` method but using parameter
-        values for C4 plants. See that method for the calculation details.
+        This method calculates :math:`\beta` as a function of soil moisture following
+        the equation described in the :meth:`~pyrealm.pmodel.CalcOptimalChi.lavergne20`
+        method.  However, the default coefficients of the moisture scaling from
+        :cite:`lavergne:2020a` for C3 plants are adjusted to match the theoretical
+        expectation that :math:`\beta` for C4 plants is nine times smaller than
+        :math:`\beta` for C3 plants (see :meth:`~pyrealm.pmodel.CalcOptimalChi.c4`):
+        :math:`b` is unchanged but :math:`a_{C4} = a_{C3} - log(9)`.
+
+        Following the calculation of :math:`\beta`, this method then follows the
+        calculations described in :meth:`~pyrealm.pmodel.CalcOptimalChi.c4_no_gamma`:
+        :math:`m_j = 1.0`  because photorespiration is negligible, but :math:`m_c` and
+        hence :math:`m_{joc}` are calculated.
 
         Note:
 
         This is an **experimental approach**. The research underlying
         :cite:`lavergne:2020a`, found **no relationship** between C4 :math:`\beta`
         values and soil moisture in leaf gas exchange measurements.
-
-        However, the :meth:`~pyrealm.pmodel.CalcOptimalChi.c4` method describes a
-        theoretical expectation that :math:`\beta` for C4 plants is nine times smaller
-        than :math:`\beta` for C3 plants. This method therefore provides soil moisture
-        dependent estimates of :math:`\beta` for C4 plants that follow that
-        expectation.
-
-        The default coefficients of the moisture scaling from :cite:`lavergne:2020a` for
-        C3 plants are simply adjusted to maintain that scaling: :math:`b` is unchanged
-        but :math:`a_{C4} = a_{C3} - log(9)`.
 
         Examples:
             >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,
@@ -1735,13 +1734,13 @@ class CalcOptimalChi:
             >>> round(vals.beta, 5)
             24.97251
             >>> round(vals.chi, 5)
-            0.49804
+            0.44432
             >>> round(vals.mc, 5)
-            1.0
+            0.28091
             >>> round(vals.mj, 5)
             1.0
             >>> round(vals.mjoc, 5)
-            1.0
+            3.55989
         """
 
         # Warn that this is experimental
@@ -1763,9 +1762,7 @@ class CalcOptimalChi:
         )
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
-        self.beta = self.pmodel_params.beta_cost_ratio_c4
         self.xi = np.sqrt((self.beta * self.env.kmm) / (1.6 * self.env.ns_star))
-
         self.chi = self.xi / (self.xi + np.sqrt(self.env.vpd))
 
         # mj is equal to 1 as gammastar is null

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1771,6 +1771,8 @@ class CalcOptimalChi:
             1.0 - self.env.gammastar / self.env.ca
         ) * self.xi / (self.xi + np.sqrt(self.env.vpd))
 
+        self.ci = self.chi * self.env.ca
+
         # Set mj, mc, mjoc to 1
         if self.shape == 1:
             self.mc = 1.0

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -616,14 +616,14 @@ def calc_soilmstress(
     Table 1 of :cite:`Stocker:2020dh` specifically for the 'FULL' use case, with
     ``method_jmaxlim="wang17"``, ``do_ftemp_kphio=TRUE``.
 
-    Args
+    Args:
         soilm: Relative soil moisture as a fraction of field capacity
             (unitless). Defaults to 1.0 (no soil moisture stress).
         meanalpha: Local annual mean ratio of actual over potential
             evapotranspiration, measure for average aridity. Defaults to 1.0.
         pmodel_params: An instance of :class:`~pyrealm.param_classes.PModelParams`.
 
-    Other Parameters
+    Other Parameters:
         theta0: lower bound of soil moisture
             (:math:`\theta_0`, `pmodel_params.soilmstress_theta0`).
         thetastar: upper bound of soil moisture
@@ -742,11 +742,11 @@ def calc_patm(
 
         p(z) = p_0 ( 1 - L z / K_0) ^{ G M / (R L) },
 
-    Args
+    Args:
         elv: Elevation above sea-level (:math:`z`, metres above sea level.)
         pmodel_params: An instance of :class:`~pyrealm.param_classes.PModelParams`.
 
-    Other Parameters
+    Other Parameters:
         G: gravity constant (:math:`g`, `pmodel_params.k_G`)
         Po: standard atmospheric pressure at sea level
             (:math:`p_0`, `pmodel_params.k_Po`)

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1762,26 +1762,22 @@ class CalcOptimalChi:
             + self.pmodel_params.lavergne_2020_a_c4
         )
 
-        # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.xi = np.sqrt(
-            (self.beta * (self.env.kmm + self.env.gammastar)) / (1.6 * self.env.ns_star)
-        )
+        # Calculate chi and xi as in Prentice 14 but removing gamma terms.
+        self.beta = self.pmodel_params.beta_cost_ratio_c4
+        self.xi = np.sqrt((self.beta * self.env.kmm) / (1.6 * self.env.ns_star))
 
-        self.chi = self.env.gammastar / self.env.ca + (
-            1.0 - self.env.gammastar / self.env.ca
-        ) * self.xi / (self.xi + np.sqrt(self.env.vpd))
+        self.chi = self.xi / (self.xi + np.sqrt(self.env.vpd))
 
-        self.ci = self.chi * self.env.ca
-
-        # Set mj, mc, mjoc to 1
+        # mj is equal to 1 as gammastar is null
         if self.shape == 1:
-            self.mc = 1.0
             self.mj = 1.0
-            self.mjoc = 1.0
         else:
-            self.mc = np.ones(self.shape)
             self.mj = np.ones(self.shape)
-            self.mjoc = np.ones(self.shape)
+
+        # Calculate m and mc and m/mc
+        self.ci = self.chi * self.env.ca
+        self.mc = (self.ci) / (self.ci + self.env.kmm)
+        self.mjoc = self.mj / self.mc
 
     def c4(self) -> None:
         r"""Estimate :math:`\chi` for C4 plants following :cite:`Prentice:2014bc`.

--- a/source/pmodel/c3c4model.md
+++ b/source/pmodel/c3c4model.md
@@ -23,7 +23,7 @@ Compared to C3 plants, plants using the C4 photosynthetic pathway:
 
 This gives C4 plants a substantial competitive advantage in warm, dry and low
 CO2 environments. The {class}`~pyrealm.pmodel.C3C3Competition` class provides an
-implementation of a model {cite}`lavergne:2020a` that estimates the expected
+implementation of a model {cite}`lavergne:2022a` that estimates the expected
 fraction of GPP from C4 plants. It uses predictions of GPP from the
 {class}`~pyrealm.pmodel.PModel` assuming communities consisting solely of C3 or
 C4 plants to calculate the expected fraction of C4 plants in the community and

--- a/source/pmodel/optimal_chi.md
+++ b/source/pmodel/optimal_chi.md
@@ -165,9 +165,8 @@ plot_opt_chi(pmodel_c3)
 
 ## Method {meth}`~pyrealm.pmodel.CalcOptimalChi.c4`
 
-This **C4_method** follows the approach detailed in {cite}`Prentice:2014bc`, but
-uses a C4 specific version of the unit cost ratio ($\beta$). It also sets
-$m_j = m_c = 1$.
+This **C4_method** follows the approach detailed in {cite}`Prentice:2014bc`, but uses a
+C4 specific version of the unit cost ratio ($\beta$). It also sets $m_j = m_c = 1$.
 
 See {meth}`~pyrealm.pmodel.CalcOptimalChi.c4` for details.
 
@@ -181,11 +180,10 @@ plot_opt_chi(pmodel_c4)
 
 ## Method {meth}`~pyrealm.pmodel.CalcOptimalChi.c4_no_gamma`
 
-This method drops terms from the {cite}`Prentice:2014bc` to reflect the
-assumption that photorespirations ($\Gamma^\ast$) is negligible in C4
-photosynthesis. It uses the same $\beta$ estimate as
-{meth}`~pyrealm.pmodel.CalcOptimalChi.c4` and also also sets $m_j = 1$, but
-$m_c$ is calculated as in {meth}`~pyrealm.pmodel.CalcOptimalChi.prentice14`.
+This method drops terms from the {cite}`Prentice:2014bc` to reflect the assumption that
+photorespiration ($\Gamma^\ast$) is negligible in C4 photosynthesis. It uses the same
+$\beta$ estimate as {meth}`~pyrealm.pmodel.CalcOptimalChi.c4` and also also sets $m_j =
+1$, but $m_c$ is calculated as in {meth}`~pyrealm.pmodel.CalcOptimalChi.prentice14`.
 
 See {meth}`~pyrealm.pmodel.CalcOptimalChi.c4_no_gamma` for details.
 
@@ -203,8 +201,8 @@ These methods follow the approach detailed in {cite}`lavergne:2020a`, which fitt
 an empirical model of $\beta$ for C3 plants as a function of volumetric soil moisture
 ($\theta$, m3/m3), using data from leaf gas exchange measurements. The C4 method takes
 the same approach but with modified empirical parameters giving predictions of
-$\beta_{C3} = 9 \times \beta_{C4}$, as in the {meth}`~pyrealm.pmodel.CalcOptimalChi.c4`
-method.
+$\beta_{C3} = 9 \times \beta_{C4}$. Following the approach of
+{meth}`~pyrealm.pmodel.CalcOptimalChi.c4_no_gamma`, $m_c$ is calculated but $m_j=1$.
 
 ```{warning}
 Note that {cite}`lavergne:2020a` found **no relationship** between C4 $\beta$
@@ -310,16 +308,13 @@ pyplot.tight_layout()
 
 ### $m_j$ and $m_c$
 
-As with the {meth}`~pyrealm.pmodel.CalcOptimalChi.c4` method, the
-{meth}`~pyrealm.pmodel.CalcOptimalChi.lavergne20_c4` method set $m_j=m_c=1$, but the
-plots below illustrate the impact of temperature and  $\theta$ on  $m_j$ and $m_c$ for
-C3 plants, again with constant atmospheric pressure (101325 Pa) and CO2
-(280 ppm).
+The plots below illustrate the impact of temperature and  $\theta$ on  $m_j$ and $m_c$,
+again with constant atmospheric pressure (101325 Pa) and CO2 (280 ppm).
 
 ```{code-cell}
 :tags: [hide-input]
 
-fig, (ax1, ax2) = pyplot.subplots(1, 2, figsize=(10, 5), sharey=False)
+fig, ((ax1, ax2), (ax3, ax4)) = pyplot.subplots(2, 2, figsize=(10, 5), sharey=False)
 
 ax1.plot(
     tc_1d,
@@ -357,6 +352,42 @@ ax2.plot(tc_1d, chi_lavc3_lo.mc[0, :, 1, 0], "r--")
 ax2.set_title(f"Variation in $m_c$ for C3 plants (`lavergne20_c3`)")
 ax2.set_ylabel(r"$m_c$")
 ax2.set_xlabel("Temperature (°C)")
+
+ax3.plot(
+    tc_1d,
+    chi_lavc4_hi.mj[0, :, 0, 0],
+    "b-",
+    label=f"VPD = {vpd_1d[0]}, theta={theta_hi}",
+)
+ax3.plot(
+    tc_1d,
+    chi_lavc4_hi.mj[0, :, 1, 0],
+    "b--",
+    label=f"VPD = {vpd_1d[1]}, theta={theta_hi}",
+)
+ax3.plot(
+    tc_1d,
+    chi_lavc4_lo.mj[0, :, 0, 0],
+    "r-",
+    label=f"VPD = {vpd_1d[0]}, theta={theta_lo}",
+)
+ax3.plot(
+    tc_1d,
+    chi_lavc4_lo.mj[0, :, 1, 0],
+    "r--",
+    label=f"VPD = {vpd_1d[1]}, theta={theta_lo}",
+)
+ax1.set_title(f"Variation in $m_j$ for C4 plants (`lavergne20_c4`)")
+ax1.set_ylabel(r"$m_j$")
+ax1.set_xlabel("Temperature (°C)")
+
+ax4.plot(tc_1d, chi_lavc4_hi.mc[0, :, 0, 0], "b-")
+ax4.plot(tc_1d, chi_lavc4_hi.mc[0, :, 1, 0], "b--")
+ax4.plot(tc_1d, chi_lavc4_lo.mc[0, :, 0, 0], "r-")
+ax4.plot(tc_1d, chi_lavc4_lo.mc[0, :, 1, 0], "r--")
+ax4.set_title(f"Variation in $m_c$ for C3 plants (`lavergne20_c3`)")
+ax4.set_ylabel(r"$m_c$")
+ax4.set_xlabel("Temperature (°C)")
 
 pyplot.tight_layout()
 ```

--- a/source/pmodel/optimal_chi.md
+++ b/source/pmodel/optimal_chi.md
@@ -314,7 +314,7 @@ again with constant atmospheric pressure (101325 Pa) and CO2 (280 ppm).
 ```{code-cell}
 :tags: [hide-input]
 
-fig, ((ax1, ax2), (ax3, ax4)) = pyplot.subplots(2, 2, figsize=(10, 5), sharey=False)
+fig, ((ax1, ax3), (ax2, ax4)) = pyplot.subplots(2, 2, figsize=(10, 10), sharey=True)
 
 ax1.plot(
     tc_1d,
@@ -377,15 +377,15 @@ ax3.plot(
     "r--",
     label=f"VPD = {vpd_1d[1]}, theta={theta_lo}",
 )
-ax1.set_title(f"Variation in $m_j$ for C4 plants (`lavergne20_c4`)")
-ax1.set_ylabel(r"$m_j$")
-ax1.set_xlabel("Temperature (°C)")
+ax3.set_title(f"Variation in $m_j$ for C4 plants (`lavergne20_c4`)")
+ax3.set_ylabel(r"$m_j$")
+ax3.set_xlabel("Temperature (°C)")
 
 ax4.plot(tc_1d, chi_lavc4_hi.mc[0, :, 0, 0], "b-")
 ax4.plot(tc_1d, chi_lavc4_hi.mc[0, :, 1, 0], "b--")
 ax4.plot(tc_1d, chi_lavc4_lo.mc[0, :, 0, 0], "r-")
 ax4.plot(tc_1d, chi_lavc4_lo.mc[0, :, 1, 0], "r--")
-ax4.set_title(f"Variation in $m_c$ for C3 plants (`lavergne20_c3`)")
+ax4.set_title(f"Variation in $m_c$ for C4 plants (`lavergne20_c4`)")
 ax4.set_ylabel(r"$m_c$")
 ax4.set_xlabel("Temperature (°C)")
 

--- a/source/refs.bib
+++ b/source/refs.bib
@@ -343,8 +343,8 @@
 @article{lavergne:2022a,
   title = {A Semi-Empirical Model for Primary Production, Isotopic Discrimination and Competition of {{C3}} and {{C4}} Plants},
   author = {Lavergne, Ali{\'e}nor and Harrison, Sandy P. and Atsawawaranunt, Kamolphat and Dong, Ning and Prentice, Iain Colin},
-  year = {2022},
-  journal = {Global Ecology and Biogeography (submitted)},
+  year = {Submitted},
+  journal = {Global Change Biology},
   file = {/Users/dorme/Zotero/storage/C4HSADV3/Lavergneetal_GEB.docx}
 }
 

--- a/test/pmodel/test_pmodel.py
+++ b/test/pmodel/test_pmodel.py
@@ -793,7 +793,7 @@ def test_pmodel_class_c4(request, values, pmodelenv, soilmstress, ftemp_kphio, e
 @pytest.mark.parametrize("theta", np.linspace(0, 0.8, 9))
 @pytest.mark.parametrize(
     "variable_method, fixed_method, is_C4",
-    [("lavergne20_c3", "prentice14", False), ("lavergne20_c4", "c4", True)],
+    [("lavergne20_c3", "prentice14", False), ("lavergne20_c4", "c4_no_gamma", True)],
 )
 def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
 

--- a/test/pmodel/test_pmodel.py
+++ b/test/pmodel/test_pmodel.py
@@ -778,3 +778,47 @@ def test_pmodel_class_c4(request, values, pmodelenv, soilmstress, ftemp_kphio, e
     warnings.warn("Skipping gs test for cases with numerical instability")
     # assert np.allclose(np.nan_to_num(ret.gs),
     #                 np.nan_to_num(expected['gs']))
+
+
+# Internal testing of functions
+
+
+# ------------------------------------------
+# Testing equivalence and functionality of lavergne methods for soil moisture impacts on
+# the beta cost parameter
+# ------------------------------------------
+
+
+@pytest.mark.parametrize("tc", np.linspace(-5, 45, 5))
+@pytest.mark.parametrize("theta", np.linspace(0, 0.8, 9))
+@pytest.mark.parametrize(
+    "variable_method, fixed_method, is_C4",
+    [("lavergne20_c3", "prentice14", False), ("lavergne20_c4", "c4", True)],
+)
+def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
+
+    # Cannot do this test using N-D inputs because the PModelParams expect scalar values
+    # for paramaterizing beta - you can't set an array of values. So, test combinations
+    # of temperature and soil moisture.
+
+    env = pmodel.PModelEnvironment(tc=tc, patm=101325, vpd=100, co2=400, theta=theta)
+
+    # lavergne method
+    mod_theta = pmodel.PModel(env, method_optchi=variable_method)
+
+    # get equivalent model for fixed beta
+    if is_C4:
+        params = pmodel.PModelParams(beta_cost_ratio_c4=mod_theta.optchi.beta)
+    else:
+        params = pmodel.PModelParams(beta_cost_ratio_prentice14=mod_theta.optchi.beta)
+
+    env = pmodel.PModelEnvironment(
+        tc=tc, patm=101325, vpd=100, co2=400, theta=theta, pmodel_params=params
+    )
+
+    mod_fixed = pmodel.PModel(env, method_optchi=fixed_method)
+
+    assert np.allclose(mod_theta.optchi.chi, mod_fixed.optchi.chi)
+    assert np.allclose(mod_theta.optchi.mj, mod_fixed.optchi.mj)
+    assert np.allclose(mod_theta.optchi.mc, mod_fixed.optchi.mc)
+    assert np.allclose(mod_theta.optchi.mjoc, mod_fixed.optchi.mjoc)


### PR DESCRIPTION
This PR:

* Fixes a bug in `lavergne20_c4`, Closes #10 
* Updates `lavergne20_c4` to follow the model of `c4_no_gamma`:  $\beta$ is calculated from soil $\theta$ and then $m_c$ and $m_j$ are calculated assuming no photorespiration and hence $m_j = 1$ but $m_c$ varies.
* Updates the docstrings and documentation for the method.