### PR TITLE
Add doc build testing on GitHub Actions

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -44,3 +44,28 @@ jobs:
       run: |
         pip install codecov
         codecov
+
+  docs_build:
+    needs: qa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.1.6
+        with:
+          poetry-version: 1.2.2
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Set ipython kernel
+        run: poetry run python -m ipykernel install --user --name=vr_python3
+      
+      - name: Build docs using sphinx
+        run: |
+          cd docs
+          poetry run sphinx-build -W --keep-going source build

--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -63,7 +63,7 @@ jobs:
         run: poetry install
 
       - name: Set ipython kernel
-        run: poetry run python -m ipykernel install --user --name=vr_python3
+        run: poetry run python -m ipykernel install --user --name=pyrealm_python3
       
       - name: Build docs using sphinx
         run: |

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -429,9 +429,9 @@ def calc_kmm(tc: NDArray, patm: NDArray, const: PModelConst = PModelConst()) -> 
               for the same conversion for a value in the same table.
 
     Args:
-        tc: Temperature, relevant for photosynthesis (:math:`T`, °C) patm: Atmospheric
-        pressure (:math:`p`, Pa) const: Instance of
-        :class:`~pyrealm.constants.pmodel_const.PModelConst`.
+        tc: Temperature, relevant for photosynthesis (:math:`T`, °C)
+        patm: Atmospheric pressure (:math:`p`, Pa)
+        const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
 
     PModel Parameters:
         hac: activation energy for :math:`\ce{CO2}` (:math:`H_{kc}`, ``bernacchi_dhac``)
@@ -702,7 +702,7 @@ def calc_co2_to_ca(co2: NDArray, patm: NDArray) -> NDArray:
     accounting for atmospheric pressure.
 
     Args:
-        co2 (float): atmospheric :math:`\ce{CO2}`, ppm
+        co2: atmospheric :math:`\ce{CO2}`, ppm
         patm (float): atmospheric pressure, Pa
 
     Returns:


### PR DESCRIPTION
This PR adds a GitHub Action that builds the docs using `sphinx` using:

`sphinx-build -W --keep-going source build`

The `-W` tag turns warnings into errors, so the build has to be completely clean, and it keeps going past the first failure.