### PR TITLE
Group internal attributes in canopy into data classes

### DIFF
--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -139,7 +139,7 @@ should equal the whole canopy $f_{abs}$ calculated using the simple Beer-Lambert
 equation and the PFT trait values.
 
 ```{code-cell} ipython3
-print(simple_canopy.extinction_profile[-1])
+print(simple_canopy.community_data.extinction_profile[-1])
 ```
 
 ```{code-cell} ipython3
@@ -182,15 +182,15 @@ ax1.set_xlabel("Profile radius (m)")
 ax1.set_ylabel("Vertical height (m)")
 
 # Plot the leaf area between heights for stems
-ax2.plot(simple_canopy.stem_leaf_area, hghts, color="red")
+ax2.plot(simple_canopy.cohort_data.stem_leaf_area, hghts, color="red")
 ax2.set_xlabel("Leaf area (m2)")
 
 # Plot the fraction of light absorbed at different heights
-ax3.plot(simple_canopy.f_abs, hghts, color="red")
+ax3.plot(simple_canopy.cohort_data.f_abs, hghts, color="red")
 ax3.set_xlabel("Light absorption fraction (-)")
 
 # Plot the light extinction profile through the canopy.
-ax4.plot(simple_canopy.extinction_profile, hghts, color="red")
+ax4.plot(simple_canopy.community_data.extinction_profile, hghts, color="red")
 ax4.set_xlabel("Cumulative light\nabsorption fraction (-)")
 ```
 
@@ -312,7 +312,7 @@ print(1 - np.exp(np.sum(-community.stem_traits.par_ext * cohort_lai)))
 ```
 
 ```{code-cell} ipython3
-print(canopy.extinction_profile[-1])
+print(canopy.community_data.extinction_profile[-1])
 ```
 
 ```{code-cell} ipython3
@@ -349,16 +349,16 @@ ax1.set_xlabel("Profile radius (m)")
 ax1.set_ylabel("Vertical height (m)")
 
 # Plot the leaf area between heights for stems
-ax2.plot(canopy.stem_leaf_area, hghts)
+ax2.plot(canopy.cohort_data.stem_leaf_area, hghts)
 ax2.set_xlabel("Leaf area per stem (m2)")
 
 # Plot the fraction of light absorbed at different heights
-ax3.plot(canopy.f_abs, hghts, color="grey")
-ax3.plot(1 - canopy.cohort_f_trans, hghts)
+ax3.plot(canopy.cohort_data.f_abs, hghts, color="grey")
+ax3.plot(1 - canopy.cohort_data.f_trans, hghts)
 ax3.set_xlabel("Light absorption fraction (-)")
 
 # Plot the light extinction profile through the canopy.
-ax4.plot(canopy.extinction_profile, hghts, color="grey")
+ax4.plot(canopy.community_data.extinction_profile, hghts, color="grey")
 _ = ax4.set_xlabel("Cumulative light\nabsorption fraction (-)")
 ```
 
@@ -416,7 +416,7 @@ l_m = \left\lceil \frac{\sum_1^{N_s}{A_c}}{ A(1 - f_G)}\right\rceil
 $$
 
 ```{code-cell} ipython3
-canopy_ppa = Canopy(community=community, canopy_gap_fraction=2 / 32, fit_ppa=True)
+canopy_ppa = Canopy(community=community, canopy_gap_fraction=0 / 32, fit_ppa=True)
 ```
 
 The `canopy_ppa.heights` attribute now contains the heights at which the PPA
@@ -430,7 +430,7 @@ And the final value in the canopy extinction profile still matches the expectati
 above:
 
 ```{code-cell} ipython3
-print(canopy_ppa.extinction_profile[-1])
+print(canopy_ppa.community_data.extinction_profile[-1])
 ```
 
 ### Visualizing layer closure heights and areas
@@ -503,18 +503,18 @@ ax1.legend(frameon=False)
 for val in canopy_ppa.heights:
     ax2.axhline(val, color="red", linewidth=0.5, zorder=0)
 
-for val in canopy_ppa.extinction_profile:
+for val in canopy_ppa.community_data.extinction_profile:
     ax2.axvline(val, color="red", linewidth=0.5, zorder=0)
 
-ax2.plot(canopy.extinction_profile, hghts)
+ax2.plot(canopy.community_data.extinction_profile, hghts)
 
 ax2_top = ax2.twiny()
 ax2_top.set_xlim(ax2.get_xlim())
 extinction_labels = [
     f"$f_{{abs{l + 1}}}$ = {z:.3f}"
-    for l, z in enumerate(np.nditer(canopy_ppa.extinction_profile))
+    for l, z in enumerate(np.nditer(canopy_ppa.community_data.extinction_profile))
 ]
-ax2_top.set_xticks(canopy_ppa.extinction_profile)
+ax2_top.set_xticks(canopy_ppa.community_data.extinction_profile)
 ax2_top.set_xticklabels(extinction_labels, rotation=90)
 
 ax2.set_xlabel("Light extinction (-)")
@@ -548,11 +548,11 @@ The steps below show this partitioning process for the PPA layers calculated abo
 
 ```{code-cell} ipython3
 print("k = \n", community.stem_traits.par_ext, "\n")
-print("L_H = \n", canopy_ppa.cohort_lai)
+print("L_H = \n", canopy_ppa.cohort_data.lai)
 ```
 
 ```{code-cell} ipython3
-layer_cohort_f_tr = np.exp(-community.stem_traits.par_ext * canopy_ppa.cohort_lai)
+layer_cohort_f_tr = np.exp(-community.stem_traits.par_ext * canopy_ppa.cohort_data.lai)
 print(layer_cohort_f_tr)
 ```
 

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -532,7 +532,3 @@ plt.legend(
     bbox_to_anchor=(0.5, 1.15),
 )
 ```
-
-```{code-cell} ipython3
-
-```

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -182,7 +182,7 @@ class CohortCanopyData:
     Args:
         projected_leaf_area: A two dimensional array providing projected leaf area for a
             set of cohorts (columns) at a set of required heights (rows), as for example
-           calculated using the :class:`~pyrealm.demography.crown.CrownProfile` class.
+            calculated using the :class:`~pyrealm.demography.crown.CrownProfile` class.
         n_individuals: A one-dimensional array of the number of individuals in each
             cohort.
         pft_lai: A one-dimensional array giving the leaf area index trait for the plant

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -1,5 +1,7 @@
 """Functionality for canopy modelling."""
 
+from __future__ import annotations
+
 from dataclasses import InitVar, dataclass, field
 
 import numpy as np
@@ -174,10 +176,24 @@ class CohortCanopyData:
     required and the columns represent the different cohorts or the identical stem
     properties of individuals within cohorts.
 
-    The data class takes the projected leaf area at the required heights and then
-    partitions this into the actual leaf area within each layer, the leaf area index
-    across the whole cohort and then then light absorbtion and transmission fractions of
-    each cohort at each level.
+    The data class:
+
+    1. Takes the projected leaf area at the required heights and then partitions this
+       into the actual leaf area within each layer, the leaf area index across the whole
+       cohort and then then light absorption and transmission fractions of each cohort
+       at each level.
+
+    2. Calculates the community-wide transmission and absorption profiles. These are
+       generated as an instance of the class
+       :class:`~pyrealm.demography.canopy.CommunityCanopyData` and stored in the
+       ``community_data`` attribute.
+
+    3. Allocates the community-wide absorption across cohorts. The total fraction of
+       light absorbed across layers is a community-wide property
+        - each cohort contributes to the cumulative light absorption. Once the light
+        absorbed within a layer of the community is known, this can then be partitioned
+        back to cohorts and individual stems to give the fraction of canopy top
+        radiation intercepted by each stem within each layer.
 
     Args:
         projected_leaf_area: A two dimensional array providing projected leaf area for a
@@ -219,6 +235,9 @@ class CohortCanopyData:
     stem_fapar: NDArray[np.float64] = field(init=False)
     """The fraction of absorbed radiation for each stem by layer."""
 
+    # Community wide attributes in their own class
+    community_data: CommunityCanopyData = field(init=False)
+
     def __post_init__(
         self,
         projected_leaf_area: NDArray[np.float64],
@@ -244,22 +263,8 @@ class CohortCanopyData:
         self.f_trans = np.exp(-pft_par_ext * self.lai)
         self.f_abs = 1 - self.f_trans
 
-    def allocate_fapar(
-        self, community_fapar: NDArray[np.float64], n_individuals: NDArray[np.int_]
-    ) -> None:
-        """Allocate community-wide absorption across cohorts.
-
-        The total fraction of light absorbed across layers is a community-wide property
-        - each cohort contributes to the cumulative light absorption. Once the light
-        absorbed within a layer of the community is known, this can then be partitioned
-        back to cohorts and individual stems to give the fraction of canopy top
-        radiation intercepted by each stem within each layer.
-
-        Args:
-            community_fapar: The community wide fraction of light absorbed across all
-                layers and cohorts.
-            n_individuals: The number of individuals within each cohort.
-        """
+        # Calculate the community wide properties
+        self.community_data = CommunityCanopyData(cohort_transmissivity=self.f_trans)
 
         # Calculate the fapar profile across cohorts and layers
         # * The first part of the equation is calculating the relative absorption of
@@ -273,7 +278,7 @@ class CohortCanopyData:
         # f_abs values
         self.cohort_fapar = (
             self.f_abs / self.f_abs.sum(axis=1)[:, None]
-        ) * community_fapar[:, None]
+        ) * self.community_data.fapar[:, None]
         # Partition cohort f_APAR between the number of stems
         self.stem_fapar = self.cohort_fapar / n_individuals
 
@@ -442,13 +447,5 @@ class Canopy:
             cell_area=community.cell_area,
         )
 
-        # Calculate the community wide canopy componennts at each layer_height
-        self.community_data = CommunityCanopyData(
-            cohort_transmissivity=self.cohort_data.f_trans
-        )
-
-        # Calculate the proportion of absorbed light intercepted by each cohort and stem
-        self.cohort_data.allocate_fapar(
-            community_fapar=self.community_data.fapar,
-            n_individuals=community.cohorts.n_individuals,
-        )
+        # Create a shorter reference to the community data
+        self.community_data = self.cohort_data.community_data

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -190,10 +190,10 @@ class CohortCanopyData:
 
     3. Allocates the community-wide absorption across cohorts. The total fraction of
        light absorbed across layers is a community-wide property
-        - each cohort contributes to the cumulative light absorption. Once the light
-        absorbed within a layer of the community is known, this can then be partitioned
-        back to cohorts and individual stems to give the fraction of canopy top
-        radiation intercepted by each stem within each layer.
+       - each cohort contributes to the cumulative light absorption. Once the light
+       absorbed within a layer of the community is known, this can then be partitioned
+       back to cohorts and individual stems to give the fraction of canopy top
+       radiation intercepted by each stem within each layer.
 
     Args:
         projected_leaf_area: A two dimensional array providing projected leaf area for a

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -4,6 +4,50 @@ import numpy as np
 import pytest
 
 
+@pytest.mark.parametrize(
+    argnames="args,expected",
+    argvalues=(
+        [
+            pytest.param(
+                {
+                    "projected_leaf_area": np.array([[2, 2, 2]]),
+                    "n_individuals": np.array([2, 2, 2]),
+                    "pft_lai": np.array([2, 2, 2]),
+                    "pft_par_ext": np.array([0.5, 0.5, 0.5]),
+                    "cell_area": 8,
+                },
+                (np.full((3,), 2), np.full((3,), 1), np.full((3,), np.exp(-0.5))),
+                id="single layer",
+            ),
+            pytest.param(
+                {
+                    "projected_leaf_area": np.tile([[2], [4], [6]], 3),
+                    "n_individuals": np.array([2, 2, 2]),
+                    "pft_lai": np.array([2, 2, 2]),
+                    "pft_par_ext": np.array([0.5, 0.5, 0.5]),
+                    "cell_area": 8,
+                },
+                (np.full((3, 3), 2), np.full((3, 3), 1), np.full((3, 3), np.exp(-0.5))),
+                id="two layers",
+            ),
+        ]
+    ),
+)
+def test_CohortCanopyData__init__(args, expected):
+    """Test creation of the cohort canopy data."""
+
+    from pyrealm.demography.canopy import CohortCanopyData
+
+    # Calculate canopy components
+    instance = CohortCanopyData(**args)
+
+    # Unpack and test expectations
+    exp_stem_leaf_area, exp_lai, exp_f_trans = expected
+    assert np.allclose(instance.stem_leaf_area, exp_stem_leaf_area)
+    assert np.allclose(instance.lai, exp_lai)
+    assert np.allclose(instance.f_trans, exp_f_trans)
+
+
 def test_Canopy__init__():
     """Test happy path for initialisation.
 
@@ -49,7 +93,7 @@ def test_Canopy__init__():
             / community.cell_area
         )
     )
-    assert canopy.stem_leaf_area.shape == (
+    assert canopy.cohort_data.stem_leaf_area.shape == (
         n_layers_from_crown_area,
         canopy.n_cohorts,
     )

--- a/tests/unit/demography/test_canopy.py
+++ b/tests/unit/demography/test_canopy.py
@@ -73,6 +73,16 @@ class TestCanopyData:
         assert np.allclose(instance.lai, exp_lai)
         assert np.allclose(instance.f_trans, exp_f_trans)
 
+        # Unpack and test expectations
+        exp_f_trans, exp_trans_prof = community_expected
+        expected_fapar = -np.diff(exp_trans_prof, prepend=1)
+        assert np.allclose(
+            instance.cohort_fapar, np.tile((expected_fapar / 3)[:, None], 3)
+        )
+        assert np.allclose(
+            instance.stem_fapar, np.tile((expected_fapar / 6)[:, None], 3)
+        )
+
     def test_CommunityCanopyData__init__(
         self, cohort_args, cohort_expected, community_expected
     ):
@@ -88,31 +98,6 @@ class TestCanopyData:
         exp_f_trans, exp_trans_prof = community_expected
         assert np.allclose(instance.f_trans, exp_f_trans)
         assert np.allclose(instance.transmission_profile, exp_trans_prof)
-
-    def test_CohortCanopyData_allocate_fapar(
-        self, cohort_args, cohort_expected, community_expected
-    ):
-        """Test creation of the cohort canopy data."""
-
-        from pyrealm.demography.canopy import CohortCanopyData, CommunityCanopyData
-
-        cohort_data = CohortCanopyData(**cohort_args)
-        community_data = CommunityCanopyData(cohort_transmissivity=cohort_data.f_trans)
-
-        cohort_data.allocate_fapar(
-            community_fapar=community_data.fapar,
-            n_individuals=cohort_args["n_individuals"],
-        )
-
-        # Unpack and test expectations
-        exp_f_trans, exp_trans_prof = community_expected
-        expected_fapar = -np.diff(exp_trans_prof, prepend=1)
-        assert np.allclose(
-            cohort_data.cohort_fapar, np.tile((expected_fapar / 3)[:, None], 3)
-        )
-        assert np.allclose(
-            cohort_data.stem_fapar, np.tile((expected_fapar / 6)[:, None], 3)
-        )
 
 
 def test_Canopy__init__():


### PR DESCRIPTION
# Description

This PR revises the internal structure of the `Canopy` class, grouping the attributes under two new dataclasses: `CohortCanopyData` and `CommunityCanopyData`, which  use `__post_init__` methods to populate the attributes. This:

* gives a cleaner internal structure 
* groups the attributes that share the same dimensions (cohort is `(n_heights, n_cohorts)`, community is just `(n_heights,)`) 
* allows us to get these dataclasses to inherit methods with shared functionality such as export to pandas (upcoming #338).
* simplifies the internals of `Canopy._calculate_canopy` by bundling cohort and community calculations. This is something that @j-emberton requested in PR #328.
* adds a new test class to validate the calculations in these two dataclasses, which is a finer grained check than the previous implementation.

The calculation order here goes:

1. main cohort attributes on light extinction
2. whole community light extinction and fraction absorbed
3. divide the whole community absorption among cohorts and stems

The first iteration had: `CohortCanopyData`, `CommunityCanopyData` and then `CohortCanopyData.allocate_fapar` method, but that leaves some canopy attributes hanging until the allocation method is called. The code now generates the `CommunityCanopyData` _within_ `CohortCanopyData` so it all happens in a single pass. Within `Canopy` the community data is moved up into a top level attribute for ease of access.

```python
self.cohort_data = CohortCanopyData(...)
self.community_data = self.cohort_data.community_data
```

Fixes #337

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
