### PR TITLE
Adding `convert_water_mm_to_moles` and `calculate_water_molar_volume`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,7 +48,10 @@ worked through. The changes below are provisional.
   `calculate_simple_arrhenius_factor` and `calculate_kattge_knorr_arrhenius_factor` (see
   also the point above).
 
-- The first components in the demography module, providing an integrated set of
+- The `pyrealm.core.water` module now provides `convert_water_mm_to_moles`,
+  `convert_water_moles_to_mm` and `calculate_water_molar_volume`.
+
+- The first components in the `demography` module, providing an integrated set of
   submodules that provide: plant functional types, size-structured cohorts, plant
   communities, a community canopy model and an implementation of the T Model for
   allocation and growth.

--- a/tests/unit/core/test_water.py
+++ b/tests/unit/core/test_water.py
@@ -7,6 +7,7 @@ check the size of outputs and that the results meet a simple benchmark value.
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 
 @pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
@@ -80,6 +81,46 @@ def test_calc_viscosity_h20_matrix(shape):
     assert np.allclose(eta.round(7), np.full(shape, fill_value=0.0010016))
 
 
+def test_calculate_water_molar_volume():
+    """Simple sense check that molar volume at standard conditions ~= molar mass."""
+
+    from pyrealm.constants import CoreConst
+    from pyrealm.core.water import calculate_water_molar_volume
+
+    assert_allclose(
+        calculate_water_molar_volume(tc=0, patm=101325),
+        CoreConst.k_water_molmass,
+        atol=0.01,
+    )
+
+
+def test_convert_water_benchmark():
+    """Test water conversion functions.
+
+    Approximate benchmarking of convert_water_mm_to_moles and convert_water_moles_to_mm
+    against real world values. Further testing below looks at round trip between the two
+    functions, so this checks that the values are real world sensible.
+    """
+
+    from pyrealm.core.water import convert_water_mm_to_moles, convert_water_moles_to_mm
+
+    # At 0°C and 101325 Pa, one mole of water is ~18 g (18 cm3, 0.018 mm m-2).
+    # So, 1 mm m2 = 1 / 0.018 = ~55 moles.
+    assert_allclose(
+        convert_water_mm_to_moles(water_mm=1, tc=0, patm=101325),
+        55.508,
+        rtol=1e-5,
+    )
+
+    # At 0°C and 101325 Pa, one mole of water is ~18 g (18 cm3, 0.018 mm m-2).
+    # So, 1 mol = 0.018 mm
+    assert_allclose(
+        convert_water_moles_to_mm(water_moles=1, tc=0, patm=101325),
+        0.018015,
+        rtol=1e-4,
+    )
+
+
 @pytest.mark.parametrize(
     "water_mm, tc, patm, expected_fisher, expected_chen",
     [
@@ -93,47 +134,73 @@ def test_calc_viscosity_h20_matrix(shape):
         )
     ],
 )
-def test_convert_water_mm_to_moles_values(
-    water_mm, tc, patm, expected_fisher, expected_chen
-):
-    """Test the convert_water_mm_to_moles function."""
+def test_convert_water_values(water_mm, tc, patm, expected_fisher, expected_chen):
+    """Test the convert_water_mm_to_moles and convert_water_moles_to_mm function."""
     from pyrealm.constants import CoreConst
-    from pyrealm.core.water import convert_water_mm_to_moles
+    from pyrealm.core.water import convert_water_mm_to_moles, convert_water_moles_to_mm
+
+    # Fisher
+    fisher_const = CoreConst(water_density_method="fisher")
 
     moles_water_fisher = convert_water_mm_to_moles(
-        water_mm, tc, patm, core_const=CoreConst(water_density_method="fisher")
+        water_mm, tc, patm, core_const=fisher_const
     )
 
+    # Test forward and back conversion
     assert np.allclose(moles_water_fisher, expected_fisher, rtol=1e-5)
+    assert_allclose(
+        convert_water_moles_to_mm(
+            moles_water_fisher, tc, patm, core_const=fisher_const
+        ),
+        water_mm,
+        rtol=1e-4,
+    )
+
+    # Chen
+    chen_const = CoreConst(water_density_method="chen")
 
     moles_water_chen = convert_water_mm_to_moles(
-        water_mm, tc, patm, core_const=CoreConst(water_density_method="chen")
+        water_mm, tc, patm, core_const=chen_const
     )
 
+    # Test forward and back conversion
     assert np.allclose(moles_water_chen, expected_chen, rtol=1e-5)
+    assert_allclose(
+        convert_water_moles_to_mm(moles_water_fisher, tc, patm, core_const=chen_const),
+        water_mm,
+        rtol=1e-4,
+    )
 
 
 @pytest.mark.parametrize(argnames="shape", argvalues=[(1,), (6, 9), (4, 7, 3)])
-def test_convert_water_mm_to_moles_shape(shape):
-    """Test the viscosity calculation."""
-    from pyrealm.core.water import convert_water_mm_to_moles
+def test_convert_water(shape):
+    """Test the water conversion functions with different shapes."""
+    from pyrealm.core.water import convert_water_mm_to_moles, convert_water_moles_to_mm
 
-    moles_water = convert_water_mm_to_moles(
-        np.full(shape, fill_value=1),
-        np.full(shape, fill_value=20),
-        np.full(shape, fill_value=101325),
-    )
+    water_mm = np.full(shape, fill_value=1)
+    tc = np.full(shape, fill_value=20)
+    patm = np.full(shape, fill_value=101325)
 
+    # Test mm to moles
+    moles_water = convert_water_mm_to_moles(water_mm=water_mm, tc=tc, patm=patm)
     assert np.allclose(moles_water, np.full(shape, fill_value=55.41713669719267))
 
+    # Test reverse direction
+    assert_allclose(convert_water_moles_to_mm(moles_water, tc=tc, patm=patm), water_mm)
 
-def test_convert_water_mm_to_moles_invalid_input():
+
+def test_convert_water_invalid_input():
     """Test the convert_water_mm_to_moles function with invalid input."""
     from pyrealm.core.water import convert_water_mm_to_moles
 
+    # Input shapes not equal or scalar
     water_mm = np.array([1, 2])
+    water_moles = np.array([1, 2])
     tc = np.array([0, 5, 20])
     patm = 101325
 
     with pytest.raises(ValueError):
         convert_water_mm_to_moles(water_mm, tc, patm)
+
+    with pytest.raises(ValueError):
+        convert_water_mm_to_moles(water_moles, tc, patm)

--- a/tests/unit/core/test_water.py
+++ b/tests/unit/core/test_water.py
@@ -90,7 +90,7 @@ def test_calculate_water_molar_volume():
     assert_allclose(
         calculate_water_molar_volume(tc=0, patm=101325),
         CoreConst.k_water_molmass,
-        atol=0.01,
+        rtol=1e-3,
     )
 
 


### PR DESCRIPTION
# Description

This PR:

* Adds `convert_water_mm_to_moles` as the reciprocal of `convert_water_moles_to_mm`
* Adds `calculate_water_molar_volume` which otherwise is duplicate within those two functions.
* Adds tests - simple benchmarks for all three functions against real world approximate values and then extends the existing tests to check that the round trip through both functions works as expected.

Fixes #399

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
