### PR TITLE
Added mm/m2 to moles, tests, fixed docs

### DIFF
--- a/pyrealm/constants/core_const.py
+++ b/pyrealm/constants/core_const.py
@@ -64,6 +64,8 @@ class CoreConst(ConstantsClass):
     """O2 partial pressure, Standard Atmosphere (:math:`co` , 209476.0, ppm)"""
     k_c_molmass: float = 12.0107
     """Molecular mass of carbon (:math:`c_molmass` , 12.0107, g)"""
+    k_water_molmass: float = 18.01258
+    """Molecular mass of water (:math:`h2o_molmass` , 18.01258, g)"""
     k_Po: float = 101325.0
     """Standard reference atmosphere (Allen, 1973) (:math:`P_o` , 101325.0, Pa)"""
     k_To: float = 298.15

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -336,6 +336,9 @@ def convert_water_mm_to_moles(
         np.float64(55.417)
     """
 
+    # Check inputs, return shape not used
+    _ = check_input_shapes(water_mm, tc, patm)
+
     # Calculate density at given temperature and pressure in g/cm3
     water_density = calc_density_h2o(tc=tc, patm=patm, core_const=core_const) / 1000
     # Hence molar volume as mol/cm3 or equivalently mol/mL

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -30,7 +30,7 @@ def calc_density_h2o_chen(
             equations.
 
     Returns:
-        Water density as a float in (g cm^-3)
+        Water density in kg m3
 
     Raises:
         ValueError: if the inputs have incompatible shapes.
@@ -86,7 +86,7 @@ def calc_density_h2o_fisher(
             equations.
 
     Returns:
-        Water density as a float in (g cm^-3)
+        Water density in kg m3.
 
     Raises:
         ValueError: if the inputs have incompatible shapes.
@@ -117,7 +117,7 @@ def calc_density_h2o_fisher(
     # Calculate the specific volume (cm^3 g^-1):
     spec_vol = vinf_val + lambda_val / (po_val + pbar)
 
-    # Convert to density (g cm^-3) -> 1000 g/kg; 1000000 cm^3/m^3 -> kg/m^3:
+    # Convert to density in kg/m^3
     rho = 1e3 / spec_vol
 
     return rho
@@ -148,7 +148,7 @@ def calc_density_h2o(
             functions are numerically unstable.
 
     Returns:
-        Water density as a float in (g cm^-3)
+        Water density in kg m3.
 
     Raises:
         ValueError: if ``tc`` contains values below -30°C and ``safe`` is True, or if
@@ -267,7 +267,7 @@ def calc_viscosity_h2o_matrix(
         A float giving the viscosity of water (mu, Pa s)
 
     Examples:
-        >>> # Density of water at 20 degrees C and standard atmospheric pressure:
+        >>> # Viscosity of water at 20 degrees C and standard atmospheric pressure:
         >>> round(calc_viscosity_h2o(20, 101325), 7)
         np.float64(0.0010016)
     """
@@ -306,3 +306,40 @@ def calc_viscosity_h2o_matrix(
 
     # Calculate mu (Eq. 1, Huber et al., 2009)
     return mu_bar * core_const.huber_mu_ast  # Pa s
+
+
+def convert_water_mm_to_moles(
+    water_mm: NDArray[np.float64],
+    tc: NDArray[np.float64],
+    patm: NDArray[np.float64],
+    core_const: CoreConst = CoreConst(),
+) -> NDArray[np.float64]:
+    """Convert water in mm per square meter to moles.
+
+    This function converts water volumes expressed as mm per m2 into a number of moles
+    of water. It accounts for the changing density of water with temperature and
+    pressure.
+
+    Args:
+        water_mm: Water volume in mm per square meter
+        tc: air temperature (°C)
+        patm: atmospheric pressure (Pa)
+        core_const: Instance of :class:`~pyrealm.constants.core_const.CoreConst`
+
+    Returns:
+        Moles of water (-)
+
+    Examples:
+        >>> # Number of moles of water in 1 mm/m2 at 20 degrees C and
+        >>> # standard atmospheric pressure:
+        >>> round(convert_water_mm_to_moles(1, 20, 101325), 3)
+        np.float64(55.417)
+    """
+
+    # Calculate density at given temperature and pressure in g/cm3
+    water_density = calc_density_h2o(tc=tc, patm=patm, core_const=core_const) / 1000
+    # Hence molar volume as mol/cm3 or equivalently mol/mL
+    molar_volume = core_const.k_water_molmass / water_density
+
+    # 1 mm per square meter is 1 litre, so convert to mL and then to moles
+    return water_mm * 1000 / molar_volume

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -30,7 +30,7 @@ def calc_density_h2o_chen(
             equations.
 
     Returns:
-        Water density in kg m3
+        Water density in kg/m^3
 
     Raises:
         ValueError: if the inputs have incompatible shapes.
@@ -72,7 +72,7 @@ def calc_density_h2o_fisher(
     """Calculate water density.
 
     Calculates the density of water as a function of temperature and atmospheric
-    pressure, using the Tumlirz Equation and coefficients calculated by
+    pressure (kg/m^3), using the Tumlirz Equation and coefficients calculated by
     :cite:t:`Fisher:1975tm`.
 
     Warning:
@@ -86,7 +86,7 @@ def calc_density_h2o_fisher(
             equations.
 
     Returns:
-        Water density in kg m3.
+        Water density in kg/m^3.
 
     Raises:
         ValueError: if the inputs have incompatible shapes.
@@ -132,9 +132,9 @@ def calc_density_h2o(
     """Calculate water density.
 
     Calculates the density of water as a function of temperature and atmospheric
-    pressure. This function uses either the method provided by :cite:t:`Fisher:1975tm`
-    (:func:`~pyrealm.core.water.calc_density_h2o_fisher`) or :cite:t:`chen:2008a`
-    (:func:`~pyrealm.core.water.calc_density_h2o_chen`).
+    pressure (in kg/m^3). This function uses either the method provided by
+    :cite:t:`Fisher:1975tm` (:func:`~pyrealm.core.water.calc_density_h2o_fisher`) or
+    :cite:t:`chen:2008a` (:func:`~pyrealm.core.water.calc_density_h2o_chen`).
 
     The constants attribute
     :attr:`~pyrealm.constants.core_const.CoreConst.water_density_method` can be used to
@@ -148,7 +148,7 @@ def calc_density_h2o(
             functions are numerically unstable.
 
     Returns:
-        Water density in kg m3.
+        Water density in kg/m^3.
 
     Raises:
         ValueError: if ``tc`` contains values below -30°C and ``safe`` is True, or if

--- a/tests/unit/core/test_water.py
+++ b/tests/unit/core/test_water.py
@@ -78,3 +78,17 @@ def test_calc_viscosity_h20_matrix(shape):
     )
 
     assert np.allclose(eta.round(7), np.full(shape, fill_value=0.0010016))
+
+
+@pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
+def test_convert_water_mm_to_moles(shape):
+    """Test the viscosity calculation."""
+    from pyrealm.core.water import convert_water_mm_to_moles
+
+    moles_water = convert_water_mm_to_moles(
+        np.full(shape, fill_value=1),
+        np.full(shape, fill_value=20),
+        np.full(shape, fill_value=101325),
+    )
+
+    assert np.allclose(moles_water, np.full(shape, fill_value=55.41713669719267))

--- a/tests/unit/core/test_water.py
+++ b/tests/unit/core/test_water.py
@@ -51,7 +51,7 @@ def test_calc_density_h20(const_args, exp):
     if const_args is not None:
         args["core_const"] = CoreConst(water_density_method=const_args)
 
-    rho = calc_density_h2o(np.array([20]), np.array([101325]), **args)
+    rho = calc_density_h2o(20, 101325, **args)
 
     assert rho.round(3) == exp
 
@@ -80,8 +80,41 @@ def test_calc_viscosity_h20_matrix(shape):
     assert np.allclose(eta.round(7), np.full(shape, fill_value=0.0010016))
 
 
+@pytest.mark.parametrize(
+    "water_mm, tc, patm, expected_fisher, expected_chen",
+    [
+        pytest.param(
+            np.array([0, 1, 10, 1, 1, 1]),
+            np.array([20, 20, 20, 0, 20, 20]),
+            np.array([101325, 101325, 101325, 101325, 90000, 110000]),
+            np.array([0.0, 55.417139, 554.171387, 55.507874, 55.41685, 55.41736]),
+            np.array([0.0, 55.419629, 554.196289, 55.510708, 55.419341, 55.419849]),
+            id="array_values",
+        )
+    ],
+)
+def test_convert_water_mm_to_moles_values(
+    water_mm, tc, patm, expected_fisher, expected_chen
+):
+    """Test the convert_water_mm_to_moles function."""
+    from pyrealm.constants import CoreConst
+    from pyrealm.core.water import convert_water_mm_to_moles
+
+    moles_water_fisher = convert_water_mm_to_moles(
+        water_mm, tc, patm, core_const=CoreConst(water_density_method="fisher")
+    )
+
+    assert np.allclose(moles_water_fisher, expected_fisher, rtol=1e-5)
+
+    moles_water_chen = convert_water_mm_to_moles(
+        water_mm, tc, patm, core_const=CoreConst(water_density_method="chen")
+    )
+
+    assert np.allclose(moles_water_chen, expected_chen, rtol=1e-5)
+
+
 @pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
-def test_convert_water_mm_to_moles(shape):
+def test_convert_water_mm_to_moles_shape(shape):
     """Test the viscosity calculation."""
     from pyrealm.core.water import convert_water_mm_to_moles
 
@@ -92,3 +125,15 @@ def test_convert_water_mm_to_moles(shape):
     )
 
     assert np.allclose(moles_water, np.full(shape, fill_value=55.41713669719267))
+
+
+def test_convert_water_mm_to_moles_invalid_input():
+    """Test the convert_water_mm_to_moles function with invalid input."""
+    from pyrealm.core.water import convert_water_mm_to_moles
+
+    water_mm = np.array([1, 2])
+    tc = np.array([0, 5, 20])
+    patm = 101325
+
+    with pytest.raises(ValueError):
+        convert_water_mm_to_moles(water_mm, tc, patm)


### PR DESCRIPTION
# Description

This adds `convert_mm_water_to_moles`, tests it and fixes some incorrect unit reporting in the `calc_density_h2o`docs.

Fixes #378

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
