### PR TITLE
Switching to `sphinxcontrib.bibtex` citations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -129,3 +129,5 @@
           cleaner docs and demo usage.
         - Reorganisation of website index and page structure, nitpicking of links turned
           on and broken links fixed.
+        - Switch away from astrorefs to sphinxcontrib.bibtex, which now supports
+          author_year citation styling.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,9 +39,10 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinxcontrib.bibtex",
     "myst_nb",
-    # "sphinx_astrorefs",  # Gives author year references
     "sphinx_rtd_theme",
 ]
+
+bibtex_reference_style = "author_year"
 
 # Reference checking
 nitpicky = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,11 @@ documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import os
 import sys
+from dataclasses import dataclass, field
+
+import sphinxcontrib.bibtex.plugin
+from sphinxcontrib.bibtex.style.referencing import BracketStyle
+from sphinxcontrib.bibtex.style.referencing.author_year import AuthorYearReferenceStyle
 
 from pyrealm import __version__ as pyrealm_version
 
@@ -42,9 +47,36 @@ extensions = [
     "sphinx_rtd_theme",
 ]
 
-bibtex_reference_style = "author_year"
+# Citation styling
 
-# Reference checking
+
+def bracket_style() -> BracketStyle:
+    """Custom citation parenthesis style."""
+    return BracketStyle(
+        left="(",
+        right=")",
+    )
+
+
+@dataclass
+class MyReferenceStyle(AuthorYearReferenceStyle):
+    """Custom referencing style."""
+
+    bracket_parenthetical: BracketStyle = field(default_factory=bracket_style)
+    bracket_textual: BracketStyle = field(default_factory=bracket_style)
+    bracket_author: BracketStyle = field(default_factory=bracket_style)
+    bracket_label: BracketStyle = field(default_factory=bracket_style)
+    bracket_year: BracketStyle = field(default_factory=bracket_style)
+
+
+sphinxcontrib.bibtex.plugin.register_plugin(
+    "sphinxcontrib.bibtex.style.referencing", "author_year_round", MyReferenceStyle
+)
+
+bibtex_reference_style = "author_year_round"
+
+
+# Cross-reference checking
 nitpicky = True
 nitpick_ignore = [
     ("py:class", "numpy._typing._generic_alias.ScalarType"),

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -20,9 +20,9 @@ productivity to model plant growth and the demography of plant communities.
 
 The package is in active development and currently provides the following functionality:
 
-* Fitting the [P Model](pmodel/pmodel), which is a ecophysiological model of optimal carbon
-  dioxide uptake by plants (:{cite}`Prentice:2014bc`, :{cite}`Wang:2017go`,
-  :{cite}`Stocker:2020dh`). Extensions to this model include:
+* Fitting the [P Model](pmodel/pmodel), which is a ecophysiological model of optimal
+  carbon dioxide uptake by plants {cite:p}`Prentice:2014bc, Wang:2017go,Stocker:2020dh`.
+  Extensions to this model include:
 
   * Estimation of [isotopic discrimination of
     carbon](pmodel/isotopic_discrimination.md) resulting from photosynthesis.
@@ -30,7 +30,7 @@ The package is in active development and currently provides the following functi
     the expected fraction of C4 plants in a community.
 
 * Estimating plant allocation of gross primary productivity to growth and respiration,
-  using [T Model](tmodel/tmodel) (:{cite}`Li:2014bc`).
+  using [T Model](tmodel/tmodel) {cite:p}`Li:2014bc`.
 * Functions for [converting common hygrometric variables](./hygro) to vapour pressure
   deficit for use in the P Model.
 

--- a/docs/source/pmodel/c3c4model.md
+++ b/docs/source/pmodel/c3c4model.md
@@ -23,8 +23,8 @@ Compared to C3 plants, plants using the C4 photosynthetic pathway:
 
 This gives C4 plants a substantial competitive advantage in warm, dry and low CO2
 environments. The {class}`~pyrealm.pmodel.competition.C3C4Competition` class provides an
-implementation of a model {cite}`lavergne:2022a` that estimates the expected fraction of
-GPP from C4 plants. It uses predictions of GPP from the
+implementation of a model {cite:p}`lavergne:2022a` that estimates the expected fraction
+of GPP from C4 plants. It uses predictions of GPP from the
 {class}`~pyrealm.pmodel.pmodel.PModel` assuming communities consisting solely of C3 or
 C4 plants to calculate the expected fraction of C4 plants in the community and the
 contributions to GPP from C3 and C4 plants at each site.

--- a/docs/source/pmodel/pmodel.md
+++ b/docs/source/pmodel/pmodel.md
@@ -17,13 +17,13 @@ kernelspec:
 
 # The P Model: overview
 
-This page provides an overview of the theory of the P Model (:{cite}`Prentice:2014bc`,
-:{cite}`Wang:2017go`), and how to use the implementation in the `pyrealm` package. The
-details of calculations and the API for the package code are shown in the [module
-reference documentation](../api/pmodel_api).
+This page provides an overview of the theory of the P Model
+{cite:p}`Prentice:2014bc,Wang:2017go`, and how to use the implementation in the
+`pyrealm` package. The details of calculations and the API for the package code are
+shown in the [module reference documentation](../api/pmodel_api).
 
 The implementation in this module draws from the `rpmodel` implementation of the model
-({cite}`Stocker:2020dh`) and development matches the predictions of the two
+{cite:p}`Stocker:2020dh` and development matches the predictions of the two
 implementation for most - but not all use cases (see [here](pmodel_details/rpmodel) for
 discussion).
 

--- a/docs/source/pmodel/pmodel_details/lue_limitation.md
+++ b/docs/source/pmodel/pmodel_details/lue_limitation.md
@@ -90,13 +90,13 @@ photosynthesis.
 ```
 
 The value of $\phi_0$ shows temperature dependence, which is modelled following
-{cite}`Bernacchi:2003dc` for C3 plants and {cite}`cai:2020a` for C4 plants (see
+{cite:t}`Bernacchi:2003dc` for C3 plants and {cite:t}`cai:2020a` for C4 plants (see
 {func}`~pyrealm.pmodel.functions.calc_ftemp_kphio`). The temperature dependency is
 applied by default but can be turned off using the
 {class}`~pyrealm.pmodel.pmodel.PModel` argument `do_ftemp_kphio=False`.
 
 The default values of `kphio` vary with the model options, corresponding
-to the empirically fitted values presented for three setups in {cite}`Stocker:2020dh`.
+to the empirically fitted values presented for three setups in {cite:t}`Stocker:2020dh`.
 
 1. If the temperature dependence of $\phi_0$ is **not** applied,
     $\phi_0 = 0.049977$,
@@ -154,11 +154,11 @@ options for this setting are:
 * `simple`: These are the 'simple' formulations of the P Model, with $f_j = f_v
   = 1$.
 * `wang17`: This is the default setting for `method_jmaxlim` and applies the
-  calculations describe in  {cite}`Wang:2017go`. The calculation details can be
+  calculations describe in  {cite:t}`Wang:2017go`. The calculation details can be
   seen in the {meth}`~pyrealm.pmodel.pmodel.JmaxLimitation.wang17` method.
 
 * `smith19`: This is an alternate calculation for optimal values of $J_{max}$
-  and $V_{cmax}$ described in {cite}`Smith:2019dv`. The calculation details can be
+  and $V_{cmax}$ described in {cite:t}`Smith:2019dv`. The calculation details can be
   seen in the {meth}`~pyrealm.pmodel.pmodel.JmaxLimitation.smith19` method.
 
 ```{code-cell}

--- a/docs/source/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/pmodel/pmodel_details/optimal_chi.md
@@ -152,7 +152,7 @@ def plot_opt_chi(mod):
 
 ## Method {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.prentice14`
 
-This **C3 method** follows the approach detailed in {cite}`Prentice:2014bc`, see
+This **C3 method** follows the approach detailed in {cite:t}`Prentice:2014bc`, see
 {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.prentice14` for details.
 
 ```{code-cell}
@@ -165,8 +165,8 @@ plot_opt_chi(pmodel_c3)
 
 ## Method {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4`
 
-This **C4_method** follows the approach detailed in {cite}`Prentice:2014bc`, but uses a
-C4 specific version of the unit cost ratio ($\beta$). It also sets $m_j = m_c = 1$.
+This **C4_method** follows the approach detailed in {cite:t}`Prentice:2014bc`, but uses
+a C4 specific version of the unit cost ratio ($\beta$). It also sets $m_j = m_c = 1$.
 
 See {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4` for details.
 
@@ -180,10 +180,10 @@ plot_opt_chi(pmodel_c4)
 
 ## Method {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4_no_gamma`
 
-This method drops terms from the {cite}`Prentice:2014bc` to reflect the assumption that
-photorespiration ($\Gamma^\ast$) is negligible in C4 photosynthesis. It uses the same
-$\beta$ estimate as {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4` and also also sets
-$m_j = 1$, but $m_c$ is calculated as in
+This method drops terms from the approach given in {cite:t}`Prentice:2014bc` to reflect
+the assumption that photorespiration ($\Gamma^\ast$) is negligible in C4 photosynthesis.
+It uses the same $\beta$ estimate as {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4`
+and also also sets $m_j = 1$, but $m_c$ is calculated as in
 {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.prentice14`.
 
 See {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4_no_gamma` for details.
@@ -198,7 +198,7 @@ plot_opt_chi(pmodel_c4)
 
 ## Methods {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.lavergne20_c3` and {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.lavergne20_c4`
 
-These methods follow the approach detailed in {cite}`lavergne:2020a`, which fitted
+These methods follow the approach detailed in {cite:t}`lavergne:2020a`, which fitted
 an empirical model of $\beta$ for C3 plants as a function of volumetric soil moisture
 ($\theta$, m3/m3), using data from leaf gas exchange measurements. The C4 method takes
 the same approach but with modified empirical parameters giving predictions of
@@ -206,7 +206,7 @@ $\beta_{C3} = 9 \times \beta_{C4}$. Following the approach of
 {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4_no_gamma`, $m_c$ is calculated but $m_j=1$.
 
 ```{warning}
-Note that {cite}`lavergne:2020a` found **no relationship** between C4 $\beta$
+Note that {cite:t}`lavergne:2020a` found **no relationship** between C4 $\beta$
 values and soil moisture in leaf gas exchange data  The
 {meth}`~pyrealm.pmodel.pmodel.CalcOptimalChi.lavergne20_c4` method is **an experimental
 feature** - see the documentation for the

--- a/docs/source/pmodel/pmodel_details/rpmodel.md
+++ b/docs/source/pmodel/pmodel_details/rpmodel.md
@@ -14,10 +14,9 @@ kernelspec:
 
 # The `rpmodel` implementation
 
-The implementation and documentation of the {mod}`~pyrealm.pmodel` module is
-very heavily based on Benjamin Stocker's R implementation of the P-model
-({cite}`Stocker:2020dh`) in the [``rpmodel``](https://github.com/stineb/rpmodel)
-package:
+The implementation and documentation of the {mod}`~pyrealm.pmodel` module is very
+heavily based on the [``rpmodel``](https://github.com/stineb/rpmodel) package, which
+provides an implementation of the P-model in the R language {cite:p}`Stocker:2020dh`.
 
 ## Testing reference
 

--- a/docs/source/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/pmodel/pmodel_details/soil_moisture.md
@@ -27,7 +27,7 @@ photosynthesis:
 ## Stocker $\beta(\theta)$
 
 This is an empirically derived factor ($\beta(\theta) \in [0,1]$,
-:{cite}`Stocker:2018be`, :{cite}`Stocker:2020dh`) that captures the response of light
+{cite:p}`Stocker:2018be,Stocker:2020dh` that captures the response of light
 use efficiency (LUE) and hence gross primary productivity (GPP)  to soil moisture
 stress. The calculated value of $\beta(\theta)$ is applied directly as a penalty factor
 to LUE and hence to estimates of GPP.

--- a/docs/source/tmodel/tmodel.md
+++ b/docs/source/tmodel/tmodel.md
@@ -14,7 +14,7 @@ kernelspec:
 
 # The T Model
 
-This module provides a Python implementation of the T-Model (:{cite}`Li:2014bc`), which
+This module provides a Python implementation of the T-Model {cite:p}`Li:2014bc`, which
 provides a physiological model of tree growth given a set of traits on tree growth
 scalings and allocation of primary production.
 

--- a/pyrealm/constants/competition_const.py
+++ b/pyrealm/constants/competition_const.py
@@ -10,7 +10,7 @@ class C3C4Const(ConstantsClass):
 
     This data class holds statistically estimated coefficients used to calculate the
     fraction of C4 plants based on the relative GPP of C3 and C4 plants for given
-    conditions and estimated treecover :cite:`lavergne:2020a`.
+    conditions and estimated treecover :cite:p:`lavergne:2020a`.
     """
 
     # Non-linear regression of fraction C4 plants from proportion GPP advantage

--- a/pyrealm/constants/isotope_const.py
+++ b/pyrealm/constants/isotope_const.py
@@ -12,14 +12,14 @@ class IsotopesConst(ConstantsClass):
     carbon isotope discrimination from P Model instances.
 
     * For C4 plants, the coefficients for calculating isotopic discrimination are taken
-      from :cite:`lavergne:2022a`. The class also provides an alternative, but currently
-      implemented, parameterisation using coefficients taken from
-      :cite:`voncaemmerer:2014a`.
-    * For Cw plants, the coefficients for calculating isotopic discrimination are taken
-      from :cite:`farquhar:1982a`.
+      from :cite:t:`lavergne:2022a`. The class also provides an alternative, but
+      currently implemented, parameterisation using coefficients taken from
+      :cite:t:`voncaemmerer:2014a`.
+    * For C3 plants, the coefficients for calculating isotopic discrimination are taken
+      from :cite:t:`farquhar:1982a`.
     * Post-photosynthetic fractionation values are also provided between leaf organic
-      matter and alpha-cellulose (:cite:`frank:2015a`) and bulk wood
-      (:cite:`badeck:2005a`).
+      matter and alpha-cellulose :cite:p:`frank:2015a` and bulk wood
+      :cite:p:`badeck:2005a`.
 
     """
 

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -18,13 +18,13 @@ class PModelConst(ConstantsClass):
     given below:
 
     * **Density of water**. Values for the Tumlirz equation taken from Table 5 of
-      :cite:`Fisher:1975tm`:
+      :cite:t:`Fisher:1975tm`:
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_lambda`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_Po`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.fisher_dial_Vinf`)
 
     * **Viscosity of water**. Values for the parameterisation taken from Table 2 and 3
-      of :cite:`Huber:2009fy`:
+      of :cite:t:`Huber:2009fy`:
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.huber_tk_ast`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.huber_rho_ast`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.huber_mu_ast`,
@@ -32,12 +32,12 @@ class PModelConst(ConstantsClass):
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.huber_H_ij`)
 
     * **Temperature scaling of dark respiration**. Values taken from
-      :cite:`Heskel:2016fg`:
+      :cite:t:`Heskel:2016fg`:
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.heskel_b`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.heskel_c`)
 
     * **Temperature and entropy of VCMax**. Values taken from Table 3 of
-      :cite:`Kattge:2007db`
+      :cite:t:`Kattge:2007db`
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.kattge_knorr_a_ent`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.kattge_knorr_b_ent`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.kattge_knorr_Ha`,
@@ -46,12 +46,12 @@ class PModelConst(ConstantsClass):
     * **Scaling of Kphio with temperature**. The parameters of quadratic functions for
       the temperature dependence of Kphio are:
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.kphio_C4`, C4 plants, Eqn 5 of
-      :cite:`cai:2020a`; and
+      :cite:t:`cai:2020a`; and
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.kphio_C3`, C3 plants, Table 2
-      of :cite:`Bernacchi:2003dc`.
+      of :cite:t:`Bernacchi:2003dc`.
 
     * **Temperature responses of photosynthetic enzymes**. Values taken from Table 1 of
-      :cite:`Bernacchi:2001kg`. `kc_25` and `ko_25` are converted from µmol mol-1 and
+      :cite:t:`Bernacchi:2001kg`. `kc_25` and `ko_25` are converted from µmol mol-1 and
       mmol mol-1, assuming a measurement at an elevation of 227.076 metres and standard
       atmospheric pressure for that elevation (98716.403 Pa).
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_dhac`,
@@ -61,18 +61,18 @@ class PModelConst(ConstantsClass):
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_ko25`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs25_0`)
 
-    * **Soil moisture stress**. Parameterisation from :cite:`Stocker:2020dh`
+    * **Soil moisture stress**. Parameterisation from :cite:t:`Stocker:2020dh`
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_theta0`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_thetastar`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_a`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_b`)
 
     * **Unit cost ratios (beta)**. The value for C3 plants is taken from
-      :cite:`Stocker:2020dh`. For C4 plants, we follow the estimates of the :math:`g_1`
-      parameter for C3 and C4 plants in :cite:`Lin:2015wh`  and :cite:`DeKauwe:2015im`,
-      which have a C3/C4 ratio of around 3. Given that :math:`g_1 \equiv \xi \propto
-      \surd\beta`, a reasonable default for C4 plants is that : math:`\beta_{C4} \approx
-      \beta_{C3} / 9 \approx 146 /  9 \approx 16.222`.
+      :cite:t:`Stocker:2020dh`. For C4 plants, we follow the estimates of the
+      :math:`g_1` parameter for C3 and C4 plants in :cite:t:`Lin:2015wh`  and
+      :cite:t:`DeKauwe:2015im`, which have a C3/C4 ratio of around 3. Given that
+      :math:`g_1 \equiv \xi \propto \surd\beta`, a reasonable default for C4 plants is
+      that :math:`\beta_{C4} \approx \beta_{C3} / 9 \approx 146 /  9 \approx 16.222`.
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_prentice14`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_c4`)
 
@@ -86,12 +86,12 @@ class PModelConst(ConstantsClass):
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c4`)
 
     * **Electron transport capacity maintenance cost** Value taken from
-      :cite:`Wang:2017go`
+      :cite:t:`Wang:2017go`
 
     * **Calculation of omega**. Values for estimating the scaling factor in J max
-      limitation method of :cite:`Smith:2019dv`)
+      limitation method of :cite:t:`Smith:2019dv`.
 
-    * **Dark respiration**. Value taken from :cite:`Atkin:2015hk` for C3 herbaceous
+    * **Dark respiration**. Value taken from :cite:t:`Atkin:2015hk` for C3 herbaceous
       plants
 
     """

--- a/pyrealm/constants/tmodel_const.py
+++ b/pyrealm/constants/tmodel_const.py
@@ -9,7 +9,7 @@ class TModelTraits(ConstantsClass):
     r"""Trait data settings for a TTree instance.
 
     This data class provides the value of the key traits used in the T model. The
-    default values are taken from Table 1 of :cite:`Li:2014bc`. Note that the foliage
+    default values are taken from Table 1 of :cite:t:`Li:2014bc`. Note that the foliage
     maintenance respiration fraction is not named in the T Model description, but has
     been included as a modifiable trait in this implementation. The traits are shown
     below with mathematical notation, default value and units shown in brackets:

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -115,7 +115,7 @@ class C3C4Competition:
     r"""Implementation of the C3/C4 competition model.
 
     This class provides an implementation of the calculations of C3/C4 competition,
-    described by :cite:`lavergne:2020a`. The key inputs ``ggp_c3`` and ``gpp_c4`` are
+    described by :cite:t:`lavergne:2020a`. The key inputs ``ggp_c3`` and ``gpp_c4`` are
     gross primary productivity (GPP) estimates for C3 or C4 pathways `alone`  using the
     :class:`~pyrealm.pmodel.pmodel.PModel`
 

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -21,7 +21,7 @@ def calc_density_h2o(
 
     Calculates the density of water as a function of temperature and atmospheric
     pressure, using the Tumlirz Equation and coefficients calculated by
-    :cite:`Fisher:1975tm`.
+    :cite:t:`Fisher:1975tm`.
 
     Args:
         tc: air temperature, °C
@@ -148,7 +148,7 @@ def calc_ftemp_inst_rd(tc: NDArray, const: PModelConst = PModelConst()) -> NDArr
 
     Calculates the temperature-scaling factor for dark respiration at a given
     temperature (``tc``, :math:`T` in °C), relative to the standard reference
-    temperature :math:`T_o`, given the parameterisation in :cite:`Heskel:2016fg`.
+    temperature :math:`T_o`, given the parameterisation in :cite:t:`Heskel:2016fg`.
 
     .. math::
 
@@ -193,7 +193,7 @@ def calc_ftemp_inst_vcmax(tc: NDArray, const: PModelConst = PModelConst()) -> ND
 
        V = f V_{ref}
 
-    The value of :math:`f` is given by :cite:`Kattge:2007db` (Eqn 1) as:
+    The value of :math:`f` is given by :cite:t:`Kattge:2007db` (Eqn 1) as:
 
     .. math::
 
@@ -204,7 +204,7 @@ def calc_ftemp_inst_vcmax(tc: NDArray, const: PModelConst = PModelConst()) -> ND
     where :math:`g(T, H_a)` is a regular Arrhenius-type temperature response function
     (see :func:`~pyrealm.pmodel.functions.calc_ftemp_arrh`). The term :math:`\Delta S`
     is the entropy factor, calculated as a linear function of :math:`T` in °C following
-    :cite:`Kattge:2007db` (Table 3, Eqn 4):
+    :cite:t:`Kattge:2007db` (Table 3, Eqn 4):
 
     .. math::
 
@@ -276,9 +276,9 @@ def calc_ftemp_kphio(
     PModel Parameters:
         C3: the parameters (:math:`a,b,c`, ``kphio_C3``) are taken from the
             temperature dependence of the maximum quantum yield of photosystem
-            II in light-adapted tobacco leaves determined by :cite:`Bernacchi:2003dc`.
+            II in light-adapted tobacco leaves determined by :cite:t:`Bernacchi:2003dc`.
         C4: the parameters (:math:`a,b,c`, ``kphio_C4``) are taken from
-            :cite:`cai:2020a`.
+            :cite:t:`cai:2020a`.
 
     Returns:
         Values for :math:`\phi(T)`
@@ -314,7 +314,8 @@ def calc_gammastar(
     r"""Calculate the photorespiratory CO2 compensation point.
 
     Calculates the photorespiratory **CO2 compensation point** in absence of dark
-    respiration (:math:`\Gamma^{*}`, ::cite:`Farquhar:1980ft`) as:
+    respiration (:math:`\Gamma^{*}`, :cite:author:`Farquhar:1980ft`,
+    :cite:year:`Farquhar:1980ft`) as:
 
     .. math::
 
@@ -323,7 +324,7 @@ def calc_gammastar(
     where :math:`f(T, H_a)` modifies the activation energy to the the local temperature
     following an Arrhenius-type temperature response function implemented in
     :func:`calc_ftemp_arrh`. Estimates of :math:`\Gamma^{*}_{0}` and :math:`H_a` are
-    taken from :cite:`Bernacchi:2001kg`.
+    taken from :cite:t:`Bernacchi:2001kg`.
 
     Args:
         tc: Temperature relevant for photosynthesis (:math:`T`, °C)
@@ -404,8 +405,8 @@ def calc_kmm(tc: NDArray, patm: NDArray, const: PModelConst = PModelConst()) -> 
     r"""Calculate the Michaelis Menten coefficient of Rubisco-limited assimilation.
 
     Calculates the Michaelis Menten coefficient of Rubisco-limited assimilation
-    (:math:`K`, ::cite:`Farquhar:1980ft`) as a function of temperature (:math:`T`) and
-    atmospheric pressure (:math:`p`) as:
+    (:math:`K`, :cite:author:`Farquhar:1980ft`, :cite:year:`Farquhar:1980ft`) as a
+    function of temperature (:math:`T`) and atmospheric pressure (:math:`p`) as:
 
       .. math:: K = K_c ( 1 + p_{\ce{O2}} / K_o),
 
@@ -413,15 +414,14 @@ def calc_kmm(tc: NDArray, patm: NDArray, const: PModelConst = PModelConst()) -> 
     :math:`f(T, H_a)` is an Arrhenius-type temperature response of activation energies
     (:func:`calc_ftemp_arrh`) used to correct Michalis constants at standard temperature
     for both :math:`\ce{CO2}` and :math:`\ce{O2}` to the local temperature (Table 1,
-    ::cite:`Bernacchi:2001kg`):
+    :cite:author:`Bernacchi:2001kg`, :cite:year:`Bernacchi:2001kg`):
 
       .. math::
         :nowrap:
 
         \[
             \begin{align*}
-                K_c &= K_{c25} \cdot f(T, H_{kc})\\
-                K_o &= K_{o25} \cdot f(T, H_{ko})
+                K_c &= K_{c25} \cdot f(T, H_{kc})\\ K_o &= K_{o25} \cdot f(T, H_{ko})
             \end{align*}
         \]
 
@@ -429,9 +429,9 @@ def calc_kmm(tc: NDArray, patm: NDArray, const: PModelConst = PModelConst()) -> 
               for the same conversion for a value in the same table.
 
     Args:
-        tc: Temperature, relevant for photosynthesis (:math:`T`, °C)
-        patm: Atmospheric pressure (:math:`p`, Pa)
-        const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
+        tc: Temperature, relevant for photosynthesis (:math:`T`, °C) patm: Atmospheric
+        pressure (:math:`p`, Pa) const: Instance of
+        :class:`~pyrealm.constants.pmodel_const.PModelConst`.
 
     PModel Parameters:
         hac: activation energy for :math:`\ce{CO2}` (:math:`H_{kc}`, ``bernacchi_dhac``)
@@ -473,8 +473,8 @@ def calc_kp_c4(
     r"""Calculate the Michaelis Menten coefficient of PEPc.
 
     Calculates the Michaelis Menten coefficient of phosphoenolpyruvate carboxylase
-    (PEPc) (:math:`K`, :cite:`boyd:2015a`) as a function of temperature (:math:`T`) and
-    atmospheric pressure (:math:`p`) as:
+    (PEPc) (:math:`K`, :cite:author:`boyd:2015a`, :cite:year:`boyd:2015a`) as a function
+    of temperature (:math:`T`) and atmospheric pressure (:math:`p`) as:
 
     Args:
         tc: Temperature, relevant for photosynthesis (:math:`T`, °C)
@@ -513,9 +513,10 @@ def calc_soilmstress(
     r"""Calculate Stocker's empirical soil moisture stress factor.
 
     Calculates an **empirical soil moisture stress factor**  (:math:`\beta`,
-    ::cite:`Stocker:2020dh`) as a function of relative soil moisture (:math:`m_s`,
-    fraction of field capacity) and average aridity, quantified by the local annual mean
-    ratio of actual over potential evapotranspiration (:math:`\bar{\alpha}`).
+    :cite:author:`Stocker:2020dh`, :cite:year:`Stocker:2020dh`) as a function of
+    relative soil moisture (:math:`m_s`, fraction of field capacity) and average
+    aridity, quantified by the local annual mean ratio of actual over potential
+    evapotranspiration (:math:`\bar{\alpha}`).
 
     The value of :math:`\beta` is defined relative to two soil moisture thresholds
     (:math:`\theta_0, \theta^{*}`) as:
@@ -538,7 +539,7 @@ def calc_soilmstress(
     .. math:: q=(1 - (a + b \bar{\alpha}))/(\theta^{*} - \theta_{0})^2
 
     Default parameters of :math:`a=0` and :math:`b=0.7330` are as described in Table 1
-    of :cite:`Stocker:2020dh` specifically for the 'FULL' use case, with
+    of :cite:t:`Stocker:2020dh` specifically for the 'FULL' use case, with
     ``method_jmaxlim="wang17"``, ``do_ftemp_kphio=TRUE``.
 
     Args:
@@ -598,7 +599,7 @@ def calc_viscosity_h2o(
     r"""Calculate the viscosity of water.
 
     Calculates the viscosity of water (:math:`\eta`) as a function of temperature and
-    atmospheric pressure (::cite:`Huber:2009fy`).
+    atmospheric pressure :cite:p:`Huber:2009fy`.
 
     Args:
         tc: air temperature (°C)
@@ -655,7 +656,8 @@ def calc_patm(elv: NDArray, const: PModelConst = PModelConst()) -> NDArray:
     Calculates atmospheric pressure as a function of elevation with reference to the
     standard atmosphere.  The elevation-dependence of atmospheric pressure is computed
     by assuming a linear decrease in temperature with elevation and a mean adiabatic
-    lapse rate (Eqn 3, ::cite:`BerberanSantos:2009bk`):
+    lapse rate (Eqn 3, :cite:author:`BerberanSantos:2009bk`,
+    :cite:year:`BerberanSantos:2009bk`):
 
     .. math::
 
@@ -699,7 +701,7 @@ def calc_co2_to_ca(co2: NDArray, patm: NDArray) -> NDArray:
     Converts ambient :math:`\ce{CO2}` (:math:`c_a`) in part per million to Pascals,
     accounting for atmospheric pressure.
 
-    Args
+    Args:
         co2 (float): atmospheric :math:`\ce{CO2}`, ppm
         patm (float): atmospheric pressure, Pa
 

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -22,7 +22,7 @@ class CalcCarbonIsotopes:
     Discrimination against carbon 13 (:math:`\Delta\ce{^{13}C}`)  is calculated
     using C3 and C4 pathways specific methods, and then discrimination against
     carbon 14 is estimated as :math:`\Delta\ce{^{14}C} \approx 2 \times
-    \Delta\ce{^{13}C}` (:cite:`graven:2020a`). For C3 plants,
+    \Delta\ce{^{13}C}` :cite:p:`graven:2020a`. For C3 plants,
     :math:`\Delta\ce{^{13}C}` is calculated both including and excluding
     photorespiration, but these are assumed to be equal for C4 plants. The class
     also reports the isotopic composition of leaves and wood.
@@ -103,7 +103,7 @@ class CalcCarbonIsotopes:
 
         In this method, :math:`\delta\ce{^{13}C}` is calculated from optimal
         :math:`\chi` using an empirical relationship estimated by
-        :cite:`lavergne:2022a`.
+        :cite:p:`lavergne:2022a`.
 
         Examples:
             >>> ppar = PModelParams(beta_cost_ratio_c4=35)
@@ -128,7 +128,7 @@ class CalcCarbonIsotopes:
         r"""Calculate C4 isotopic discrimination.
 
         In this method, :math:`\delta\ce{^{13}C}` is calculated from optimal
-        :math:`\chi` following Equation 1 in :cite:`voncaemmerer:2014a`.
+        :math:`\chi` following Equation 1 in :cite:p:`voncaemmerer:2014a`.
 
         This method is not yet reachable - it needs a method selection argument to
         switch approaches and check C4 methods are used with C4 pmodels. The method is
@@ -170,7 +170,7 @@ class CalcCarbonIsotopes:
 
         This method calculates the isotopic discrimination for
         :math:`\Delta\ce{^{13}C}` both with and without the photorespiratory
-        effect following :cite:`farquhar:1982a`.
+        effect following :cite:p:`farquhar:1982a`.
 
         Examples:
             >>> env = PModelEnvironment(tc=20, patm=101325, co2=400,

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -225,7 +225,8 @@ class PModel:
       where :math:`f_v` is a limitation factor defined in
       :class:`~pyrealm.pmodel.pmodel.JmaxLimitation`, :math:`M_C` is the molar mass of
       carbon and :math:`\beta(\theta)` is an empirical soil moisture factor (see
-      :func:`~pyrealm.pmodel.functions.calc_soilmstress`,  :cite:`Stocker:2020dh`).
+      :func:`~pyrealm.pmodel.functions.calc_soilmstress`, :cite:author:`Stocker:2020dh`,
+      :cite:year:`Stocker:2020dh`).
 
     After running :meth:`~pyrealm.pmodel.pmodel.PModel.estimate_productivity`, the
     following predictions are also populated:
@@ -263,7 +264,7 @@ class PModel:
 
             R_d = b_0 \frac{fr(t)}{fv(t)} V_{cmax}
 
-      following :cite:`Atkin:2015hk`, where :math:`fr(t)` is the instantaneous
+      following :cite:t:`Atkin:2015hk`, where :math:`fr(t)` is the instantaneous
       temperature response of dark respiration implemented in
       :func:`~pyrealm.pmodel.functions.calc_ftemp_inst_rd`, and :math:`b_0` is set in
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.atkin_rd_to_vcmax`.
@@ -805,10 +806,10 @@ class CalcOptimalChi:
         return f"CalcOptimalChi(shape={self.shape}, method={self.method})"
 
     def prentice14(self) -> None:
-        r"""Calculate :math:`\chi` for C3 plants following :cite:`Prentice:2014bc`.
+        r"""Calculate :math:`\chi` for C3 plants following :cite:t:`Prentice:2014bc`.
 
         Optimal :math:`\chi` is calculated following Equation 8 in
-        :cite:`Prentice:2014bc`:
+        :cite:t:`Prentice:2014bc`:
 
           .. math:: :nowrap:
 
@@ -821,7 +822,7 @@ class CalcOptimalChi:
             \]
 
         The :math:`\ce{CO2}` limitation term of light use efficiency (:math:`m_j`) is
-        calculated following Equation 3 in :cite:`Wang:2017go`:
+        calculated following Equation 3 in :cite:t:`Wang:2017go`:
 
         .. math::
 
@@ -829,7 +830,7 @@ class CalcOptimalChi:
                        {c_a + 2 \Gamma^{*}}
 
         Finally,  :math:`m_c` is calculated, following Equation 7 in
-        :cite:`Stocker:2020dh`, as:
+        :cite:t:`Stocker:2020dh`, as:
 
         .. math::
 
@@ -877,7 +878,7 @@ class CalcOptimalChi:
         r"""Calculate soil moisture corrected :math:`\chi` for C3 plants.
 
         This method calculates the unit cost ratio $\beta$ as a function of soil
-        moisture ($\theta$, m3 m-3), following :cite:`lavergne:2020a`:
+        moisture ($\theta$, m3 m-3), following :cite:t:`lavergne:2020a`:
 
           .. math:: :nowrap:
 
@@ -886,7 +887,7 @@ class CalcOptimalChi:
             \]
 
         The coefficients are experimentally derived values with defaults taken from
-        Figure 6a of :cite:`lavergne:2020a` (:math:`a`,
+        Figure 6a of :cite:t:`lavergne:2020a` (:math:`a`,
         :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c3`;
         :math:`b`,
         :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c3`).
@@ -945,13 +946,12 @@ class CalcOptimalChi:
         This method calculates :math:`\beta` as a function of soil moisture following
         the equation described in the
         :meth:`~pyrealm.pmodel.pmodel.CalcOptimalChi.lavergne20_c3` method.  However,
-        the default coefficients of the moisture scaling from :cite:`lavergne:2020a` for
-        C3 plants are adjusted to match the theoretical expectation that :math:`\beta`
-        for C4 plants is nine times smaller than :math:`\beta` for C3 plants (see
-        :meth:`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4`): :math:`b`
+        the default coefficients of the moisture scaling from :cite:t:`lavergne:2020a`
+        for C3 plants are adjusted to match the theoretical expectation that
+        :math:`\beta` for C4 plants is nine times smaller than :math:`\beta` for C3
+        plants (see :meth:`~pyrealm.pmodel.pmodel.CalcOptimalChi.c4`): :math:`b`
         (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c4`) is
-        unchanged but
-        :math:`a_{C4} = a_{C3} - log(9)`
+        unchanged but :math:`a_{C4} = a_{C3} - log(9)`
         (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c4`) .
 
         Following the calculation of :math:`\beta`, this method then follows the
@@ -963,7 +963,7 @@ class CalcOptimalChi:
         Note:
 
         This is an **experimental approach**. The research underlying
-        :cite:`lavergne:2020a`, found **no relationship** between C4 :math:`\beta`
+        :cite:t:`lavergne:2020a`, found **no relationship** between C4 :math:`\beta`
         values and soil moisture in leaf gas exchange measurements.
 
         Examples:
@@ -1013,7 +1013,7 @@ class CalcOptimalChi:
         self.mjoc = self.mj / self.mc
 
     def c4(self) -> None:
-        r"""Estimate :math:`\chi` for C4 plants following :cite:`Prentice:2014bc`.
+        r"""Estimate :math:`\chi` for C4 plants following :cite:t:`Prentice:2014bc`.
 
         Optimal :math:`\chi` is calculated as in
         :meth:`~pyrealm.pmodel.pmodel.CalcOptimalChi.prentice14`, but using a C4
@@ -1152,14 +1152,14 @@ class JmaxLimitation:
 
         * ``simple``: applies the 'simple' equations with no limitation. The alias
           ``none`` is also accepted.
-        * ``wang17``: applies the framework of :cite:`Wang:2017go`.
-        * ``smith19``: applies the framework of :cite:`Smith:2019dv`
+        * ``wang17``: applies the framework of :cite:t:`Wang:2017go`.
+        * ``smith19``: applies the framework of :cite:t:`Smith:2019dv`
 
-    Note that :cite:`Smith:2019dv` defines :math:`\phi_0` as the quantum efficiency of
+    Note that :cite:t:`Smith:2019dv` defines :math:`\phi_0` as the quantum efficiency of
     electron transfer, whereas :class:`pyrealm.pmodel.pmodel.PModel` defines
     :math:`\phi_0` as the quantum efficiency of photosynthesis, which is 4 times
     smaller. This is why the factors here are a factor of 4 greater than Eqn 15 and 17
-    in :cite:`Smith:2019dv`.
+    in :cite:t:`Smith:2019dv`.
 
     Arguments:
         optchi: an instance of :class:`CalcOptimalChi` providing the :math:`\ce{CO2}`
@@ -1216,10 +1216,10 @@ class JmaxLimitation:
         """:math:`V_{cmax}` limitation factor, calculated using the method."""
         self.omega: Optional[NDArray] = None
         """Component of :math:`J_{max}` calculation for method ``smith19``
-        (:cite:`Smith:2019dv`)."""
+        :cite:p:`Smith:2019dv`."""
         self.omega_star: Optional[NDArray] = None
         """Component of :math:`J_{max}` calculation for method ``smith19``
-        (:cite:`Smith:2019dv`)."""
+        :cite:p:`Smith:2019dv`."""
 
         all_methods = {
             "wang17": self.wang17,
@@ -1246,9 +1246,9 @@ class JmaxLimitation:
         return f"JmaxLimitation(shape={self.shape})"
 
     def wang17(self) -> None:
-        r"""Calculate limitation factors following :cite:`Wang:2017go`.
+        r"""Calculate limitation factors following :cite:t:`Wang:2017go`.
 
-        These factors are described in Equation 49 of :cite:`Wang:2017go` as the
+        These factors are described in Equation 49 of :cite:t:`Wang:2017go` as the
         square root term at the end of that equation:
 
             .. math::
@@ -1287,7 +1287,7 @@ class JmaxLimitation:
             self.f_v = np.nan
 
     def smith19(self) -> None:
-        r"""Calculate limitation factors following :cite:`Smith:2019dv`.
+        r"""Calculate limitation factors following :cite:t:`Smith:2019dv`.
 
         The values are calculated as:
 

--- a/pyrealm/tmodel.py
+++ b/pyrealm/tmodel.py
@@ -31,7 +31,7 @@ class TTree:
     """Model plant growth using the T model.
 
     This class provides an implementation of the calculations of tree geometry, mass and
-    growth described by :cite:`Li:2014bc`. All of the properties of the T model are
+    growth described by :cite:t:`Li:2014bc`. All of the properties of the T model are
     derived from a set of traits (see
     :class:`~pyrealm.constants.tmodel_const.TModelTraits`), stem diameter measurements
     and estimates of gross primary productivity.


### PR DESCRIPTION
The package was using the [`sphinx-astrorefs`](https://github.com/jobovy/sphinx-astrorefs) package for citations, to get author year styling and some flexible roles. As of version `2.2.0`, `sphinxcontrib.bibtex` now supports author year, and `sphinx-astrorefs` is pinned against an earlier version, so this PR updates `conf.py` to move to pure `sphinxcontrib.bibtex` (customised to use round parentheses) and then updates all of the citations with the appropriate `:cite:` roles.