### PR TITLE
Moved private functions out of C3C4Competition

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -125,3 +125,5 @@
         - param_classes.py used as the basis for a new constants module with smaller
           better documented files and XYZConst naming scheme.
         - '(pmodel)_params' style arguments updated to 'const', docs updated to match.
+        - C3C4 competition private functions now exposed as stand-alone functions with
+          cleaner docs and demo usage.

--- a/pyrealm/constants/hygro_const.py
+++ b/pyrealm/constants/hygro_const.py
@@ -14,9 +14,9 @@ class HygroConst(ConstantsClass):
 
     This data class provides constants used in :mod:`~pyrealm.hygro`, which includes
     hygrometric conversions. The values for
-    :attr:`~pyrealm.constants.hygro_const.HygroParams.magnus_coef`` be set directly or
+    :attr:`~pyrealm.constants.hygro_const.HygroConst.magnus_coef`` be set directly or
     by selecting one of ``Allen1998``, ``Alduchov1996`` or ``Sonntag1990`` as
-    :attr:`~pyrealm.constants.hygro_const.HygroParams.magnus_option``. The default
+    :attr:`~pyrealm.constants.hygro_const.HygroConst.magnus_option``. The default
     setting is to use the ``Sonntag1990`` parameters.
 
     """

--- a/pyrealm/pmodel/__init__.py
+++ b/pyrealm/pmodel/__init__.py
@@ -24,7 +24,11 @@ PModel Parameters
 # flatten the namespace for the main public components and setup.cfg applies
 # # noqa: F401 to the whole file.
 
-from pyrealm.pmodel.competition import C3C4Competition
+from pyrealm.pmodel.competition import (
+    C3C4Competition,
+    calculate_tree_proportion,
+    convert_gpp_advantage_to_c4_fraction,
+)
 from pyrealm.pmodel.functions import (
     calc_co2_to_ca,
     calc_density_h2o,


### PR DESCRIPTION
This PR fixes #39 by:

* Moving the two private methods in C3C4Competition out to be standalone functions.
* Docstrings improved - can farm out details from C3C4Competition to exposed functions.
* Notebook using the model updated (and simplified - easier to access the functions!)

