### PR TITLE
Revise cohort structure inside community

### DIFF
--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -40,7 +40,7 @@ import numpy as np
 import pandas as pd
 
 from pyrealm.demography.flora import PlantFunctionalType, Flora
-from pyrealm.demography.community import Community
+from pyrealm.demography.community import Cohorts, Community
 from pyrealm.demography.crown import CrownProfile, get_crown_xy
 from pyrealm.demography.canopy import Canopy
 from pyrealm.demography.t_model_functions import StemAllometry
@@ -117,9 +117,11 @@ simple_community = Community(
     flora=simple_flora,
     cell_area=total_area,
     cell_id=1,
-    cohort_dbh_values=stem_dbh,
-    cohort_n_individuals=np.array([1]),
-    cohort_pft_names=np.array(["defaults"]),
+    cohorts=Cohorts(
+        dbh_values=stem_dbh,
+        n_individuals=np.array([1]),
+        pft_names=np.array(["defaults"]),
+    ),
 )
 
 # Get the canopy model for the simple case from the canopy top
@@ -255,9 +257,11 @@ community = Community(
     flora=flora,
     cell_area=32,
     cell_id=1,
-    cohort_dbh_values=np.array([0.1, 0.20, 0.5]),
-    cohort_n_individuals=np.array([7, 3, 2]),
-    cohort_pft_names=np.array(["short", "short", "tall"]),
+    cohorts=Cohorts(
+        dbh_values=np.array([0.1, 0.20, 0.5]),
+        n_individuals=np.array([7, 3, 2]),
+        pft_names=np.array(["short", "short", "tall"]),
+    ),
 )
 
 # Calculate the canopy profile across vertical heights
@@ -281,7 +285,7 @@ profiles = get_crown_xy(
 for idx, crown in enumerate(profiles):
 
     # Get spaced but slightly randomized stem locations
-    n_stems = community.cohort_data["n_individuals"][idx]
+    n_stems = community.cohorts.n_individuals[idx]
     stem_locations = np.linspace(0, 10, num=n_stems) + np.random.normal(size=n_stems)
 
     # Plot the crown model for each stem
@@ -298,7 +302,7 @@ vertical profile is equal to the expected value across the whole community.
 ```{code-cell} ipython3
 # Calculate L_h for each cohort
 cohort_lai = (
-    community.cohort_data["n_individuals"]
+    community.cohorts.n_individuals
     * community.stem_traits.lai
     * community.stem_allometry.crown_area
 ) / community.cell_area
@@ -439,13 +443,13 @@ individuals in each cohort.
 ```{code-cell} ipython3
 # Calculate the total projected crown area across the community at each height
 community_crown_area = np.nansum(
-    canopy.crown_profile.projected_crown_area * community.cohort_data["n_individuals"],
+    canopy.crown_profile.projected_crown_area * community.cohorts.n_individuals,
     axis=1,
 )
 
 # Do the same for the projected leaf area
 community_leaf_area = np.nansum(
-    canopy.crown_profile.projected_leaf_area * community.cohort_data["n_individuals"],
+    canopy.crown_profile.projected_leaf_area * community.cohorts.n_individuals,
     axis=1,
 )
 ```
@@ -609,6 +613,6 @@ print(cohort_fapar)
    cohort to given the $f_{APAR}$ for each stem at each height.
 
 ```{code-cell} ipython3
-stem_fapar = cohort_fapar / community.cohort_data["n_individuals"]
+stem_fapar = cohort_fapar / community.cohorts.n_individuals
 print(stem_fapar)
 ```

--- a/docs/source/users/demography/community.md
+++ b/docs/source/users/demography/community.md
@@ -36,7 +36,7 @@ import numpy as np
 import pandas as pd
 
 from pyrealm.demography.flora import PlantFunctionalType, Flora
-from pyrealm.demography.community import Community
+from pyrealm.demography.community import Cohorts, Community
 ```
 
 ```{code-cell} ipython3
@@ -57,16 +57,14 @@ community = Community(
     flora=flora,
     cell_area=32,
     cell_id=1,
-    cohort_dbh_values=np.array([0.02, 0.20, 0.5]),
-    cohort_n_individuals=np.array([15, 5, 2]),
-    cohort_pft_names=np.array(["short", "short", "tall"]),
+    cohorts=Cohorts(
+        dbh_values=np.array([0.02, 0.20, 0.5]),
+        n_individuals=np.array([15, 5, 2]),
+        pft_names=np.array(["short", "short", "tall"]),
+    ),
 )
 ```
 
 ```{code-cell} ipython3
 community
-```
-
-```{code-cell} ipython3
-
 ```

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -118,7 +118,7 @@ def fit_perfect_plasticity_approximation(
 
     # Calculate the number of layers to contain the total community crown area
     total_community_crown_area = (
-        community.stem_allometry.crown_area * community.cohort_data["n_individuals"]
+        community.stem_allometry.crown_area * community.cohorts.n_individuals
     ).sum()
     crown_area_per_layer = community.cell_area * (1 - canopy_gap_fraction)
     n_layers = int(np.ceil(total_community_crown_area / crown_area_per_layer))
@@ -144,7 +144,7 @@ def fit_perfect_plasticity_approximation(
                 community.stem_traits.n,
                 community.stem_traits.q_m,
                 community.stem_allometry.crown_z_max,
-                community.cohort_data["n_individuals"],
+                community.cohorts.n_individuals,
                 target_area,
                 False,  # validate
             ),
@@ -293,7 +293,7 @@ class Canopy:
         # the available community area.
         self.cohort_lai = (
             self.stem_leaf_area
-            * community.cohort_data["n_individuals"]
+            * community.cohorts.n_individuals
             * community.stem_traits.lai
         ) / community.cell_area  # self.filled_community_area
 
@@ -323,4 +323,4 @@ class Canopy:
         self.cohort_fapar = (
             self.cohort_f_abs / self.cohort_f_abs.sum(axis=1)[:, None]
         ) * self.fapar[:, None]
-        self.stem_fapar = self.cohort_fapar / community.cohort_data["n_individuals"]
+        self.stem_fapar = self.cohort_fapar / community.cohorts.n_individuals

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -84,9 +84,11 @@ Initialize a Community into an area of 1000 square meter with the given cohort d
 ...     cell_id=1,
 ...     cell_area=1000.0,
 ...     flora=flora,
-...     cohort_dbh_values=cohort_dbh_values,
-...     cohort_n_individuals=cohort_n_individuals,
-...     cohort_pft_names=cohort_pft_names
+...     cohorts=Cohorts(
+...         dbh_values=cohort_dbh_values,
+...         n_individuals=cohort_n_individuals,
+...         pft_names=cohort_pft_names,
+...     ),
 ... )
 
 Convert some of the data to a :class:`pandas.DataFrame` for nicer display and show some

--- a/tests/unit/demography/conftest.py
+++ b/tests/unit/demography/conftest.py
@@ -66,7 +66,7 @@ def rtmodel_flora():
 @pytest.fixture
 def fixture_community():
     """A fixture providing a simple community."""
-    from pyrealm.demography.community import Community
+    from pyrealm.demography.community import Cohorts, Community
     from pyrealm.demography.flora import Flora, PlantFunctionalType
 
     # A simple community containing one sample stem, with an initial crown gap fraction
@@ -76,9 +76,11 @@ def fixture_community():
         cell_id=1,
         cell_area=100,
         flora=flora,
-        cohort_n_individuals=np.repeat([1], 4),
-        cohort_pft_names=np.repeat(["test"], 4),
-        cohort_dbh_values=np.array([0.2, 0.4, 0.6, 0.8]),
+        cohorts=Cohorts(
+            n_individuals=np.repeat([1], 4),
+            pft_names=np.repeat(["test"], 4),
+            dbh_values=np.array([0.2, 0.4, 0.6, 0.8]),
+        ),
     )
 
 

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -12,7 +12,7 @@ def test_Canopy__init__():
     """
 
     from pyrealm.demography.canopy import Canopy
-    from pyrealm.demography.community import Community
+    from pyrealm.demography.community import Cohorts, Community
     from pyrealm.demography.flora import Flora, PlantFunctionalType
 
     flora = Flora(
@@ -25,9 +25,11 @@ def test_Canopy__init__():
     community = Community(
         cell_id=1,
         cell_area=20,
-        cohort_pft_names=np.array(["broadleaf", "conifer"]),
-        cohort_n_individuals=np.array([6, 1]),
-        cohort_dbh_values=np.array([0.2, 0.5]),
+        cohorts=Cohorts(
+            pft_names=np.array(["broadleaf", "conifer"]),
+            n_individuals=np.array([6, 1]),
+            dbh_values=np.array([0.2, 0.5]),
+        ),
         flora=flora,
     )
 

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -40,7 +40,7 @@ def test_Canopy__init__():
             (
                 (
                     community.stem_allometry.crown_area
-                    * community.cohort_data["n_individuals"]
+                    * community.cohorts.n_individuals
                 ).sum()
                 * (1 + canopy_gap_fraction)
             )
@@ -78,7 +78,7 @@ def test_solve_canopy_area_filling_height(fixture_community):
             z=this_height,
             stem_height=fixture_community.stem_allometry.stem_height,
             crown_area=fixture_community.stem_allometry.crown_area,
-            n_individuals=fixture_community.cohort_data["n_individuals"],
+            n_individuals=fixture_community.cohorts.n_individuals,
             m=fixture_community.stem_traits.m,
             n=fixture_community.stem_traits.n,
             q_m=fixture_community.stem_traits.q_m,

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -52,6 +52,54 @@ def check_expected(community, expected):
     argvalues=[
         pytest.param(
             {
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
+            },
+            does_not_raise(),
+            None,
+            id="correct",
+        ),
+        pytest.param(
+            {
+                "pft_names": False,
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
+            },
+            pytest.raises(ValueError),
+            "Cohort data not passed as numpy arrays",
+            id="not np array",
+        ),
+        pytest.param(
+            {
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
+            },
+            pytest.raises(ValueError),
+            "Cohort arrays are of unequal length",
+            id="not np array",
+        ),
+    ],
+)
+def test_Cohorts(args, outcome, excep_message):
+    """Test the cohorts data structure."""
+    from pyrealm.demography.community import Cohorts
+
+    with outcome as excep:
+        cohorts = Cohorts(**args)
+        # trivial test of success
+        assert len(cohorts.dbh_values) == 2
+        return
+
+    assert str(excep.value) == excep_message
+
+
+@pytest.mark.parametrize(
+    argnames="args,outcome,excep_message",
+    argvalues=[
+        pytest.param(
+            {
                 "cell_id": 1,
                 "cell_area": 100,
                 "cohort_pft_names": np.array(["broadleaf", "conifer"]),

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -34,7 +34,7 @@ def check_expected(community, expected):
     """Helper function to provide simple check of returned community objects."""
 
     assert np.allclose(
-        community.cohort_data["n_individuals"],
+        community.cohorts.n_individuals,
         expected["n_individuals"],
     )
     assert np.allclose(
@@ -68,7 +68,17 @@ def check_expected(community, expected):
             },
             pytest.raises(ValueError),
             "Cohort data not passed as numpy arrays",
-            id="not np array",
+            id="not_iterable",
+        ),
+        pytest.param(
+            {
+                "pft_names": ["broadleaf", "conifer"],
+                "n_individuals": [6, 1],
+                "dbh_values": [0.2, 0.5],
+            },
+            pytest.raises(ValueError),
+            "Cohort data not passed as numpy arrays",
+            id="lists_not_arrays",
         ),
         pytest.param(
             {
@@ -96,123 +106,91 @@ def test_Cohorts(args, outcome, excep_message):
 
 
 @pytest.mark.parametrize(
-    argnames="args,outcome,excep_message",
+    argnames="args,cohort_data,outcome,excep_message",
     argvalues=[
         pytest.param(
+            {"cell_id": 1, "cell_area": 100},
             {
-                "cell_id": 1,
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             does_not_raise(),
             None,
             id="correct",
         ),
         pytest.param(
+            {"cell_area": 100},
             {
-                "cell_id": 1,
-                "cell_area": 100,
-                "cohort_pft_names": ["broadleaf", "conifer"],
-                "cohort_n_individuals": [6, 1],
-                "cohort_dbh_values": [0.2, 0.5],
-            },
-            pytest.raises(ValueError),
-            "Cohort data not passed as numpy arrays.",
-            id="lists_not_arrays",
-        ),
-        pytest.param(
-            {
-                "cell_id": 1,
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5, 0.9]),
-            },
-            pytest.raises(ValueError),
-            "Cohort arrays are of unequal length",
-            id="unequal_cohort_arrays",
-        ),
-        pytest.param(
-            {
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(TypeError),
             "Community.__init__() missing 1 required positional argument: 'cell_id'",
             id="missing_arg",
         ),
         pytest.param(
+            {"cell_id": 1, "cell_area": 100, "cell_elevation": 100},
             {
-                "cell_id": 1,
-                "cell_area": 100,
-                "cell_elevation": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(TypeError),
             "Community.__init__() got an unexpected keyword argument 'cell_elevation'",
             id="extra_arg",
         ),
         pytest.param(
+            {"cell_id": 1, "cell_area": "100"},
             {
-                "cell_id": 1,
-                "cell_area": "100",
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(ValueError),
             "Community cell area must be a positive number.",
             id="cell_area_as_string",
         ),
         pytest.param(
+            {"cell_id": 1, "cell_area": -100},
             {
-                "cell_id": 1,
-                "cell_area": -100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(ValueError),
             "Community cell area must be a positive number.",
             id="cell_area_negative",
         ),
         pytest.param(
+            {"cell_id": "1", "cell_area": 100},
             {
-                "cell_id": "1",
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(ValueError),
             "Community cell id must be a integer >= 0.",
             id="cell_id_as_string",
         ),
         pytest.param(
+            {"cell_id": -1, "cell_area": 100},
             {
-                "cell_id": -1,
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "conifer"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(ValueError),
             "Community cell id must be a integer >= 0.",
             id="cell_id_negative",
         ),
         pytest.param(
+            {"cell_id": 1, "cell_area": 100},
             {
-                "cell_id": 1,
-                "cell_area": 100,
-                "cohort_pft_names": np.array(["broadleaf", "juniper"]),
-                "cohort_n_individuals": np.array([6, 1]),
-                "cohort_dbh_values": np.array([0.2, 0.5]),
+                "pft_names": np.array(["broadleaf", "juniper"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0.5]),
             },
             pytest.raises(ValueError),
             "Plant functional types unknown in flora: juniper",
@@ -221,7 +199,7 @@ def test_Cohorts(args, outcome, excep_message):
     ],
 )
 def test_Community__init__(
-    fixture_flora, fixture_expected, args, outcome, excep_message
+    fixture_flora, fixture_expected, args, cohort_data, outcome, excep_message
 ):
     """Test Community initialisation.
 
@@ -229,10 +207,13 @@ def test_Community__init__(
     properties.
     """
 
-    from pyrealm.demography.community import Community
+    from pyrealm.demography.community import Cohorts, Community
+
+    # Build the cohorts object
+    cohorts = Cohorts(**cohort_data)
 
     with outcome as excep:
-        community = Community(**args, flora=fixture_flora)
+        community = Community(**args, cohorts=cohorts, flora=fixture_flora)
 
         if isinstance(outcome, does_not_raise):
             # Simple test that data is loaded and trait and t model data calculated


### PR DESCRIPTION
# Description

This PR:

* replaces the `community.cohort_data: dict[str, NDArray]` dictionary of arrays with a new dataclass `Cohorts`.
* updates the test suite to add some simple testing of the `Cohorts` constructor
* updates the rest of the test suite and the code to the new structure. 

The main reasons are:

* more consistent attribute access within model rather than a mix of dataclass dot notation and dictionary keys.
* ability to extend the functionality of the Cohorts dataclass with shared functionality (see #338).

Fixes #336

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
