### PR TITLE
Bug in PModel._check_estimated

### DIFF
--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -508,7 +508,7 @@ class PModel:
         A helper function to raise an error when a user accesses a P Model
         parameter that has not yet been estimated via `estimate_productivity`.
         """
-        if getattr(self, "_" + varname) is None:
+        if not hasattr(self, "_" + varname):
             raise RuntimeError(f"{varname} not calculated: use estimate_productivity")
 
     @property


### PR DESCRIPTION
This PR patches a minor bug: `PModel._check_estimated` was using `getattr` to check if (e.g.) `gpp` had been populated by `estimate_productivity`, but these attributes are now only defined at all when `estimate_productivity` is run, so this should now use `hasattr`.