### PR TITLE
Upgrade upload-artifact version

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Archive built docs for error checking on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-docs
           path: docs/build


### PR DESCRIPTION
Fixes #353 . 

As described in the issue, version 3 will be deprecated from Dec. Version 4 is already used for download-artifacts in [this workflow](https://github.com/ImperialCollegeLondon/pyrealm/blob/develop/.github/workflows/pyrealm_publish.yaml).