### PR TITLE
Tidying PModel module docstrings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -98,16 +98,21 @@
       - Shifting package management to using poetry and implementing better QA toolchain
         including pre-commit suite.
       - Moving docs out of root and into docs/source, docs/build etc.
-0.9.0 - Moved support python versions to >=3.9, <3.11
-      - Update to poetry 1.2+
-      - Substantial maintenance review
-      - Implementing mypy checking via pre-commit and package config
-      - Fixed mypy errors (missing types, clashes etc)
-      - Updated typing to use consistent NDArray and remove edge case code to handle
-        scalar inputs. Users now expected to provide arrays.
-      - Using importlib to single source package version from pyproject.toml
-      - Moved test/ to tests/ and added __init__.py - module paths in testing.
-      - Restructure of TModel code and extended test suite
-      - Extended test suite for psychrometric functions, bug fix in HygroParams.
-      - Better definition and handling of class attributes to avoid unnecessary Optional
-        types in __init__ methods.
+0.9.0 - Substantial maintenance review
+      - Breaking changes:
+        - Support for scalar inputs removed - numpy arrays now expected as inputs.
+        - Python minimum version is now 3.9
+      - Detailed changes:
+        - Moved support python versions to >=3.9, <3.11
+        - Update to poetry 1.2+
+        - Implementing mypy checking via pre-commit and package config
+        - Fixed mypy errors (missing types, clashes etc)
+        - Updated typing to use consistent NDArray and remove edge case code to handle
+          scalar inputs. Users now expected to provide arrays.
+        - Using importlib to single source package version from pyproject.toml
+        - Moved test/ to tests/ and added __init__.py - module paths in testing.
+        - Partial restructure of TModel code and extended test suite
+        - Extended test suite for psychrometric functions, bug fix in HygroParams.
+        - Better definition and handling of class attributes to avoid unnecessary
+          Optional types in __init__ methods.
+        - Updated docstrings, particularly class attributes now docstringed in place.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,11 +59,13 @@ mathjax3_config = {
 napoleon_use_ivar = True
 napoleon_custom_sections = [("PModel Parameters", "params_style")]
 
-# Suppress signature expansion of arguments
+# Autodoc configuration:
+# - Suppress signature expansion of arguments
 autodoc_preserve_defaults = True
-
-# Have funcname not pyrealm.pmodel.funcname in autodoc
+# - Have funcname not pyrealm.pmodel.funcname in autodoc
 add_module_names = False
+# - Group members by type not alphabetically
+autodoc_member_order = "groupwise"
 
 bibtex_bibfiles = ["refs.bib"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,7 @@ mathjax3_config = {
 
 # Turn off ugly rendering of class attributes
 napoleon_use_ivar = True
+napoleon_custom_sections = [("PModel Parameters", "params_style")]
 
 # Suppress signature expansion of arguments
 autodoc_preserve_defaults = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,9 @@ napoleon_custom_sections = [("PModel Parameters", "params_style")]
 # Suppress signature expansion of arguments
 autodoc_preserve_defaults = True
 
+# Have funcname not pyrealm.pmodel.funcname in autodoc
+add_module_names = False
+
 bibtex_bibfiles = ["refs.bib"]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/pmodel/pmodel_reference.md
+++ b/docs/source/pmodel/pmodel_reference.md
@@ -10,22 +10,12 @@ kernelspec:
   name: python3
 ---
 
-# Module reference for `pmodel`
-
-This page contains the detailed documentation of the functions and classes in the
-`pyrealm.pmodel` module. The documentation describes the key equations used in each
-member. In particular, note that the documentation of functions and methods includes two
-lists of parameters:
-
-* **Parameters**. These are the arguments in the function or class signature.
-* **Other parameters**. These are the underlying parameters of the P model described in
-  the [parameters](../params) documentation. These can be changed by the user but have a
-  global effect rather than just altering a single function.
+# API reference for the {mod}`~pyrealm.pmodel` module
 
 ```{eval-rst}
 .. automodule:: pyrealm.pmodel
     :autosummary:
     :members:
-    :special-members: __init__
+    :special-members: __repr__
 
 ```

--- a/pyrealm/param_classes.py
+++ b/pyrealm/param_classes.py
@@ -329,8 +329,8 @@ class PModelParams(ParamClass):
     soilmstress_b: float = 0.733
 
     # Unit cost ratio (beta) values for different CalcOptimalChi methods
-    beta_cost_ratio_prentice14: float = 146.0
-    beta_cost_ratio_c4: float = 146.0 / 9
+    beta_cost_ratio_prentice14: NDArray[np.float32] = np.array([146.0])
+    beta_cost_ratio_c4: NDArray[np.float32] = np.array([146.0 / 9])
     lavergne_2020_b_c3: float = 1.73
     lavergne_2020_a_c3: float = 4.55
     lavergne_2020_b_c4: float = 1.73

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -2549,8 +2549,8 @@ class C3C4Competition:
     ) -> None:
         r"""Estimate CO2 isotopic discrimination values.
 
-        Creating an instance of {class}`~pyrealm.pmodel.CalcCarbonIsotopes` from a
-        {class}`~pyrealm.pmodel.PModel` instance provides estimated total annual
+        Creating an instance of :class:`~pyrealm.pmodel.CalcCarbonIsotopes` from a
+        :class:`~pyrealm.pmodel.PModel` instance provides estimated total annual
         descrimination against Carbon 13 (:math:`\Delta\ce{^13C}`) for a single
         photosynthetic pathway.
 
@@ -2603,7 +2603,7 @@ class C3C4Competition:
             ("gpp_c4_contrib", "gC m-2 yr-1"),
         ]
 
-        if self.d13C_C3 is not None:
+        if hasattr(self, "d13C_C3"):
             attrs.extend(
                 [
                     ("Delta13C_C3", "permil"),

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1459,6 +1459,7 @@ class CalcOptimalChi:
         # rootzonestress conforms to the environment data
         if np.allclose(rootzonestress, 1.0):
             self.shape: tuple = env.shape
+            """Records the common numpy array shape of array inputs."""
         else:
             self.shape = check_input_shapes(env.ca, rootzonestress)
             warn("The rootzonestress option is an experimental feature.")
@@ -1903,13 +1904,6 @@ class JmaxLimitation:
             or ``smith19`` or ``none``)
         pmodel_params: An instance of :class:`~pyrealm.param_classes.PModelParams`.
 
-    Attributes:
-        f_j (float): :math:`J_{max}` limitation factor, calculated using the method.
-        f_v (float): :math:`V_{cmax}` limitation factor, calculated using the method.
-        omega (float): component of :math:`J_{max}` calculation (:cite:`Smith:2019dv`).
-        omega_star (float):  component of :math:`J_{max}` calculation
-            (:cite:`Smith:2019dv`).
-
     Examples:
         >>> env = PModelEnvironment(tc= 20, patm=101325, co2=400, vpd=1000)
         >>> optchi = CalcOptimalChi(env)
@@ -1940,18 +1934,27 @@ class JmaxLimitation:
         method: str = "wang17",
         pmodel_params: PModelParams = PModelParams(),
     ):
-        self.shape = check_input_shapes(optchi.mj)
-
-        self.optchi = optchi
-        self.method = method
-        self.pmodel_params = pmodel_params
+        self.shape: tuple = check_input_shapes(optchi.mj)
+        """Records the common numpy array shape of array inputs."""
+        self.optchi: CalcOptimalChi = optchi
+        """Details of the optimal chi calculation for the model"""
+        self.method: str = method
+        """Records the method used to calculate Jmax limitation."""
+        self.pmodel_params: PModelParams = pmodel_params
+        """The PModelParams instance used for the calculation."""
 
         # Attributes populated by alternative method - two should always be populated by
         # the methods used below, but omega and omega_star only apply to smith19
         self.f_j: NDArray
+        """:math:`J_{max}` limitation factor, calculated using the method."""
         self.f_v: NDArray
+        """:math:`V_{cmax}` limitation factor, calculated using the method."""
         self.omega: Optional[NDArray] = None
+        """Component of :math:`J_{max}` calculation for method ``smith19``
+        (:cite:`Smith:2019dv`)."""
         self.omega_star: Optional[NDArray] = None
+        """Component of :math:`J_{max}` calculation for method ``smith19``
+        (:cite:`Smith:2019dv`)."""
 
         all_methods = {
             "wang17": self.wang17,
@@ -1974,6 +1977,7 @@ class JmaxLimitation:
         this_method()
 
     def __repr__(self) -> str:
+        """Generates a string representation of a JmaxLimitation instance."""
         return f"JmaxLimitation(shape={self.shape})"
 
     def wang17(self) -> None:
@@ -2047,12 +2051,13 @@ class JmaxLimitation:
             \]
 
         given,
-            * :math:`\theta`, (`pmodel_params.smith19_theta`) captures the
-              curved relationship between light intensity and photosynthetic
-              capacity, and
-            * :math:`c`, (`pmodel_params.smith19_c_cost`) as a cost parameter
-              for maintaining :math:`J_{max}`, equivalent to :math:`c^\ast = 4c`
-              in the :meth:`~pyrealm.pmodel.JmaxLimitation.wang17` method.
+
+        * :math:`\theta`, (``pmodel_params.smith19_theta``) captures the
+          curved relationship between light intensity and photosynthetic
+          capacity, and
+        * :math:`c`, (``pmodel_params.smith19_c_cost``) as a cost parameter
+          for maintaining :math:`J_{max}`, equivalent to :math:`c^\ast = 4c`
+          in the :meth:`~pyrealm.pmodel.JmaxLimitation.wang17` method.
         """
 
         # Adopted from Nick Smith's code:
@@ -2073,7 +2078,9 @@ class JmaxLimitation:
         aquad = -1
         bquad = cap_p
         cquad = -(cap_p * theta)
-        roots = np.polynomial.polynomial.polyroots([aquad, bquad, cquad])  # type:ignore
+        roots = np.polynomial.polynomial.polyroots(
+            [aquad, bquad, cquad]
+        )  # type: ignore [no-untyped-call]
 
         # factors derived as in Smith et al., 2019
         m_star = (4 * c_cost) / roots[0].real

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -896,7 +896,7 @@ class PModelEnvironment:
         return f"PModelEnvironment(shape={self.shape})"
 
     def summarize(self, dp: int = 2) -> None:
-        """Print PModelEnvironment summary.
+        """Prints a summary of PModelEnvironment variables.
 
         Prints a summary of the input and photosynthetic attributes in a instance of a
         PModelEnvironment including the mean, range and number of nan values.
@@ -1137,10 +1137,10 @@ class PModel:
 
         # Check method_optchi and set c3/c4
         self.c4: bool = CalcOptimalChi._method_lookup(method_optchi)
-        """Boolean flag indicating C3 or C4 photosynthesis."""
+        """Indicates if estimates calculated using C3 or C4 photosynthesis."""
 
-        self.method_optchi = method_optchi
-        """Method used to calculate optimal chi."""
+        self.method_optchi: str = method_optchi
+        """Indicates method used to calculate optimal chi."""
 
         # -----------------------------------------------------------------------
         # Temperature dependence of quantum yield efficiency
@@ -1168,12 +1168,13 @@ class PModel:
         # -----------------------------------------------------------------------
         # Calculation of Jmax limitation terms
         # -----------------------------------------------------------------------
-        self.method_jmaxlim = method_jmaxlim
+        self.method_jmaxlim: str = method_jmaxlim
+        """Method used to calculate Jmax limitation."""
 
         self.jmaxlim: JmaxLimitation = JmaxLimitation(
             self.optchi, method=self.method_jmaxlim, pmodel_params=env.pmodel_params
         )
-        """Details of the JmaxLimitation calculation for the model"""
+        """Details of the Jmax limitation calculation for the model"""
         # -----------------------------------------------------------------------
         # Store the two efficiency predictions
         # -----------------------------------------------------------------------
@@ -1182,7 +1183,9 @@ class PModel:
         # in Pascals, but more commonly reported in µmol mol-1. The standard equation
         # (ca - ci) / 1.6 expects inputs in ppm, so the pascal versions are back
         # converted here.
-        self.iwue = (5 / 8 * (env.ca - self.optchi.ci)) / (1e-6 * self.env.patm)
+        self.iwue: NDArray = (5 / 8 * (env.ca - self.optchi.ci)) / (
+            1e-6 * self.env.patm
+        )
         """Intrinsic water use efficiency (iWUE, µmol mol-1)"""
 
         # The basic calculation of LUE = phi0 * M_c * m but here we implement
@@ -1191,7 +1194,7 @@ class PModel:
         # Note: the rpmodel implementation also estimates soilmstress effects on
         #       jmax and vcmax but pyrealm.pmodel only applies the stress factor
         #       to LUE and hence GPP
-        self.lue = (
+        self.lue: NDArray = (
             self.kphio
             * self.optchi.mj
             * self.jmaxlim.f_v
@@ -1237,42 +1240,42 @@ class PModel:
             raise RuntimeError(f"{varname} not calculated: use estimate_productivity")
 
     @property
-    def gpp(self) -> Union[float, np.ndarray]:
+    def gpp(self) -> NDArray:
         """Gross primary productivity (µg C m-2 s-1)."""
         self._check_estimated("gpp")
 
         return self._gpp
 
     @property
-    def vcmax(self) -> Union[float, np.ndarray]:
+    def vcmax(self) -> NDArray:
         """Maximum rate of carboxylation (µmol m-2 s-1)."""
         self._check_estimated("vcmax")
         self._soilwarn("vcmax")
         return self._vcmax
 
     @property
-    def vcmax25(self) -> Union[float, np.ndarray]:
+    def vcmax25(self) -> NDArray:
         """Maximum rate of carboxylation at standard temperature (µmol m-2 s-1)."""
         self._check_estimated("vcmax25")
         self._soilwarn("vcmax25")
         return self._vcmax25
 
     @property
-    def rd(self) -> Union[float, np.ndarray]:
+    def rd(self) -> NDArray:
         """Dark respiration (µmol m-2 s-1)."""
         self._check_estimated("rd")
         self._soilwarn("rd")
         return self._rd
 
     @property
-    def jmax(self) -> Union[float, np.ndarray]:
+    def jmax(self) -> NDArray:
         """Maximum rate of electron transport (µmol m-2 s-1)."""
         self._check_estimated("jmax")
         self._soilwarn("jmax")
         return self._jmax
 
     @property
-    def gs(self) -> Union[float, np.ndarray]:
+    def gs(self) -> NDArray:
         """Stomatal conductance (µmol m-2 s-1)."""
         self._check_estimated("gs")
         self._soilwarn("gs")
@@ -1350,6 +1353,7 @@ class PModel:
         self._gs = assim / (self.env.ca - self.optchi.ci)
 
     def __repr__(self) -> str:
+        """Generates a string representation of PModel instance."""
         if self.do_soilmstress:
             stress = "Soil moisture"
         elif self.do_rootzonestress:
@@ -1368,13 +1372,12 @@ class PModel:
         )
 
     def summarize(self, dp: int = 2) -> None:
-        """Print PModel summary.
+        """Prints a summary of PModel estimates.
 
-        Prints a summary of the calculated values in a PModel instance
-        including the mean, range and number of nan values. This will always
-        show efficiency variables (LUE and IWUE) and productivity estimates are
-        shown if :meth:`~pyrealm.pmodel.PModel.calculate_productivity` has been
-        run.
+        Prints a summary of the calculated values in a PModel instance including the
+        mean, range and number of nan values. This will always show efficiency variables
+        (LUE and IWUE) and productivity estimates are shown if
+        :meth:`~pyrealm.pmodel.PModel.calculate_productivity` has been run.
 
         Args:
             dp: The number of decimal places used in rounding summary stats.

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1422,7 +1422,7 @@ class CalcOptimalChi:
 
     The ratio of carboxylation to transpiration cost factors (``beta``, :math:`\beta`)
     is a key parameter in these methods. It is often held constant across cells but some
-    methods (``lavergne20_c3`` and ``lavergne20_c4``) calculate :math:`beta` from
+    methods (``lavergne20_c3`` and ``lavergne20_c4``) calculate :math:`\beta` from
     environmental conditions. For this reason, the ``beta`` attribute records the values
     used in calculations as an array.
 
@@ -1475,10 +1475,10 @@ class CalcOptimalChi:
         r"""Defines the sensitivity of :math:`\chi` to the vapour pressure deficit,
         related to the carbon cost of water (Medlyn et al. 2011; Prentice et 2014)."""
         self.chi: NDArray
-        r"""The ratio of leaf internal to ambient :math:`\ce{CO2}`partial pressure
+        r"""The ratio of leaf internal to ambient :math:`\ce{CO2}` partial pressure
         (:math:`\chi`)."""
         self.ci: NDArray
-        r"""The leaf internal :math:`\ce{CO2}`partial pressure (:math:`\c_i`)."""
+        r"""The leaf internal :math:`\ce{CO2}` partial pressure (:math:`c_i`)."""
         self.mc: NDArray
         r""":math:`\ce{CO2}` limitation factor for RuBisCO-limited assimilation
         (:math:`m_c`)."""

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1,11 +1,24 @@
-"""The pmodel Module.
+"""This page contains the detailed documentation of the functions and classes in the
+:mod:`~pyrealm.pmodel` module. The documentation describes the key equations used in
+each member. In particular, note that the documentation of functions and methods
+includes two lists of parameters:
 
-This module provides the P Model class, implementing an optimality based model
-of photosynthesis, along with a set of functions to convert environmental
-forcings to key parameters used within the model.
+Parameters
+  These are the arguments specific to the class, method or function signature.
+
+PModel Parameters
+  These are shared parameters of the PModel used by this function, which are taken from
+  a :mod:`~pyrealm.params.PModelParams` instance. These can be changed by the user but 
+  are typically used to configure an entire analysis rather than a single function.
+
+This module provides:
+
+* The :mod:`~pyrealm.pmodel.PModel` class, implementing an optimality based model of
+  photosynthesis, along with a set of functions to convert environmental forcings to key
+  parameters used within the model.
 
 The module also provides code for...  TODO: Update this.
-"""
+"""  # noqa D210, D415
 
 from typing import Optional, Union
 from warnings import warn

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -961,14 +961,14 @@ class PModel:
     predictions are also populated:
 
     * Gross primary productivity, calculated as
-        :math:`\text{GPP} = \text{LUE} \cdot I_{abs}`, where :math:`I_{abs}` is
-        the absorbed photosynthetic radiation
+      :math:`\text{GPP} = \text{LUE} \cdot I_{abs}`, where :math:`I_{abs}` is
+      the absorbed photosynthetic radiation
 
     * The maximum rate of Rubisco regeneration at the growth temperature
-        (:math:`J_{max}`)
+      (:math:`J_{max}`)
 
     * The maximum carboxylation capacity (mol C m-2) at the growth temperature
-        (:math:`V_{cmax}`).
+      (:math:`V_{cmax}`).
 
     These two predictions are calculated as follows:
 

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -31,9 +31,9 @@ def calc_density_h2o(
 ) -> NDArray:
     """Calculate water density.
 
-    Calculates the **density of water** as a function of temperature and
-    atmospheric pressure, using the Tumlirz Equation and coefficients calculated
-    by :cite:`Fisher:1975tm`.
+    Calculates the density of water as a function of temperature and atmospheric
+    pressure, using the Tumlirz Equation and coefficients calculated by
+    :cite:`Fisher:1975tm`.
 
     Args:
         tc: air temperature, °C
@@ -42,13 +42,10 @@ def calc_density_h2o(
         safe: Prevents the function from estimating density below -30°C, where the
             function behaves poorly
 
-    Other Parameters:
-        lambda_: polynomial coefficients of Tumlirz equation
-            (`pmodel_params.fisher_dial_lambda`).
-        Po: polynomial coefficients of Tumlirz equation
-            (`pmodel_params.fisher_dial_Po`).
-        Vinf: polynomial coefficients of Tumlirz equation
-            (`pmodel_params.fisher_dial_Vinf`).
+    PModel Parameters:
+        lambda_: polynomial coefficients of Tumlirz equation (``fisher_dial_lambda``).
+        Po: polynomial coefficients of Tumlirz equation (``fisher_dial_Po``).
+        Vinf: polynomial coefficients of Tumlirz equation (``fisher_dial_Vinf``).
 
     Returns:
         Water density as a float in (g cm^-3)

--- a/pyrealm/pmodel.py
+++ b/pyrealm/pmodel.py
@@ -1098,7 +1098,7 @@ class PModel:
             )
 
         if soilmstress is None:
-            self.soilmstress: Union[float, np.ndarray] = 1.0
+            self.soilmstress: NDArray = np.array(1.0)
             """The soil moisture stress factor applied to model.
 
             This value will be 1.0 if no soil moisture stress was provided in the
@@ -1140,7 +1140,7 @@ class PModel:
         """Indicates if estimates calculated using C3 or C4 photosynthesis."""
 
         self.method_optchi: str = method_optchi
-        """Indicates method used to calculate optimal chi."""
+        """Records the method used to calculate optimal chi."""
 
         # -----------------------------------------------------------------------
         # Temperature dependence of quantum yield efficiency
@@ -1169,7 +1169,7 @@ class PModel:
         # Calculation of Jmax limitation terms
         # -----------------------------------------------------------------------
         self.method_jmaxlim: str = method_jmaxlim
-        """Method used to calculate Jmax limitation."""
+        """Records the method used to calculate Jmax limitation."""
 
         self.jmaxlim: JmaxLimitation = JmaxLimitation(
             self.optchi, method=self.method_jmaxlim, pmodel_params=env.pmodel_params

--- a/pyrealm/tmodel.py
+++ b/pyrealm/tmodel.py
@@ -101,97 +101,97 @@ class TTree:
 
     @property
     def diameter(self) -> NDArray:
-        """Fetch the plant diameter."""
+        """Individual diameter (m)."""  # noqa: D402
         return self._diameter
 
     @property
     def height(self) -> NDArray:
-        """Fetch the plant height."""
+        """Individual height (m)."""  # noqa: D402
         return self._height
 
     @property
     def crown_fraction(self) -> NDArray:
-        """Fetch the plant crown fraction."""
+        """Individual crown fraction (unitless)."""
         return self._crown_fraction
 
     @property
     def crown_area(self) -> NDArray:
-        """Fetch the plant crown area."""
+        """Individual crown area (m2)."""
         return self._crown_area
 
     @property
     def mass_swd(self) -> NDArray:
-        """Fetch the plant softwood mass."""
+        """Individual softwood mass (kg)."""
         return self._mass_swd
 
     @property
     def mass_stm(self) -> NDArray:
-        """Fetch the plant stem mass."""
+        """Individual stem mass (kg)."""
         return self._mass_stm
 
     @property
     def mass_fol(self) -> NDArray:
-        """Fetch the plant foliage mass."""
+        """Individual foliage mass (kg)."""
         return self._mass_fol
 
     @property
     def gpp_raw(self) -> NDArray:
-        """Fetch the raw gross primary productivity."""
+        """Raw gross primary productivity."""
         return self._check_growth_calculated("_gpp_raw")
 
     @property
     def gpp_actual(self) -> NDArray:
-        """Fetch the actual gross primary productivity."""
+        """Actual gross primary productivity."""
         return self._check_growth_calculated("_gpp_actual")
 
     @property
     def resp_swd(self) -> NDArray:
-        """Fetch the plant softwood respiration."""
+        """Individual softwood respiration costs."""
         return self._check_growth_calculated("_resp_swd")
 
     @property
     def resp_frt(self) -> NDArray:
-        """Fetch the plant fine root respiration."""
+        """Individual fine root respiration costs."""
         return self._check_growth_calculated("_resp_frt")
 
     @property
     def resp_fol(self) -> NDArray:
-        """Fetch the plant foliar respiration."""
+        """Individual foliar respiration costs."""
         return self._check_growth_calculated("_resp_fol")
 
     @property
     def npp(self) -> NDArray:
-        """Fetch the net primary productivity."""
+        """Net primary productivity."""
         return self._check_growth_calculated("_npp")
 
     @property
     def turnover(self) -> NDArray:
-        """Fetch the plant turnover."""
+        """Plant turnover."""
         return self._check_growth_calculated("_turnover")
 
     @property
     def d_mass_s(self) -> NDArray:
-        """Fetch the plant change in mass."""
+        """Individual relative change in mass."""
         return self._check_growth_calculated("_d_mass_s")
 
     @property
     def d_mass_fr(self) -> NDArray:
-        """Fetch the plant change in fine root mass."""
+        """Individual relative change in fine root mass."""
         return self._check_growth_calculated("_d_mass_fr")
 
     @property
     def delta_d(self) -> NDArray:
-        """Fetch the plant change in diameter."""
+        """Individual change in diameter."""
         return self._check_growth_calculated("_delta_d")
 
     @property
     def delta_mass_stm(self) -> NDArray:
-        """Fetch the plant change in stem mass."""
+        """Individual total change in stem mass."""
         return self._check_growth_calculated("_delta_mass_stm")
 
     @property
     def delta_mass_frt(self) -> NDArray:
-        """Fetch the plant change in fine root mass."""
+        """Individual total change in fine root mass."""
         return self._check_growth_calculated("_delta_mass_frt")
 
     def reset_diameters(self, values: NDArray) -> None:
@@ -246,9 +246,9 @@ class TTree:
     def calculate_growth(self, gpp: NDArray) -> None:
         """Calculate growth predictions given a GPP estimate.
 
-        This method updates the instance with predicted changes in tree
-        geometry, mass and respiration costs from the initial state given an
-        estimate of gross primary productivity (GPP).
+        This method updates the instance with predicted changes in tree geometry, mass
+        and respiration costs from the initial state given an estimate of gross primary
+        productivity (GPP).
 
         Args:
             gpp: Primary productivity

--- a/tests/pmodel/test_pmodel.py
+++ b/tests/pmodel/test_pmodel.py
@@ -585,7 +585,7 @@ def test_pmodel_class_c3(
             values["soilm_sc"], values["meanalpha_sc"]
         )
     else:
-        soilmstress = None
+        soilmstress = np.array([1.0])
 
     ret = pmodel.PModel(
         pmodelenv[environ],


### PR DESCRIPTION
This PR is a little untidy but is mostly a review of the `pyrealm.pmodel` docstrings:

* Updating the docs generally to remove syntax issues
* Documenting the attributes in situ using docstrings so they get picked up properly in `autodoc`.
* Updating the `sphinx` config to give nicer rendering and ordering of members.
* Fixing broken syntax approach to separating values from `pmodel_params` used within functions.

There are then a few typing fixes that escaped the last PR.