### PR TITLE
Updated RTD config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,26 +1,41 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+  jobs:
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      - poetry install --with docs
+      # Install the project ipykernel under the fixed name
+      - poetry run python -m ipykernel install --user --name=pyrealm_python3
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: source/conf.py
+   configuration: docs/source/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
 
-# Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.7
-  install:
-    - requirements: source/requirements.txt
-    - method: pip
-      path: .
+# Optionally declare the Python requirements required to build your docs
+# These are installed as dev requirements via poetry (but note that this will need to be
+# updated for poetry 1.2).
+#
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/docs/source/api/constants_api.md
+++ b/docs/source/api/constants_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 

--- a/docs/source/api/hygro_api.md
+++ b/docs/source/api/hygro_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 

--- a/docs/source/api/pmodel_api.md
+++ b/docs/source/api/pmodel_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The {mod}`~pyrealm.pmodel` module

--- a/docs/source/api/tmodel_api.md
+++ b/docs/source/api/tmodel_api.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The {mod}`~pyrealm.tmodel` module

--- a/docs/source/api/utilities_api.md
+++ b/docs/source/api/utilities_api.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 

--- a/docs/source/constants.md
+++ b/docs/source/constants.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Constants

--- a/docs/source/development/developers.md
+++ b/docs/source/development/developers.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Package documentation

--- a/docs/source/hygro.md
+++ b/docs/source/hygro.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Hygrometric functions

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,7 +7,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The `pyrealm` package

--- a/docs/source/pmodel/isotopic_discrimination.md
+++ b/docs/source/pmodel/isotopic_discrimination.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Isotopic discrimination

--- a/docs/source/pmodel/pmodel.md
+++ b/docs/source/pmodel/pmodel.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 <!-- markdownlint-disable-next-line MD041 -->

--- a/docs/source/pmodel/pmodel_details/envt_variation_outputs.md
+++ b/docs/source/pmodel/pmodel_details/envt_variation_outputs.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # P Model predictions

--- a/docs/source/pmodel/pmodel_details/extreme_values.md
+++ b/docs/source/pmodel/pmodel_details/extreme_values.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Extreme forcing values

--- a/docs/source/pmodel/pmodel_details/global_example.md
+++ b/docs/source/pmodel/pmodel_details/global_example.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Worked example

--- a/docs/source/pmodel/pmodel_details/lue_limitation.md
+++ b/docs/source/pmodel/pmodel_details/lue_limitation.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # LUE Limitation

--- a/docs/source/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/pmodel/pmodel_details/optimal_chi.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Optimal $\chi$ and leaf $\ce{CO2}$

--- a/docs/source/pmodel/pmodel_details/photosynthetic_environment.md
+++ b/docs/source/pmodel/pmodel_details/photosynthetic_environment.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Photosynthetic environment

--- a/docs/source/pmodel/pmodel_details/pmodel_details.md
+++ b/docs/source/pmodel/pmodel_details/pmodel_details.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The P Model: details

--- a/docs/source/pmodel/pmodel_details/rpmodel.md
+++ b/docs/source/pmodel/pmodel_details/rpmodel.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The `rpmodel` implementation

--- a/docs/source/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/pmodel/pmodel_details/soil_moisture.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # Soil moisture stress

--- a/docs/source/tmodel/tmodel.md
+++ b/docs/source/tmodel/tmodel.md
@@ -9,7 +9,7 @@ jupytext:
 kernelspec:
   display_name: Python 3
   language: python
-  name: python3
+  name: pyrealm_python3
 ---
 
 # The T Model


### PR DESCRIPTION
This PR updates the `.readthedocs.yaml` file to build using `poetry` and also updates all of the markdown files in `docs/source` to use the `pyrealm_python3` kernel name for consistent building across machines.