### PR TITLE
Shared base classes for demography classes

### DIFF
--- a/docs/source/api/demography_api.md
+++ b/docs/source/api/demography_api.md
@@ -30,6 +30,14 @@ language_info:
     :members:
 ```
 
+## The {mod}`~pyrealm.demography.core` module
+
+```{eval-rst}
+.. automodule:: pyrealm.demography.core
+    :autosummary:
+    :members:
+```
+
 ## The {mod}`~pyrealm.demography.flora` module
 
 ```{eval-rst}

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -274,9 +274,9 @@ above calculated at each height $z$:
 crown_profiles
 ```
 
-The {meth}`~pyrealm.demography.crown.CrownProfile.to_pandas` method can be used to
-extract the data into a table, with the separate stems identified by the column index
-field.
+The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.crown.CrownProfile` class can be used to extract the data
+into a table, with the separate stems identified by the column index field.
 
 ```{code-cell} ipython3
 crown_profiles.to_pandas()

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -218,12 +218,10 @@ flora = Flora([narrow_pft, medium_pft, wide_pft])
 flora
 ```
 
-The Flora object can also be used to show a table of canopy variables:
+The key canopy variables from the flora are:
 
 ```{code-cell} ipython3
-# TODO - add a Flora.to_pandas() method
-flora_data = pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
-flora_data[["name", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]]
+flora.to_pandas()[["name", "h_max", "ca_ratio", "m", "n", "f_g", "q_m", "z_max_prop"]]
 ```
 
 The next section of code generates the `StemAllometry` to use for the profiles.
@@ -249,14 +247,12 @@ allometry = StemAllometry(stem_traits=flora, at_dbh=stem_dbh)
 We can again use {mod}`pandas` to get a table of those allometric predictions:
 
 ```{code-cell} ipython3
-pd.DataFrame({k: getattr(allometry, k) for k in allometry.allometry_attrs})
+allometry.to_pandas()
 ```
 
 Finally, we can define a set of vertical heights. In order to calculate the
 variables for each PFT at each height, this needs to be provided as a column array,
-that is with a shape `(N, 1)`.
-
-We can then calculate the crown profiles.
+that is with a shape `(N, 1)`. We can then calculate the crown profiles:
 
 ```{code-cell} ipython3
 # Create a set of vertical heights as a column array.
@@ -276,6 +272,14 @@ above calculated at each height $z$:
 
 ```{code-cell} ipython3
 crown_profiles
+```
+
+The {meth}`~pyrealm.demography.crown.CrownProfile.to_pandas` method can be used to
+extract the data into a table, with the separate stems identified by the column index
+field.
+
+```{code-cell} ipython3
+crown_profiles.to_pandas()
 ```
 
 ### Visualising crown profiles
@@ -531,8 +535,4 @@ plt.legend(
     loc="upper center",
     bbox_to_anchor=(0.5, 1.15),
 )
-```
-
-```{code-cell} ipython3
-
 ```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -147,9 +147,9 @@ flora
 ```
 
 The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
-{meth}`~pyrealm.demography.t_model_functions.StemTraits` class exports the trait data as
-a {class}`pandas.DataFrame`, making it easier to use for plotting or calculations
-outside of `pyrealm`.
+{meth}`~pyrealm.demography.flora.StemTraits` class exports the trait data as a
+{class}`pandas.DataFrame`, making it easier to use for plotting or calculations outside
+of `pyrealm`.
 
 ```{code-cell} ipython3
 flora.to_pandas()
@@ -176,8 +176,7 @@ stem_traits = flora.get_stem_traits(pft_names=stem_pfts)
 ```
 
 Again, the {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
-{meth}`~pyrealm.demography.t_model_functions.StemTraits` class can be use to extract
-the data:
+{meth}`~pyrealm.demography.flora.StemTraits` class can be use to extract the data:
 
 ```{code-cell} ipython3
 stem_traits.to_pandas()

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -146,8 +146,12 @@ flora = Flora([short_pft, medium_pft, tall_pft])
 flora
 ```
 
+The class provides a {meth}`~pyrealm.demography.StemTraits.to_pandas()` method to export
+the trait data as a {class}`pandas.DataFrame`, making it easier to use for plotting or
+calculations outside of `pyrealm`.
+
 ```{code-cell} ipython3
-pd.DataFrame({k: getattr(flora, k) for k in flora.trait_attrs})
+flora.to_pandas()
 ```
 
 You can also create `Flora` instances using PFT data stored TOML, JSON and CSV file
@@ -168,7 +172,11 @@ more easily created from a `Flora` object by providing a list of PFT names:
 # Get stem traits for a range of stems
 stem_pfts = ["short", "short", "short", "medium", "medium", "tall"]
 stem_traits = flora.get_stem_traits(pft_names=stem_pfts)
+```
 
-# Show the repeated values
-stem_traits.h_max
+Again, the class provides the {meth}`~pyrealm.demography.StemTraits.to_pandas()` method
+to extract the data:
+
+```{code-cell} ipython3
+stem_traits.to_pandas()
 ```

--- a/docs/source/users/demography/flora.md
+++ b/docs/source/users/demography/flora.md
@@ -146,9 +146,10 @@ flora = Flora([short_pft, medium_pft, tall_pft])
 flora
 ```
 
-The class provides a {meth}`~pyrealm.demography.StemTraits.to_pandas()` method to export
-the trait data as a {class}`pandas.DataFrame`, making it easier to use for plotting or
-calculations outside of `pyrealm`.
+The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.t_model_functions.StemTraits` class exports the trait data as
+a {class}`pandas.DataFrame`, making it easier to use for plotting or calculations
+outside of `pyrealm`.
 
 ```{code-cell} ipython3
 flora.to_pandas()
@@ -174,8 +175,9 @@ stem_pfts = ["short", "short", "short", "medium", "medium", "tall"]
 stem_traits = flora.get_stem_traits(pft_names=stem_pfts)
 ```
 
-Again, the class provides the {meth}`~pyrealm.demography.StemTraits.to_pandas()` method
-to extract the data:
+Again, the {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.t_model_functions.StemTraits` class can be use to extract
+the data:
 
 ```{code-cell} ipython3
 stem_traits.to_pandas()

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -77,9 +77,9 @@ for each PFT. This then calculates a single estimate at the given size for each 
 single_allometry = StemAllometry(stem_traits=flora, at_dbh=np.array([0.1, 0.1, 0.1]))
 ```
 
-The class provides a
-{meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()` method
-to export the stem data for data exploration.
+The {meth}`~pyrealm.demography.t_model_functions.StemAllometry` class provides the
+{meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method to export the stem
+data for data exploration.
 
 ```{code-cell} ipython3
 single_allometry.to_pandas()
@@ -123,8 +123,9 @@ for ax, (var, ylab) in zip(axes.flatten(), plot_details):
         ax.legend(frameon=False)
 ```
 
-The {meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()` method
-can still be used, but the values are stacked into columns along with a column index
+The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.t_model_functions.StemAllometry` class can still be used, but
+the values are stacked into columns along with a index showing the different cohorts.
 
 ```{code-cell} ipython3
 allometries.to_pandas()
@@ -144,8 +145,8 @@ single_allocation = StemAllocation(
 single_allocation
 ```
 
-The class provides the
-{meth}`~pyrealm.demography.t_model_functions.StemAllocation.to_pandas()` method to
+The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.t_model_functions.StemAllocation` class can be used to
 export data for exploration.
 
 ```{code-cell} ipython3
@@ -227,8 +228,9 @@ for ax, (var, ylab) in zip(axes, plot_details):
 fig.delaxes(axes[-1])
 ```
 
-As before, the {meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()`
-method can be used to export the data for each stem:
+As before, the {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
+{meth}`~pyrealm.demography.t_model_functions.StemAllometry` classs can be used to export
+the data for each stem:
 
 ```{code-cell} ipython3
 allocation.to_pandas()

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -40,7 +40,7 @@ from pyrealm.demography.t_model_functions import StemAllocation, StemAllometry
 ```
 
 To generate predictions under the T Model, we need a Flora object providing the
-[trait values](./flora.md) for each of the PFTsto be modelled:
+[trait values](./flora.md) for each of the PFTs to be modelled:
 
 ```{code-cell} ipython3
 # Three PFTS
@@ -77,12 +77,12 @@ for each PFT. This then calculates a single estimate at the given size for each 
 single_allometry = StemAllometry(stem_traits=flora, at_dbh=np.array([0.1, 0.1, 0.1]))
 ```
 
-We can display those predictions as a `pandas.DataFrame`:
+The class provides a
+{meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()` method
+to export the stem data for data exploration.
 
 ```{code-cell} ipython3
-pd.DataFrame(
-    {k: getattr(single_allometry, k) for k in single_allometry.allometry_attrs}
-)
+single_allometry.to_pandas()
 ```
 
 However, the DBH values can also be a column array (an `N` x 1 array). In this case, the
@@ -123,11 +123,19 @@ for ax, (var, ylab) in zip(axes.flatten(), plot_details):
         ax.legend(frameon=False)
 ```
 
+The {meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()` method
+can still be used, but the values are stacked into columns along with a column index
+
+```{code-cell} ipython3
+allometries.to_pandas()
+```
+
 ## Productivity allocation
 
 The T Model also predicts how potential GPP will be allocated to respiration, turnover
-and growth for stems with a given PFT and allometry. Again, a single value can be
-provided to get a single estimate of the allocation model for each stem:
+and growth for stems with a given PFT and allometry using the
+{meth}`~pyrealm.demography.t_model_functions.StemAllometry` class. Again, a single
+value can be provided to get a single estimate of the allocation model for each stem:
 
 ```{code-cell} ipython3
 single_allocation = StemAllocation(
@@ -136,10 +144,12 @@ single_allocation = StemAllocation(
 single_allocation
 ```
 
+The class provides the
+{meth}`~pyrealm.demography.t_model_functions.StemAllocation.to_pandas()` method to
+export data for exploration.
+
 ```{code-cell} ipython3
-pd.DataFrame(
-    {k: getattr(single_allocation, k) for k in single_allocation.allocation_attrs}
-)
+single_allocation.to_pandas()
 ```
 
 Using a column array of potential GPP values can be used to predict multiple estimates of
@@ -217,6 +227,9 @@ for ax, (var, ylab) in zip(axes, plot_details):
 fig.delaxes(axes[-1])
 ```
 
-```{code-cell} ipython3
+As before, the {meth}`~pyrealm.demography.t_model_functions.StemAllometry.to_pandas()`
+method can be used to export the data for each stem:
 
+```{code-cell} ipython3
+allocation.to_pandas()
 ```

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from scipy.optimize import root_scalar  # type: ignore [import-untyped]
 
 from pyrealm.demography.community import Community
+from pyrealm.demography.core import PandasExporter
 from pyrealm.demography.crown import (
     CrownProfile,
     _validate_z_qz_args,
@@ -166,7 +167,7 @@ def fit_perfect_plasticity_approximation(
 
 
 @dataclass
-class CohortCanopyData:
+class CohortCanopyData(PandasExporter):
     """Dataclass holding canopy data across cohorts.
 
     The cohort canopy data consists of a set of attributes represented as two
@@ -279,7 +280,7 @@ class CohortCanopyData:
 
 
 @dataclass
-class CommunityCanopyData:
+class CommunityCanopyData(PandasExporter):
     """Dataclass holding community-wide canopy data.
 
     The community canopy data consists of a set of attributes represented as one

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
+from typing import ClassVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -209,6 +210,15 @@ class CohortCanopyData(PandasExporter):
         cell_area: A float setting the total canopy area available to the cohorts.
     """
 
+    array_attrs: ClassVar[tuple[str, ...]] = (
+        "stem_leaf_area",
+        "lai",
+        "f_trans",
+        "f_abs",
+        "cohort_fapar",
+        "stem_fapar",
+    )
+
     # Init vars
     projected_leaf_area: InitVar[NDArray[np.float64]]
     """An array of the stem projected leaf area for each cohort at each of the required
@@ -303,6 +313,14 @@ class CommunityCanopyData(PandasExporter):
             heights, as calculated as
             :attr:`CohortCanopyData.f_trans<pyrealm.demography.canopy.CohortCanopyData.f_trans>`.
     """
+
+    array_attrs: ClassVar[tuple[str, ...]] = (
+        "f_trans",
+        "f_abs",
+        "transmission_profile",
+        "extinction_profile",
+        "fapar",
+    )
 
     # Init vars
     cohort_transmissivity: InitVar[NDArray[np.float64]]

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -124,6 +124,7 @@ from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.demography.core import PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
 from pyrealm.demography.t_model_functions import StemAllometry
 
@@ -136,7 +137,7 @@ else:
 
 
 @dataclass
-class Cohorts:
+class Cohorts(PandasExporter):
     """A dataclass to hold data for a set of plant cohorts.
 
     The attributes should be numpy arrays of equal length, containing an entry for each

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -538,22 +538,38 @@ class Community:
 
         return cls(**file_data, flora=flora)
 
-    def add_cohorts(self, new_cohorts: Cohorts) -> None:
+    def drop_cohorts(self, drop_indices: NDArray[np.int_]) -> None:
+        """Drop cohorts from the community.
+
+        This method drops the identified cohorts from the ``cohorts`` attribute and then
+        removes their data from  the ``stem_traits`` and ``stem_allometry`` attributes
+        to match.
+        """
+
+        self.cohorts.drop_cohort_data(drop_indices=drop_indices)
+        self.stem_traits.drop_cohort_data(drop_indices=drop_indices)
+        self.stem_allometry.drop_cohort_data(drop_indices=drop_indices)
+
+    def add_cohorts(self, new_data: Cohorts) -> None:
         """Add a new set of cohorts to the community.
 
         This method extends the ``cohorts`` attribute with the new cohort data and then
         also extends the ``stem_traits`` and ``stem_allometry`` to match.
+
+        Args:
+            new_data: An instance of :class:`~pyrealm.demography.community.Cohorts`
+                containing cohort data to add to the community.
         """
 
-        self.cohorts.add_cohort_data(new_cohorts)
+        self.cohorts.add_cohort_data(new_data=new_data)
 
-        new_stem_traits = self.flora.get_stem_traits(new_cohorts.pft_names)
-        self.stem_traits.add_cohort_data(new_stem_traits)
+        new_stem_traits = self.flora.get_stem_traits(pft_names=new_data.pft_names)
+        self.stem_traits.add_cohort_data(new_data=new_stem_traits)
 
         new_stem_allometry = StemAllometry(
-            stem_traits=new_stem_traits, at_dbh=new_cohorts.dbh_values
+            stem_traits=new_stem_traits, at_dbh=new_data.dbh_values
         )
-        self.stem_allometry.add_cohort_data(new_stem_allometry)
+        self.stem_allometry.add_cohort_data(new_data=new_stem_allometry)
 
     # @classmethod
     # def load_communities_from_csv(

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -136,7 +136,7 @@ from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
-from pyrealm.demography.core import PandasExporter
+from pyrealm.demography.core import CohortMethods, PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
 from pyrealm.demography.t_model_functions import StemAllometry
 
@@ -149,7 +149,7 @@ else:
 
 
 @dataclass
-class Cohorts(PandasExporter):
+class Cohorts(PandasExporter, CohortMethods):
     """A dataclass to hold data for a set of plant cohorts.
 
     The attributes should be numpy arrays of equal length, containing an entry for each
@@ -537,6 +537,23 @@ class Community:
             raise excep
 
         return cls(**file_data, flora=flora)
+
+    def add_cohorts(self, new_cohorts: Cohorts) -> None:
+        """Add a new set of cohorts to the community.
+
+        This method extends the ``cohorts`` attribute with the new cohort data and then
+        also extends the ``stem_traits`` and ``stem_allometry`` to match.
+        """
+
+        self.cohorts.add_cohort_data(new_cohorts)
+
+        new_stem_traits = self.flora.get_stem_traits(new_cohorts.pft_names)
+        self.stem_traits.add_cohort_data(new_stem_traits)
+
+        new_stem_allometry = StemAllometry(
+            stem_traits=new_stem_traits, at_dbh=new_cohorts.dbh_values
+        )
+        self.stem_allometry.add_cohort_data(new_stem_allometry)
 
     # @classmethod
     # def load_communities_from_csv(

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -24,8 +24,8 @@ class PandasExporter(ABC):
     def to_pandas(self) -> pd.DataFrame:
         """Convert the instance array attributes into a {class}`pandas.DataFrame.
 
-        If the array values are two-dimensional (e.g. stems by heights), the data are
-        stacked and an index field is added.
+        If the array values are two-dimensional (i.e. stem or cohort data by vertical
+        heights), the data are stacked and an index is added.
         """
 
         # Extract the attributes into a dictionary
@@ -37,13 +37,13 @@ class PandasExporter(ABC):
         if len(data_shape) == 2:
             # create an index entry to show the column of each value
             stacked_data = {
-                "column_index": np.repeat(np.arange(data_shape[1]), data_shape[0])
+                "column_stem_index": np.repeat(np.arange(data_shape[1]), data_shape[0])
             }
             # Ravel the attribute data using column-major Fortan style
             for ky, vl in data.items():
                 stacked_data[ky] = np.ravel(vl, order="F")
 
-            return pd.DataFrame(stacked_data)
+            return pd.DataFrame(stacked_data).set_index("column_stem_index")
 
         return pd.DataFrame(data)
 

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -95,5 +95,15 @@ class CohortMethods(ABC):
             drop_indices: An array of integer indices to drop from each array attribute.
         """
 
+        # TODO - Probably part of tackling #317
+        #        The delete axis=0 here is tied to the case of dropping rows from 2D
+        #        arrays, but then I'm thinking it makes more sense to _only_ support 2D
+        #        arrays rather than the current mixed bag of getting a 1D array when a
+        #        single height is provided. Promoting that kind of input to 2D and then
+        #        enforcing an identical internal structure seems better.
+        #      - But! Trait data does not have 2 dimensions!
+        #      - Also to check here - this can lead to empty instances, which probably
+        #        are a thing we want, if mortality removes all cohorts.
+
         for trait in self.array_attrs:
-            setattr(self, trait, np.delete(getattr(self, trait), drop_indices))
+            setattr(self, trait, np.delete(getattr(self, trait), drop_indices, axis=0))

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -1,4 +1,16 @@
-"""Core shared functionality for the {mod}`~pyrealm.demography` module."""
+"""Core shared functionality for the {mod}`~pyrealm.demography` module.
+
+This module implements two abstract base classes that are used to share core methods
+across demography classes:
+
+* {class}`~pyrealm.demography.core.PandasExporter` provides the utility
+  {meth}`~pyrealm.demography.core.PandasExporter.to_pandas` method for extracting data
+  from demography classes for plotting and exploring data.
+* {class}`~pyrealm.demography.core.CohortMethods` provides the utility
+  {meth}`~pyrealm.demography.core.CohortMethods.add_cohort_data` and
+  {meth}`~pyrealm.demography.core.CohortMethods.drop_cohort_data` methods that are used
+  to append new cohort data across some demography dataclasses.
+"""
 
 from __future__ import annotations
 

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -22,8 +22,30 @@ class PandasExporter(ABC):
     array_attrs: ClassVar[tuple[str, ...]]
 
     def to_pandas(self) -> pd.DataFrame:
-        """Convert the instance array attributes into a {class}`pandas.DataFrame."""
-        return pd.DataFrame({k: getattr(self, k) for k in self.array_attrs})
+        """Convert the instance array attributes into a {class}`pandas.DataFrame.
+
+        If the array values are two-dimensional (e.g. stems by heights), the data are
+        stacked and an index field is added.
+        """
+
+        # Extract the attributes into a dictionary
+        data = {k: getattr(self, k) for k in self.array_attrs}
+
+        # Check the first attribute array to see if the values are two dimensional
+        data_shape = data[self.array_attrs[0]].shape
+
+        if len(data_shape) == 2:
+            # create an index entry to show the column of each value
+            stacked_data = {
+                "column_index": np.repeat(np.arange(data_shape[1]), data_shape[0])
+            }
+            # Ravel the attribute data using column-major Fortan style
+            for ky, vl in data.items():
+                stacked_data[ky] = np.ravel(vl, order="F")
+
+            return pd.DataFrame(stacked_data)
+
+        return pd.DataFrame(data)
 
 
 class Cohorts(ABC):

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -64,26 +64,31 @@ class CohortMethods(ABC):
 
     array_attrs: ClassVar[tuple[str, ...]]
 
-    def add_cohorts(self, add: CohortMethods) -> None:
+    def add_cohort_data(self, new_data: CohortMethods) -> None:
         """Add array attributes from a second instance implementing the base class.
 
         Args:
-            add: A second instance from which to add array attribute values.
+            new_data: A second instance from which to add cohort data to array attribute
+                values.
         """
 
-        if not isinstance(add, self.__class__):
+        # Check the incoming dataclass matches the calling instance.
+        if not isinstance(new_data, self.__class__):
             raise ValueError(
-                f"Cannot add {type(add).__name__} instance to {type(self).__name__}"
+                f"Cannot add cohort data from an {type(new_data).__name__} "
+                f"instance to {type(self).__name__}"
             )
 
+        # Concatenate the array attributes from the incoming instance to the calling
+        # instance.
         for trait in self.array_attrs:
             setattr(
                 self,
                 trait,
-                np.concatenate([getattr(self, trait), getattr(add, trait)]),
+                np.concatenate([getattr(self, trait), getattr(new_data, trait)]),
             )
 
-    def drop_cohorts(self, drop_indices: NDArray[np.int_]) -> None:
+    def drop_cohort_data(self, drop_indices: NDArray[np.int_]) -> None:
         """Drop array attribute values from an instance.
 
         Args:

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -48,7 +48,7 @@ class PandasExporter(ABC):
         return pd.DataFrame(data)
 
 
-class Cohorts(ABC):
+class CohortMethods(ABC):
     """Abstract base class implementing cohort manipulation functionality.
 
     Classes inheriting from this ABC must define a class attribute ``array_attrs`` that
@@ -64,12 +64,18 @@ class Cohorts(ABC):
 
     array_attrs: ClassVar[tuple[str, ...]]
 
-    def add_cohorts(self, add: Cohorts) -> None:
-        """Add array attributes from a second instance.
+    def add_cohorts(self, add: CohortMethods) -> None:
+        """Add array attributes from a second instance implementing the base class.
 
         Args:
             add: A second instance from which to add array attribute values.
         """
+
+        if not isinstance(add, self.__class__):
+            raise ValueError(
+                f"Cannot add {type(add).__name__} instance to {type(self).__name__}"
+            )
+
         for trait in self.array_attrs:
             setattr(
                 self,

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -1,0 +1,66 @@
+"""Core shared functionality for the {mod}`~pyrealm.demography` module."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import ClassVar
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+
+class PandasExporter(ABC):
+    """Abstract base class implementing pandas export.
+
+    Classes inheriting from this ABC must define a class attribute ``array_attrs`` that
+    names a set of class attributes that are all numpy arrays of equal length. The
+    classes then inherit the `to_pandas` method that exports those attributes to a
+    {class}`pandas.DataFrame`.
+    """
+
+    array_attrs: ClassVar[tuple[str, ...]]
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Convert the instance array attributes into a {class}`pandas.DataFrame."""
+        return pd.DataFrame({k: getattr(self, k) for k in self.array_attrs})
+
+
+class Cohorts(ABC):
+    """Abstract base class implementing cohort manipulation functionality.
+
+    Classes inheriting from this ABC must define a class attribute ``array_attrs`` that
+    names a set of class attributes that are all numpy arrays of equal length. The class
+    then inherit:
+
+    * The `add_cohorts` method, which allows a second instance of the same class to be
+      joined to the calling instance, concatenting each of the array attributes from
+      the second instance onto the calling instance.
+    * The `drop_cohorts` method, which takes a set of indices onto the array attributes
+      and drops the values from those indices for each array attribute.
+    """
+
+    array_attrs: ClassVar[tuple[str, ...]]
+
+    def add_cohorts(self, add: Cohorts) -> None:
+        """Add array attributes from a second instance.
+
+        Args:
+            add: A second instance from which to add array attribute values.
+        """
+        for trait in self.array_attrs:
+            setattr(
+                self,
+                trait,
+                np.concatenate([getattr(self, trait), getattr(add, trait)]),
+            )
+
+    def drop_cohorts(self, drop_indices: NDArray[np.int_]) -> None:
+        """Drop array attribute values from an instance.
+
+        Args:
+            drop_indices: An array of integer indices to drop from each array attribute.
+        """
+
+        for trait in self.array_attrs:
+            setattr(self, trait, np.delete(getattr(self, trait), drop_indices))

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.demography.core import PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
 from pyrealm.demography.t_model_functions import StemAllometry
 
@@ -282,7 +283,7 @@ def calculate_stem_projected_leaf_area_at_z(
 
 
 @dataclass
-class CrownProfile:
+class CrownProfile(PandasExporter):
     """Calculate vertical crown profiles for stems.
 
     This method calculates crown profile predictions, given an array of vertical
@@ -315,7 +316,7 @@ class CrownProfile:
         z_max: A row array providing expected z_max height for each PFT.
     """
 
-    var_attr_names: ClassVar[tuple[str, ...]] = (
+    array_attrs: ClassVar[tuple[str, ...]] = (
         "relative_crown_radius",
         "crown_radius",
         "projected_crown_area",
@@ -447,7 +448,7 @@ def get_crown_xy(
     """
 
     # Input validation
-    if attr not in crown_profile.var_attr_names:
+    if attr not in crown_profile.array_attrs:
         raise ValueError(f"Unknown crown profile attribute: {attr}")
 
     # TODO

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -37,6 +37,8 @@ import pandas as pd
 from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
+from pyrealm.demography.core import PandasExporter
+
 if sys.version_info[:2] >= (3, 11):
     import tomllib
     from tomllib import TOMLDecodeError
@@ -236,7 +238,7 @@ in gaps from the default values.
 
 
 @dataclass(frozen=True)
-class Flora:
+class Flora(PandasExporter):
     """A dataclass providing trait data on collection of plant functional types.
 
     A flora provides trait data on the complete collection of plant functional types
@@ -258,10 +260,10 @@ class Flora:
     pfts: InitVar[Sequence[type[PlantFunctionalTypeStrict]]]
     r"""A sequence of plant functional type instances to include in the Flora."""
 
-    # A class variable setting the attribute names of traits.
-    trait_attrs: ClassVar[list[str]] = [
+    # A class variable setting the names of PFT traits held as arrays.
+    array_attrs: ClassVar[tuple[str, ...]] = tuple(
         f.name for f in fields(PlantFunctionalTypeStrict)
-    ]
+    )
 
     # Populated post init
     # - trait arrays
@@ -342,7 +344,7 @@ class Flora:
         object.__setattr__(self, "_n_stems", len(pfts))
 
         # Populate the trait attributes with arrays
-        for pft_field in self.trait_attrs:
+        for pft_field in self.array_attrs:
             object.__setattr__(
                 self, pft_field, np.array([getattr(pft, pft_field) for pft in pfts])
             )
@@ -436,12 +438,12 @@ class Flora:
         # matching the pft_names and pass that into the StemTraits constructor.
 
         return StemTraits(
-            **{trt: getattr(self, trt)[pft_index] for trt in self.trait_attrs}
+            **{trt: getattr(self, trt)[pft_index] for trt in self.array_attrs}
         )
 
 
 @dataclass()
-class StemTraits:
+class StemTraits(PandasExporter):
     """A dataclass for stem traits.
 
     This dataclass is used to provide arrays of plant functional type (PFT) traits
@@ -457,9 +459,9 @@ class StemTraits:
     """
 
     # A class variable setting the attribute names of traits.
-    trait_attrs: ClassVar[list[str]] = [
+    array_attrs: ClassVar[tuple[str, ...]] = tuple(
         f.name for f in fields(PlantFunctionalTypeStrict)
-    ]
+    )
 
     # Instance trait attributes
     name: NDArray[np.str_]

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -37,7 +37,7 @@ import pandas as pd
 from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
-from pyrealm.demography.core import PandasExporter
+from pyrealm.demography.core import CohortMethods, PandasExporter
 
 if sys.version_info[:2] >= (3, 11):
     import tomllib
@@ -443,7 +443,7 @@ class Flora(PandasExporter):
 
 
 @dataclass()
-class StemTraits(PandasExporter):
+class StemTraits(PandasExporter, CohortMethods):
     """A dataclass for stem traits.
 
     This dataclass is used to provide arrays of plant functional type (PFT) traits

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
-from pyrealm.demography.core import PandasExporter
+from pyrealm.demography.core import CohortMethods, PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
 
 
@@ -660,7 +660,7 @@ def calculate_growth_increments(
 
 
 @dataclass
-class StemAllometry(PandasExporter):
+class StemAllometry(PandasExporter, CohortMethods):
     """Calculate T Model allometric predictions across a set of stems.
 
     This method calculate predictions of stem allometries for stem height, crown area,

--- a/pyrealm/demography/t_model_functions.py
+++ b/pyrealm/demography/t_model_functions.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.demography.core import PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
 
 
@@ -659,7 +660,7 @@ def calculate_growth_increments(
 
 
 @dataclass
-class StemAllometry:
+class StemAllometry(PandasExporter):
     """Calculate T Model allometric predictions across a set of stems.
 
     This method calculate predictions of stem allometries for stem height, crown area,
@@ -675,7 +676,7 @@ class StemAllometry:
             allometry values.
     """
 
-    allometry_attrs: ClassVar[tuple[str, ...]] = (
+    array_attrs: ClassVar[tuple[str, ...]] = (
         "dbh",
         "stem_height",
         "crown_area",
@@ -796,7 +797,7 @@ class StemAllometry:
 
 
 @dataclass()
-class StemAllocation:
+class StemAllocation(PandasExporter):
     """Calculate T Model allocation predictions across a set of stems.
 
     This method calculate predictions of allocation of potential GPP for stems under the
@@ -814,7 +815,7 @@ class StemAllocation:
             predict stem allometry values.
     """
 
-    allocation_attrs: ClassVar[tuple[str, ...]] = (
+    array_attrs: ClassVar[tuple[str, ...]] = (
         "potential_gpp",
         "whole_crown_gpp",
         "sapwood_respiration",

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -73,7 +73,7 @@ class TestCanopyData:
         assert np.allclose(instance.lai, exp_lai)
         assert np.allclose(instance.f_trans, exp_f_trans)
 
-        # Unpack and test expectations
+        # Unpack and test expectations for cohort and stem fapar
         exp_f_trans, exp_trans_prof = community_expected
         expected_fapar = -np.diff(exp_trans_prof, prepend=1)
         assert np.allclose(
@@ -82,6 +82,16 @@ class TestCanopyData:
         assert np.allclose(
             instance.stem_fapar, np.tile((expected_fapar / 6)[:, None], 3)
         )
+
+        # Test the inherited to_pandas method
+        df = instance.to_pandas()
+
+        assert df.shape == (
+            np.prod(exp_stem_leaf_area.shape),
+            len(instance.array_attrs),
+        )
+
+        assert set(instance.array_attrs) == set(df.columns)
 
     def test_CommunityCanopyData__init__(
         self, cohort_args, cohort_expected, community_expected
@@ -98,6 +108,16 @@ class TestCanopyData:
         exp_f_trans, exp_trans_prof = community_expected
         assert np.allclose(instance.f_trans, exp_f_trans)
         assert np.allclose(instance.transmission_profile, exp_trans_prof)
+
+        # Test the inherited to_pandas method
+        df = instance.to_pandas()
+
+        assert df.shape == (
+            len(exp_f_trans),
+            len(instance.array_attrs),
+        )
+
+        assert set(instance.array_attrs) == set(df.columns)
 
 
 def test_Canopy__init__():

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -100,6 +100,13 @@ def test_Cohorts(args, outcome, excep_message):
         cohorts = Cohorts(**args)
         # trivial test of success
         assert len(cohorts.dbh_values) == 2
+
+        # test the to_pandas method
+        df = cohorts.to_pandas()
+
+        assert df.shape == (cohorts.n_cohorts, len(cohorts.array_attrs))
+        assert set(cohorts.array_attrs) == set(df.columns)
+
         return
 
     assert str(excep.value) == excep_message
@@ -215,10 +222,10 @@ def test_Community__init__(
     with outcome as excep:
         community = Community(**args, cohorts=cohorts, flora=fixture_flora)
 
-        if isinstance(outcome, does_not_raise):
-            # Simple test that data is loaded and trait and t model data calculated
-            check_expected(community=community, expected=fixture_expected)
-            return
+        # Simple test that data is loaded and trait and t model data calculated
+        check_expected(community=community, expected=fixture_expected)
+
+        return
 
     # Check exception message
     assert str(excep.value) == excep_message

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -112,6 +112,31 @@ def test_Cohorts(args, outcome, excep_message):
     assert str(excep.value) == excep_message
 
 
+def test_Cohorts_CohortMethods():
+    """Test the inherited CohortMethods methods."""
+
+    from pyrealm.demography.community import Cohorts
+
+    # Create and instance to modify using methods
+    cohorts = Cohorts(
+        pft_names=np.array(["broadleaf", "conifer"]),
+        n_individuals=np.array([6, 1]),
+        dbh_values=np.array([0.2, 0.5]),
+    )
+
+    # Check failure mode
+    with pytest.raises(ValueError) as excep:
+        cohorts.add_cohort_data(new_data=dict(a=1))
+
+    assert str(excep.value) == "Cannot add cohort data from an dict instance to Cohorts"
+
+    # Check success of adding and dropping data
+    cohorts.add_cohort_data(new_data=cohorts)
+    assert np.allclose(cohorts.dbh_values, np.array([0.2, 0.5, 0.2, 0.5]))
+    cohorts.drop_cohort_data(drop_indices=np.array([0, 2]))
+    assert np.allclose(cohorts.dbh_values, np.array([0.5, 0.5]))
+
+
 @pytest.mark.parametrize(
     argnames="args,cohort_data,outcome,excep_message",
     argvalues=[

--- a/tests/unit/demography/test_core.py
+++ b/tests/unit/demography/test_core.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 
 import numpy as np
 import pandas as pd
+import pytest
 from numpy.typing import NDArray
 
 
@@ -62,6 +63,40 @@ def test_Cohorts():
     t1.drop_cohorts(np.array([0, 5]))
     assert np.allclose(t1.a, np.arange(2, 6))
     assert np.allclose(t1.b, np.arange(5, 9))
+
+
+def test_Cohorts_failure():
+    """Test the Cohorts abstract base class failure mode."""
+
+    from pyrealm.demography.core import CohortMethods
+
+    @dataclass
+    class TestClass(CohortMethods):
+        """Simple test class implementing the ABC."""
+
+        array_attrs: ClassVar[tuple[str, ...]] = ("a", "b")
+
+        a: NDArray[np.float64]
+        b: NDArray[np.float64]
+
+    @dataclass
+    class NotTheSameClass(CohortMethods):
+        """A different simple test class implementing the ABC."""
+
+        array_attrs: ClassVar[tuple[str, ...]] = ("c", "d")
+
+        c: NDArray[np.float64]
+        d: NDArray[np.float64]
+
+    # Create instances
+    t1 = TestClass(a=np.array([1, 2, 3]), b=np.array([4, 5, 6]))
+    t2 = NotTheSameClass(c=np.array([4, 5, 6]), d=np.array([7, 8, 9]))
+
+    # Check that adding a different
+    with pytest.raises(ValueError) as excep:
+        t1.add_cohorts(t2)
+
+    assert str(excep.value) == "Cannot add NotTheSameClass instance to TestClass"
 
 
 def test_PandasExporter_Cohorts_multiple_inheritance():

--- a/tests/unit/demography/test_core.py
+++ b/tests/unit/demography/test_core.py
@@ -1,0 +1,121 @@
+"""Tests of core demography objects."""
+
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from typing import ClassVar
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+
+def test_PandasExporter():
+    """Test the PandasExporter abstract base class."""
+
+    from pyrealm.demography.core import PandasExporter
+
+    @dataclass
+    class TestClass(PandasExporter):
+        """Simple test dataclass implementing the ABC."""
+
+        array_attrs: ClassVar[tuple[str, ...]] = ("c", "d", "e")
+        c: NDArray[np.float64]
+        d: NDArray[np.float64]
+        e: NDArray[np.float64]
+
+    # create instance and run method
+    instance = TestClass(c=np.arange(5), d=np.arange(5), e=np.arange(5))
+    pandas_out = instance.to_pandas()
+
+    # simple checks of output class and behaviour
+    assert isinstance(pandas_out, pd.DataFrame)
+    assert pandas_out.shape == (5, 3)
+    assert np.allclose(pandas_out.sum(axis=1), np.arange(5) * 3)
+    assert np.allclose(pandas_out.sum(axis=0), np.repeat(10, 3))
+
+
+def test_Cohorts():
+    """Test the Cohorts abstract base class."""
+
+    from pyrealm.demography.core import Cohorts
+
+    @dataclass
+    class TestClass(Cohorts):
+        """Simple test class implementing the ABC."""
+
+        array_attrs: ClassVar[tuple[str, ...]] = ("a", "b")
+
+        a: NDArray[np.float64]
+        b: NDArray[np.float64]
+
+    # Create instances
+    t1 = TestClass(a=np.array([1, 2, 3]), b=np.array([4, 5, 6]))
+    t2 = TestClass(a=np.array([4, 5, 6]), b=np.array([7, 8, 9]))
+
+    # Add the t2 data into t1 and check the a and b attributes are extended
+    t1.add_cohorts(t2)
+    assert np.allclose(t1.a, np.arange(1, 7))
+    assert np.allclose(t1.b, np.arange(4, 10))
+
+    # Drop some indices and check the a and b attributes are truncated
+    t1.drop_cohorts(np.array([0, 5]))
+    assert np.allclose(t1.a, np.arange(2, 6))
+    assert np.allclose(t1.b, np.arange(5, 9))
+
+
+def test_PandasExporter_Cohorts_multiple_inheritance():
+    """Test the behaviour of a class inheriting both core ABCs."""
+
+    from pyrealm.demography.core import Cohorts, PandasExporter
+
+    @dataclass
+    class TestClass(Cohorts, PandasExporter):
+        """Test class with multiple inheritance."""
+
+        array_attrs: ClassVar[tuple[str, ...]] = ("c", "d", "e")
+
+        n: InitVar[int]
+        start_vals: InitVar[NDArray[np.int_]]
+
+        c: NDArray[np.float64] = field(init=False)
+        d: NDArray[np.int_] = field(init=False)
+        e: NDArray[np.float64] = field(init=False)
+
+        def __post_init__(self, n: int, start_vals: NDArray[np.int_]) -> None:
+            self.c = np.arange(start_vals[0], start_vals[0] + n)
+            self.d = np.arange(start_vals[1], start_vals[1] + n)
+            self.e = np.arange(start_vals[2], start_vals[2] + n)
+
+    # Create instances
+    t1 = TestClass(n=5, start_vals=np.array([1, 2, 3]))
+    t2 = TestClass(n=3, start_vals=np.array([6, 7, 8]))
+
+    # Test dataframe properties
+    t1_out = t1.to_pandas()
+
+    # simple checks of output class and behaviour
+    assert isinstance(t1_out, pd.DataFrame)
+    assert t1_out.shape == (5, 3)
+    assert np.allclose(t1_out.sum(axis=1), np.array([6, 9, 12, 15, 18]))
+    assert np.allclose(t1_out.sum(axis=0), np.repeat(15, 3) + np.array([0, 5, 10]))
+
+    # Add the second set and check the results via pandas
+    t1.add_cohorts(t2)
+    t1_out_add = t1.to_pandas()
+
+    # simple checks of output class and behaviour
+    assert isinstance(t1_out_add, pd.DataFrame)
+    assert t1_out_add.shape == (8, 3)
+    assert np.allclose(t1_out_add.sum(axis=1), np.array([6, 9, 12, 15, 18, 21, 24, 27]))
+    assert np.allclose(t1_out_add.sum(axis=0), np.repeat(36, 3) + np.array([0, 8, 16]))
+
+    # Drop some entries and recheck
+    t1.drop_cohorts(np.array([0, 7]))
+    t1_out_drop = t1.to_pandas()
+
+    # simple checks of output class and behaviour
+    assert isinstance(t1_out_drop, pd.DataFrame)
+    assert t1_out_drop.shape == (6, 3)
+    assert np.allclose(t1_out_drop.sum(axis=1), np.array([9, 12, 15, 18, 21, 24]))
+    assert np.allclose(t1_out_drop.sum(axis=0), np.repeat(27, 3) + np.array([0, 6, 12]))

--- a/tests/unit/demography/test_core.py
+++ b/tests/unit/demography/test_core.py
@@ -39,10 +39,10 @@ def test_PandasExporter():
 def test_Cohorts():
     """Test the Cohorts abstract base class."""
 
-    from pyrealm.demography.core import Cohorts
+    from pyrealm.demography.core import CohortMethods
 
     @dataclass
-    class TestClass(Cohorts):
+    class TestClass(CohortMethods):
         """Simple test class implementing the ABC."""
 
         array_attrs: ClassVar[tuple[str, ...]] = ("a", "b")
@@ -102,10 +102,10 @@ def test_Cohorts_failure():
 def test_PandasExporter_Cohorts_multiple_inheritance():
     """Test the behaviour of a class inheriting both core ABCs."""
 
-    from pyrealm.demography.core import Cohorts, PandasExporter
+    from pyrealm.demography.core import CohortMethods, PandasExporter
 
     @dataclass
-    class TestClass(Cohorts, PandasExporter):
+    class TestClass(CohortMethods, PandasExporter):
         """Test class with multiple inheritance."""
 
         array_attrs: ClassVar[tuple[str, ...]] = ("c", "d", "e")

--- a/tests/unit/demography/test_core.py
+++ b/tests/unit/demography/test_core.py
@@ -11,7 +11,7 @@ import pytest
 from numpy.typing import NDArray
 
 
-def test_PandasExporter():
+def test_PandasExporter() -> None:
     """Test the PandasExporter abstract base class."""
 
     from pyrealm.demography.core import PandasExporter
@@ -26,7 +26,11 @@ def test_PandasExporter():
         e: NDArray[np.float64]
 
     # create instance and run method
-    instance = TestClass(c=np.arange(5), d=np.arange(5), e=np.arange(5))
+    instance = TestClass(
+        c=np.arange(5, dtype=np.float64),
+        d=np.arange(5, dtype=np.float64),
+        e=np.arange(5, dtype=np.float64),
+    )
     pandas_out = instance.to_pandas()
 
     # simple checks of output class and behaviour
@@ -36,7 +40,7 @@ def test_PandasExporter():
     assert np.allclose(pandas_out.sum(axis=0), np.repeat(10, 3))
 
 
-def test_Cohorts():
+def test_Cohorts() -> None:
     """Test the Cohorts abstract base class."""
 
     from pyrealm.demography.core import CohortMethods
@@ -55,17 +59,17 @@ def test_Cohorts():
     t2 = TestClass(a=np.array([4, 5, 6]), b=np.array([7, 8, 9]))
 
     # Add the t2 data into t1 and check the a and b attributes are extended
-    t1.add_cohorts(t2)
+    t1.add_cohort_data(t2)
     assert np.allclose(t1.a, np.arange(1, 7))
     assert np.allclose(t1.b, np.arange(4, 10))
 
     # Drop some indices and check the a and b attributes are truncated
-    t1.drop_cohorts(np.array([0, 5]))
+    t1.drop_cohort_data(np.array([0, 5]))
     assert np.allclose(t1.a, np.arange(2, 6))
     assert np.allclose(t1.b, np.arange(5, 9))
 
 
-def test_Cohorts_failure():
+def test_Cohorts_add_cohort_data_failure() -> None:
     """Test the Cohorts abstract base class failure mode."""
 
     from pyrealm.demography.core import CohortMethods
@@ -94,12 +98,15 @@ def test_Cohorts_failure():
 
     # Check that adding a different
     with pytest.raises(ValueError) as excep:
-        t1.add_cohorts(t2)
+        t1.add_cohort_data(t2)
 
-    assert str(excep.value) == "Cannot add NotTheSameClass instance to TestClass"
+    assert (
+        str(excep.value)
+        == "Cannot add cohort data from an NotTheSameClass instance to TestClass"
+    )
 
 
-def test_PandasExporter_Cohorts_multiple_inheritance():
+def test_PandasExporter_Cohorts_multiple_inheritance() -> None:
     """Test the behaviour of a class inheriting both core ABCs."""
 
     from pyrealm.demography.core import CohortMethods, PandasExporter
@@ -136,7 +143,7 @@ def test_PandasExporter_Cohorts_multiple_inheritance():
     assert np.allclose(t1_out.sum(axis=0), np.repeat(15, 3) + np.array([0, 5, 10]))
 
     # Add the second set and check the results via pandas
-    t1.add_cohorts(t2)
+    t1.add_cohort_data(t2)
     t1_out_add = t1.to_pandas()
 
     # simple checks of output class and behaviour
@@ -146,7 +153,7 @@ def test_PandasExporter_Cohorts_multiple_inheritance():
     assert np.allclose(t1_out_add.sum(axis=0), np.repeat(36, 3) + np.array([0, 8, 16]))
 
     # Drop some entries and recheck
-    t1.drop_cohorts(np.array([0, 7]))
+    t1.drop_cohort_data(np.array([0, 7]))
     t1_out_drop = t1.to_pandas()
 
     # simple checks of output class and behaviour

--- a/tests/unit/demography/test_crown.py
+++ b/tests/unit/demography/test_crown.py
@@ -586,7 +586,8 @@ def test_CrownProfile(fixture_community):
     """Test the CrownProfile class.
 
     This implements a subset of the tests in the more detailed function checks above to
-    validate that this wrapper class works as intended.
+    validate that this wrapper class works as intended. It also tests the inherited
+    to_pandas method.
     """
 
     from pyrealm.demography.crown import CrownProfile
@@ -615,3 +616,13 @@ def test_CrownProfile(fixture_community):
         np.diag(crown_profile.projected_leaf_area),
         fixture_community.stem_allometry.crown_area,
     )
+
+    # Test the inherited to_pandas method
+    df = crown_profile.to_pandas()
+
+    assert df.shape == (
+        crown_profile._n_stems * crown_profile._n_pred,
+        len(crown_profile.array_attrs),
+    )
+
+    assert set(crown_profile.array_attrs) == set(df.columns)

--- a/tests/unit/demography/test_flora.py
+++ b/tests/unit/demography/test_flora.py
@@ -338,7 +338,7 @@ def test_flora_get_stem_traits(fixture_flora, pft_names, outcome):
     with outcome:
         stem_traits = fixture_flora.get_stem_traits(pft_names=pft_names)
 
-        for trt in stem_traits.trait_attrs:
+        for trt in stem_traits.array_attrs:
             assert len(getattr(stem_traits, trt)) == len(pft_names)
 
 

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -728,7 +728,7 @@ def test_calculate_dbh_from_height_edge_cases():
 
 
 def test_StemAllometry(rtmodel_flora, rtmodel_data):
-    """Test the StemAllometry class."""
+    """Test the StemAllometry class and inherited methods."""
 
     from pyrealm.demography.t_model_functions import StemAllometry
 
@@ -736,14 +736,23 @@ def test_StemAllometry(rtmodel_flora, rtmodel_data):
         stem_traits=rtmodel_flora, at_dbh=rtmodel_data["dbh"][:, [0]]
     )
 
-    # Check the variables provided by the rtmodel implementation
+    # Check the values of the variables calculated against the expectations from the
+    # rtmodel implementation
     vars_to_check = (
-        v
-        for v in stem_allometry.allometry_attrs
-        if v not in ["crown_r0", "crown_z_max"]
+        v for v in stem_allometry.array_attrs if v not in ["crown_r0", "crown_z_max"]
     )
     for var in vars_to_check:
         assert np.allclose(getattr(stem_allometry, var), rtmodel_data[var])
+
+    # Test the inherited to_pandas method
+    df = stem_allometry.to_pandas()
+
+    assert df.shape == (
+        stem_allometry._n_stems * stem_allometry._n_pred,
+        len(stem_allometry.array_attrs),
+    )
+
+    assert set(stem_allometry.array_attrs) == set(df.columns)
 
 
 def test_StemAllocation(rtmodel_flora, rtmodel_data):
@@ -761,9 +770,20 @@ def test_StemAllocation(rtmodel_flora, rtmodel_data):
         at_potential_gpp=rtmodel_data["potential_gpp"],
     )
 
-    # Check the variables provided by the rtmodel implementation
+    # Check the values of the variables calculated against the expectations from the
+    # rtmodel implementation
     vars_to_check = (
-        v for v in stem_allocation.allocation_attrs if v not in ["foliar_respiration"]
+        v for v in stem_allocation.array_attrs if v not in ["foliar_respiration"]
     )
     for var in vars_to_check:
         assert np.allclose(getattr(stem_allocation, var), rtmodel_data[var])
+
+    # Test the inherited to_pandas method
+    df = stem_allocation.to_pandas()
+
+    assert df.shape == (
+        stem_allocation._n_stems * stem_allocation._n_pred,
+        len(stem_allocation.array_attrs),
+    )
+
+    assert set(stem_allocation.array_attrs) == set(df.columns)


### PR DESCRIPTION
# Description

> [!note]
> I probably should have done this as two PRs - it's not too bloaty, but there is a clear division between the two classes here. 

This PR:

* Introduces the `demography.core` module and defines the `PandasExporter` and `CohortMethods` abstract base classes. These two ABCs share a common class attribute (`array_attrs`) which is used to define which fields to export to `pandas.DataFrame` and which fields need to be kept synchronised as cohorts are added or removed.
* Adds some low level tests of some basic subclasses in `tests.unit.demography.test_core.py` to show that the ABCs work independently and with multiple inheritance.

* Applies the `PandasExporter` to many of the `demography` classes:
    * They  inherit the new `to_pandas()` method from the base class.
    * Updates documentation to use the method.
    * Adds simple checks to existing tests to make sure the method works on all subclasses.

* Applies the `CohortMethods` subclass to the `Cohorts`, `StemTraits` and `StemAllometry` classes. These are the three main dataclasses within `Community`, where the functionality to synchronise the addition and deletion of cohorts is required.
    * Adds tests for each classes  that the inherited `add_cohort_data` and `drop_cohort_data` methods are working as expected.

* Adds `Community.add_cohorts` and `Community.drop_cohorts` methods, which wrap the individual dataclass methods to update the instance.

Fixes #314 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
