### PR TITLE
Adding two leaf two stream canopy and solar rad model

### DIFF
--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -25,8 +25,9 @@ from pyrealm.constants import CoreConst
 
 ## plan to move individual functions from splash.solar.py here for general use
 
+
 def calc_distance_factor(nu, k_e):
-    '''Calculate distance factor
+    """Calculate distance factor
 
     This function calculates distance factor using the method of Berger et al. (1993)
     Args:
@@ -35,19 +36,14 @@ def calc_distance_factor(nu, k_e):
 
     Returns:
         dr: distance factor
-    '''
-    dr = (
-            1.0
-            / (
-                (1.0 - k_e**2)
-                / (1.0 + k_e * np.cos(np.deg2rad(nu)))
-            )
-        ) ** 2
+    """
+    dr = (1.0 / ((1.0 - k_e**2) / (1.0 + k_e * np.cos(np.deg2rad(nu))))) ** 2
 
     return dr
 
+
 def calc_declination_angle_delta(lambda_, k_eps, k_pir):
-    '''Calculate declination angle delta
+    """Calculate declination angle delta
 
     This function calculates the solar declination angle delta using the method of Woolf (1968)
 
@@ -58,18 +54,14 @@ def calc_declination_angle_delta(lambda_, k_eps, k_pir):
 
     Returns:
         delta: solar declination angle delta
-    '''
-    delta = (
-            np.arcsin(
-                np.sin(np.deg2rad(lambda_)) * np.sin(np.deg2rad(k_eps))
-            )
-            / k_pir
-        )
+    """
+    delta = np.arcsin(np.sin(np.deg2rad(lambda_)) * np.sin(np.deg2rad(k_eps))) / k_pir
 
     return delta
 
+
 def calc_lat_delta_intermediates(delta, lat):
-    '''Calculates intermediate values for use in solar radiation calcs
+    """Calculates intermediate values for use in solar radiation calcs
 
     This function calculates ru and rv which are dimensionless intermediate values calculated from the solar declination angle delta and the observation latitude
 
@@ -79,25 +71,27 @@ def calc_lat_delta_intermediates(delta, lat):
 
     Returns:
         Tuple: ru, rv
-            
-    '''
+
+    """
     ru = np.sin(np.deg2rad(delta)) * np.sin(np.deg2rad(lat))
     rv = np.cos(np.deg2rad(delta)) * np.cos(np.deg2rad(lat))
 
     return ru, rv
 
+
 def calc_sunset_hour_angle(ru, rv, k_pir):
-    '''Calculate sunset hour angle
+    """Calculate sunset hour angle
 
     This function calculates the sunset hour angle using Eq3.22, Stine & Geyer (2001)
-    
+
     Args:
         ru: dimensionless
-    '''
+    """
 
-    angle  = np.arccos(-1.0 * np.clip(ru / rv, -1.0, 1.0))/ k_pir
+    angle = np.arccos(-1.0 * np.clip(ru / rv, -1.0, 1.0)) / k_pir
 
     return angle
+
 
 def calc_heliocentric_longitudes(
     julian_day: NDArray, n_days: NDArray, core_const: CoreConst = CoreConst()
@@ -163,5 +157,3 @@ def calc_heliocentric_longitudes(
     nu = (lambda_ - core_const.k_omega) % 360
 
     return (nu, lambda_)
-
-

--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -23,6 +23,82 @@ from pyrealm.constants import CoreConst
 # )
 
 
+## plan to move individual functions from splash.solar.py here for general use
+
+def calc_distance_factor(nu, k_e):
+    '''Calculate distance factor
+
+    This function calculates distance factor using the method of Berger et al. (1993)
+    Args:
+        nu: helio centric true anomaly
+        k_e: Solar eccentricity
+
+    Returns:
+        dr: distance factor
+    '''
+    dr = (
+            1.0
+            / (
+                (1.0 - k_e**2)
+                / (1.0 + k_e * np.cos(np.deg2rad(nu)))
+            )
+        ) ** 2
+
+    return dr
+
+def calc_declination_angle_delta(lambda_, k_eps, k_pir):
+    '''Calculate declination angle delta
+
+    This function calculates the solar declination angle delta using the method of Woolf (1968)
+
+    Args:
+        lambda_: heliocentric longitude
+        k_eps: Solar obliquity
+        k_pir: conversion factor from radians to degrees
+
+    Returns:
+        delta: solar declination angle delta
+    '''
+    delta = (
+            np.arcsin(
+                np.sin(np.deg2rad(lambda_)) * np.sin(np.deg2rad(k_eps))
+            )
+            / k_pir
+        )
+
+    return delta
+
+def calc_lat_delta_intermediates(delta, lat):
+    '''Calculates intermediate values for use in solar radiation calcs
+
+    This function calculates ru and rv which are dimensionless intermediate values calculated from the solar declination angle delta and the observation latitude
+
+    Args:
+        delta: solar declination delta
+        lat: observation latitude
+
+    Returns:
+        Tuple: ru, rv
+            
+    '''
+    ru = np.sin(np.deg2rad(delta)) * np.sin(np.deg2rad(lat))
+    rv = np.cos(np.deg2rad(delta)) * np.cos(np.deg2rad(lat))
+
+    return ru, rv
+
+def calc_sunset_hour_angle(ru, rv, k_pir):
+    '''Calculate sunset hour angle
+
+    This function calculates the sunset hour angle using Eq3.22, Stine & Geyer (2001)
+    
+    Args:
+        ru: dimensionless
+    '''
+
+    angle  = np.arccos(-1.0 * np.clip(ru / rv, -1.0, 1.0))/ k_pir
+
+    return angle
+
 def calc_heliocentric_longitudes(
     julian_day: NDArray, n_days: NDArray, core_const: CoreConst = CoreConst()
 ) -> tuple[NDArray, NDArray]:
@@ -87,3 +163,5 @@ def calc_heliocentric_longitudes(
     nu = (lambda_ - core_const.k_omega) % 360
 
     return (nu, lambda_)
+
+

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -9,7 +9,11 @@ from numpy.typing import NDArray
 
 from pyrealm.constants import CoreConst
 from pyrealm.core.calendar import Calendar
-from pyrealm.core.solar import calc_heliocentric_longitudes, calc_distance_factor, calc_declination_angle_delta
+from pyrealm.core.solar import (
+    calc_declination_angle_delta,
+    calc_distance_factor,
+    calc_heliocentric_longitudes,
+)
 from pyrealm.core.utilities import check_input_shapes
 
 
@@ -89,7 +93,9 @@ class DailySolarFluxes:
         dr = calc_distance_factor(nu, self.core_const.k_e)
 
         # Calculate declination angle (delta), Woolf (1968)
-        delta = calc_declination_angle_delta(lambda_, self.const.k_eps, self.const.k_pir)
+        delta = calc_declination_angle_delta(
+            lambda_, self.const.k_eps, self.const.k_pir
+        )
 
         # The nu, lambda_, dr and delta attributes are all one dimensional arrays
         # calculated from the Calendar along the first (time) axis of the other inputs.

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -9,7 +9,7 @@ from numpy.typing import NDArray
 
 from pyrealm.constants import CoreConst
 from pyrealm.core.calendar import Calendar
-from pyrealm.core.solar import calc_heliocentric_longitudes
+from pyrealm.core.solar import calc_heliocentric_longitudes, calc_distance_factor, calc_declination_angle_delta
 from pyrealm.core.utilities import check_input_shapes
 
 
@@ -86,21 +86,10 @@ class DailySolarFluxes:
         )
 
         # Calculate distance factor (dr), Berger et al. (1993)
-        dr = (
-            1.0
-            / (
-                (1.0 - self.core_const.k_e**2)
-                / (1.0 + self.core_const.k_e * np.cos(np.deg2rad(nu)))
-            )
-        ) ** 2
+        dr = calc_distance_factor(nu, self.core_const.k_e)
 
         # Calculate declination angle (delta), Woolf (1968)
-        delta = (
-            np.arcsin(
-                np.sin(np.deg2rad(lambda_)) * np.sin(np.deg2rad(self.core_const.k_eps))
-            )
-            / self.core_const.k_pir
-        )
+        delta = calc_declination_angle_delta(lambda_, self.const.k_eps, self.const.k_pir)
 
         # The nu, lambda_, dr and delta attributes are all one dimensional arrays
         # calculated from the Calendar along the first (time) axis of the other inputs.


### PR DESCRIPTION

# Description

This PR relates to the ongoing discussion #234 and the implementation of a two-leaf canopy representation and associated solar model (Work in progress)

To do list:
- Migrate useful solar functions out of splash.solar into core.solar to extend core solar library
- Create alternative method to calculate pdf
- Implement similar radiation model as supplied R code using python libs and/or custom code
- Implement canopy model
- Integrate canopy model productivity into existing code

Fixes # N/A

## Type of change

- [ x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
