### PR TITLE
Let flake8 ignore E203

### DIFF
--- a/profiling/report.py
+++ b/profiling/report.py
@@ -77,7 +77,7 @@ kpis = ["tottime_percall", "cumtime_percall", "tottime", "cumtime"]
 labels = df[kpis].idxmax()
 bm = df.pivot_table(index="timestamp", columns="label", values=kpis)
 bm = bm[list(map(tuple, labels.reset_index().values))]
-bm = bm.iloc[-args.max_benchmark:]  # fmt: skip
+bm = bm.iloc[-args.max_benchmark :]
 bm.columns = bm.columns.map(lambda x: f"{x[1]}({x[0]})")
 bm.T.plot.barh(figsize=(20, 10))
 plt.tight_layout()

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ ignore =
 	# Line break before binary operators is ok
 	D105
 	# Magic methods do not need docstrings.
+	E203
+	# Whitespace before ':' is ok
 per-file-ignores =
 	pyrealm/pmodel/__init__.py: F401
 	pyrealm/constants/__init__.py: F401


### PR DESCRIPTION
# Description

There is a conflict between `black` and `flake8` dealing with the space before colons used for slicing. Letting flake8 ignore this will fix it.
