### PR TITLE
Make `summarize_attrs` use non-mutable tuple as `attrs` argument

### DIFF
--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -111,7 +111,10 @@ def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> t
 
 
 def summarize_attrs(
-    obj: object, attrs: list, dp: int = 2, repr_head: bool = True
+    obj: object,
+    attrs: tuple[tuple[str, str], ...],
+    dp: int = 2,
+    repr_head: bool = True,
 ) -> None:
     """Print a summary table of object attributes.
 
@@ -121,35 +124,22 @@ def summarize_attrs(
 
     Args:
         obj: An object with attributes to summarize
-        attrs: A list of strings of attribute names, or a list of 2-tuples
-            giving attribute names and units.
+        attrs: A tuple of 2-tuples giving attribute names and units.
         dp: The number of decimal places used in rounding summary stats.
         repr_head: A boolean indicating whether to show the object
             representation before the summary table.
     """
 
     # Check inputs
-    if not isinstance(attrs, list):
-        raise RuntimeError("attrs input not a list")
+    if not isinstance(attrs, tuple):
+        raise RuntimeError("attrs input not a tuple")
 
     # Create a list to hold variables and summary stats
     ret = []
 
     if len(attrs):
-        first = attrs[0]
-
-        # TODO: - not much checking for consistency here!
-        if isinstance(first, str):
-            has_units = False
-            attrs = [(vl, None) for vl in attrs]
-        else:
-            has_units = True
-
         # Process the attributes
-        for attr_entry in attrs:
-            attr = attr_entry[0]
-            unit = attr_entry[1]
-
+        for attr, unit in attrs:
             data = getattr(obj, attr)
 
             # Avoid masked arrays - run into problems with edge cases with all NaN
@@ -165,15 +155,10 @@ def summarize_attrs(
                 np.round(np.nanmax(data), dp),
                 np.count_nonzero(np.isnan(data)),
             ]
-            if has_units:
-                attr_row.append(unit)
-
+            attr_row.append(unit)
             ret.append(attr_row)
 
-    if has_units:
-        hdrs = ["Attr", "Mean", "Min", "Max", "NaN", "Units"]
-    else:
-        hdrs = ["Attr", "Mean", "Min", "Max", "NaN"]
+    hdrs = ["Attr", "Mean", "Min", "Max", "NaN", "Units"]
 
     if repr_head:
         print(obj)

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -304,20 +304,19 @@ class C3C4Competition:
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [
+        attrs: tuple[tuple[str, str], ...] = (
             ("frac_c4", "-"),
             ("gpp_c3_contrib", "gC m-2 yr-1"),
             ("gpp_c4_contrib", "gC m-2 yr-1"),
-        ]
+        )
 
         if hasattr(self, "d13C_C3"):
-            attrs.extend(
-                [
-                    ("Delta13C_C3", "permil"),
-                    ("Delta13C_C4", "permil"),
-                    ("d13C_C3", "permil"),
-                    ("d13C_C4", "permil"),
-                ]
+            attrs = (
+                *attrs,
+                ("Delta13C_C3", "permil"),
+                ("Delta13C_C4", "permil"),
+                ("d13C_C3", "permil"),
+                ("d13C_C4", "permil"),
             )
 
         summarize_attrs(self, attrs, dp=dp)

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -234,13 +234,13 @@ class CalcCarbonIsotopes:
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [
+        attrs = (
             ("Delta13C_simple", "permil"),  # ‰
             ("Delta13C", "permil"),
             ("Delta14C", "permil"),
             ("d13C_leaf", "permil"),
             ("d14C_leaf", "permil"),
             ("d13C_wood", "permil"),
-        ]
+        )
 
         summarize_attrs(self, attrs, dp=dp)

--- a/pyrealm/pmodel/jmax_limitation.py
+++ b/pyrealm/pmodel/jmax_limitation.py
@@ -89,7 +89,7 @@ class JmaxLimitationABC(metaclass=ABCMeta):
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        summarize_attrs(self, list(self.data_attrs), dp=dp)
+        summarize_attrs(self, self.data_attrs, dp=dp)
 
     @abstractmethod
     def _calculate_limitation_terms(self) -> None:

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -168,13 +168,13 @@ class OptimalChiABC(ABC):
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [
+        attrs = (
             ("xi", " Pa ^ (1/2)"),
             ("chi", "-"),
             ("mc", "-"),
             ("mj", "-"),
             ("mjoc", "-"),
-        ]
+        )
         summarize_attrs(self, attrs, dp=dp)
 
     @classmethod

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -475,18 +475,20 @@ class PModel:
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [("lue", "g C mol-1"), ("iwue", "µmol mol-1")]
+        attrs: tuple[tuple[str, str], ...] = (
+            ("lue", "g C mol-1"),
+            ("iwue", "µmol mol-1"),
+        )
 
         if hasattr(self, "_gpp"):
-            attrs.extend(
-                [
-                    ("gpp", "µg C m-2 s-1"),
-                    ("vcmax", "µmol m-2 s-1"),
-                    ("vcmax25", "µmol m-2 s-1"),
-                    ("rd", "µmol m-2 s-1"),
-                    ("gs", "µmol m-2 s-1"),
-                    ("jmax", "µmol m-2 s-1"),
-                ]
+            attrs = (
+                *attrs,
+                ("gpp", "µg C m-2 s-1"),
+                ("vcmax", "µmol m-2 s-1"),
+                ("vcmax25", "µmol m-2 s-1"),
+                ("rd", "µmol m-2 s-1"),
+                ("gs", "µmol m-2 s-1"),
+                ("jmax", "µmol m-2 s-1"),
             )
 
         summarize_attrs(self, attrs, dp=dp)

--- a/pyrealm/pmodel/pmodel_environment.py
+++ b/pyrealm/pmodel/pmodel_environment.py
@@ -209,7 +209,7 @@ class PModelEnvironment:
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [
+        attrs: tuple[tuple[str, str], ...] = (
             ("tc", "°C"),
             ("vpd", "Pa"),
             ("co2", "ppm"),
@@ -218,7 +218,7 @@ class PModelEnvironment:
             ("gammastar", "Pa"),
             ("kmm", "Pa"),
             ("ns_star", "-"),
-        ]
+        )
 
         # Add any optional variables - need to check here if these attributes actually
         # exist because if they are not provided they are typed but not populated.
@@ -229,8 +229,12 @@ class PModelEnvironment:
             ("mean_growth_temperature", "°C"),
         ]
 
-        for opt_var, unit in optional_vars:
-            if getattr(self, opt_var, None) is not None:
-                attrs += [(opt_var, unit)]
+        to_add = [
+            (opt_var, unit)
+            for opt_var, unit in optional_vars
+            if getattr(self, opt_var, None) is not None
+        ]
+
+        attrs = (*attrs, *to_add)
 
         summarize_attrs(self, attrs, dp=dp)

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -192,7 +192,7 @@ class QuantumYieldABC(ABC):
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        attrs = [("kphio", "-")]
+        attrs = (("kphio", "-"),)
 
         summarize_attrs(self, attrs, dp=dp)
 


### PR DESCRIPTION
# Description

This PR updates the `attrs` argument to `pyrealm.core.utilities.summarize_attrs`. It used to accept values as lists of attribute names, either with or without units:

```python
["attr_name_1", "attr_name_2"]
[("attr_name_1", "m2"), ("attr_name_2", "kg")]
```
But that mutable list argument makes it awkward to use with e.g. class attributes etc. So it is accepts a tuple of values and the option to just specify names has been removed as it was never used. 

```python
(("attr_name_1", "m2"), ("attr_name_2", "kg"))
```

All the use cases are now updated to match.

Fixes #402

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
