### PR TITLE
Fixing formatting in `QuantumYieldABC`

### DIFF
--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -45,7 +45,7 @@ class QuantumYieldABC(ABC):
 
     This provides an abstract base class for the implementation of alternative
     approaches to calculating the the intrinsic quantum yield of photosynthesis. All
-    implementations estimate the :math:`\phi_{0} following values, which is then stored
+    implementations estimate the :math:`\phi_{0}` following values, which is then stored
     in the ``kphio`` attribute of the resulting class instance.
 
     The abstract base class requires that implementations of specific approaches defines


### PR DESCRIPTION
# Description

Fixes formatting error in `QuantumYieldABC` from `:math:` role

Fixes #397

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
