### PR TITLE
Develop the AcclimationModel class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@ worked through. The changes below are provisional.
   **Breaking change**: Need to specify `fapar` and `ppfd` in `PModelEnvironment`.
 
 - The `bounds_checker` function has been retired and replaced with the `BoundsChecker`
-  class, which provides more flexible and user-configurable bounds checking.
+  class, which provides more flexible and user-configurable bounds checking. This
+  functionality is used within other classes and does not introduce breaking changes.
 
 - A new system for providing alternative calculations of quantum yield ($\phi_0$) in the
   P Model, using the new `pyrealm.pmodel.quantum_yield` module. This module now provides
@@ -53,6 +54,21 @@ worked through. The changes below are provisional.
   settings, the reported values for $V_{cmax25}$ and $J_{max25}$ using `PModel` will
   change between v1 and v2, with the shift from `kattge_knorr` to `simple` as the
   default factors.
+
+- Many of the arguments to `SubdailyPModel` have been brought together into a new
+  `AcclimationModel` class. This replaces `SubdailyScaler` and bundles all of the
+  settings for acclimation into a single class. The following **breaking change**:
+  
+  - `SubdailyScaler` has been replaced with `AcclimationModel`.
+
+- The legacy implementation `SubdailyPModel_JAMES` has been deprecated. This
+  implementation duplicated the original Mengoli et al JAMES code. This was largely a
+  proof of concept implementation, misses some key parts of the acclimation model and
+  the internal calculations are sufficiently different that there is a high maintenance
+  cost to updating it the new API in version 2.0.0.
+
+  - The `fill_from` argument to `fill_daily_to_subdaily` was only required for
+    `SubdailyPModel_JAMES` and so this has also been deprecated.
 
 - The functions `calc_ftemp_kphio` and `calc_ftemp_inst_vcmax` provided narrow use cases
   with code duplication. They have been replaced by two broader Arrhenius functions:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,15 +57,19 @@ worked through. The changes below are provisional.
 
 - Many of the arguments to `SubdailyPModel` have been brought together into a new
   `AcclimationModel` class. This replaces `SubdailyScaler` and bundles all of the
-  settings for acclimation into a single class. The following **breaking change**:
+  settings for acclimation into a single class. The following is therefore a **breaking
+  change**:
   
-  - `SubdailyScaler` has been replaced with `AcclimationModel`.
+  - `SubdailyScaler` has been replaced with `AcclimationModel`, and the following
+    arguments to `SubdailyPModel` are now arguments to `AcclimationModel`: `alpha`,
+    `allow_holdover`, `allow_partial_data`, `update_point`, `fill_kind` (as
+    `fill_method`).
 
 - The legacy implementation `SubdailyPModel_JAMES` has been deprecated. This
   implementation duplicated the original Mengoli et al JAMES code. This was largely a
   proof of concept implementation, misses some key parts of the acclimation model and
   the internal calculations are sufficiently different that there is a high maintenance
-  cost to updating it the new API in version 2.0.0.
+  cost to updating it to the new API in version 2.0.0.
 
   - The `fill_from` argument to `fill_daily_to_subdaily` was only required for
     `SubdailyPModel_JAMES` and so this has also been deprecated.

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -157,3 +157,99 @@ def evaluate_horner_polynomial(
     for c in reversed(cf):
         y = x * y + c
     return y
+
+
+def exponential_moving_average(
+    values: NDArray[np.float64],
+    initial_values: NDArray[np.float64] | None = None,
+    alpha: float = 0.067,
+    allow_holdover: bool = False,
+) -> NDArray[np.float64]:
+    r"""Apply an exponential moving average to a variable.
+
+    This function implements an exponential moving average for an input array, using
+    the parameter `alpha` (:math:`\alpha`) to control the speed of convergence of the
+    smoothed values (:math:`S`) to the input values (:math:`X`):
+
+    .. math::
+
+        S_{t} = S_{t-1}(1 - \alpha) + X_{t} \alpha
+
+    For :math:`t_{0}`, the first value in the input values is used (:math:`S_{0} =
+    X_{0}`), unless alternative initial values are provided. The ``values`` array can
+    have multiple dimensions but the smoothing is only applied along the first
+    dimension, which is assumed to represent time.
+
+    By default, the ``values`` array must not contain any missing values (`numpy.nan`).
+    However, when ``allow_holdover`` is set then the function attempts to handle missing
+    data by holding over the last non-missing smoothed value. This obviously cannot
+    replace missing data at the start of a sequence, but after this if the current input
+    value is missing, then the previous smoothed value will be recycled until it can
+    next be updated from the input data.
+
+    +-------------------+--------+-------------------------------------------------+
+    |                   |        |   Current input data (:math:`X_{t}`)            |
+    +-------------------+--------+-----------------+-------------------------------+
+    |                   |        |     NA          |   not NA                      |
+    +-------------------+--------+-----------------+-------------------------------+
+    | Previous          |    NA  |     NA          |     X_{t}                     |
+    | smoothed data     +--------+-----------------+-------------------------------+
+    | (:math:`S_{t-1}`) | not NA | :math:`S_{t-1}` | :math:`S_{t-1}(1-a) + X_{t}a` |
+    +-------------------+--------+-----------------+-------------------------------+
+
+    Args:
+        values: The values to apply the memory effect to.
+        initial_values: Values to use at :math:`S_{0}` in place of :math:`X_{0}`.
+        alpha: The relative weight applied to the most recent observation.
+        allow_holdover: Allow missing values to be filled by holding over earlier
+            values.
+
+    Returns:
+        An array of the same shape as ``values`` with the memory effect applied.
+    """
+
+    # Check for nan and nan handling
+    nan_present = np.any(np.isnan(values))
+    if nan_present and not allow_holdover:
+        raise ValueError("Missing values in data passed to exponential_moving_average")
+
+    # Initialise the output storage and set the first values to be a slice along the
+    # first axis of the input values
+    smoothed_values = np.empty_like(values, dtype=np.float64)
+    if initial_values is None:
+        smoothed_values[0] = values[0]
+    else:
+        smoothed_values[0] = initial_values * (1 - alpha) + values[0] * alpha
+
+    # Handle the data if there are no missing data,
+    if not nan_present:
+        # Loop over the first axis, in each case taking slices through the first axis of
+        # the inputs. This handles arrays of any dimension.
+        for idx in range(1, len(smoothed_values)):
+            smoothed_values[idx] = (
+                smoothed_values[idx - 1] * (1 - alpha) + values[idx] * alpha
+            )
+
+        return smoothed_values
+
+    # Otherwise, do the same thing but handling missing data at each step.
+    for idx in range(1, len(smoothed_values)):
+        # Need to check for nan conditions:
+        # - the previous value might be nan from an initial nan or sequence of nans, in
+        #   which case the current value is accepted without weighting - it could be nan
+        #   itself to extend a chain of initial nan values.
+        # - the current value might be nan, in which case the previous value gets
+        #   held over as the current value.
+        prev_nan = np.isnan(smoothed_values[idx - 1])
+        curr_nan = np.isnan(values[idx])
+        smoothed_values[idx] = np.where(
+            prev_nan,
+            values[idx],
+            np.where(
+                curr_nan,
+                smoothed_values[idx - 1],
+                smoothed_values[idx - 1] * (1 - alpha) + values[idx] * alpha,
+            ),
+        )
+
+    return smoothed_values

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -1,0 +1,671 @@
+"""The :mod:`~pyrealm.pmodel.acclimation` module provides the
+:class:`~pyrealm.pmodel.acclimation.AcclimationModel` class, which is a required input
+to the :class:`~pyrealm.pmodel.new_pmodel.SubdailyPModelNew` class for fitting the P
+Model at subdaily time scales. The class is used as follows:
+
+* A :class:`~pyrealm.pmodel.acclimation.AcclimationModel` instance is created using
+  the time series of the observations for the subdaily data being used within a model.
+  The acclimation behaviour can be modified through other arguments to the class
+  constructor.
+
+* An acclimation window is then set, defining a period of the day representing the
+  environmental conditions that plants will acclimate to. This will typically by the
+  time of day with highest productivity - usually around noon - when the light use
+  efficiency of the plant can best make use of high levels of sunlight. The window can
+  be set using one of three methods:
+
+  * The
+    :meth:`AcclimationModel.set_window<~pyrealm.pmodel.acclimation.AcclimationModel.set_window>`
+    method sets a window centred on a given time during the day with a fixed width.
+  * The
+    :meth:`AcclimationModel.set_nearest<~pyrealm.pmodel.acclimation.AcclimationModel.set_nearest>`
+    method sets the acclimation window as the single observation closest to a given time
+    of day.
+  * The
+    :meth:`AcclimationModel.set_include<~pyrealm.pmodel.acclimation.AcclimationModel.set_include>`
+    method allows the user to set an arbitrary selection of observations during the day
+    as the acclimation window.
+
+  If new ``set_`` functions are defined, then they will need to call the
+  :meth:`~pyrealm.pmodel.acclimation.AcclimationModel._set_sampling_times` method to
+  update the instance attributes used to set the acclimation window.
+
+* The :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_daily_means` method
+  can then be used to get the average value of a variable within the acclimation window
+  for each day. Alternatively, the
+  :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_window_values` method can
+  be used to get the actual values observed during each daily window.
+
+* The :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.fill_daily_to_subdaily`
+  reverses this process: it takes an array of daily values and fills those values back
+  onto the faster timescale used to create the
+  :class:`~pyrealm.pmodel.acclimation.AcclimationModel` instance.
+"""  # noqa: D205, D415
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.interpolate import interp1d  # type: ignore
+
+from pyrealm.core.utilities import exponential_moving_average
+
+
+class AcclimationModel:
+    """Define the acclimation model to be used for the subdaily P Model.
+
+    This class provides methods that allow data to be converted between
+    photsynthetically 'fast' and 'slow' timescales. Many plant responses to changing
+    enviroments are 'fast' - on the scale of minutes to seconds - but other responses
+    are slow - over the scale of days or weeks, capturing the timescales over which
+    plants will acclimate to changing conditions.
+
+    An instance of this class is created using an array of :class:`numpy.datetime64`
+    values that provide the observation datetimes for a dataset sampled on a 'fast'
+    timescale. The datetimes must:
+
+    * be strictly increasing,
+    * be evenly spaced, using a spacing that evenly divides a day, and
+    * completely cover a set of days.
+
+    The additional arguments to the class set:
+
+    * The weighting (``alpha``) that sets the speed of acclimation. This value must be
+      between 0 and 1 and is used as the weight term in an exponential moving average of
+      daily values. Values closer to 1 lead to faster acclimation, with 1 giving
+      instantaneous acclimation and 0 giving no acclimation.
+
+    * The update point sets the point on the subdaily scale at which the plant updates
+      acclimating variables to the new daily realised value. TODO describe
+
+    *
+
+    .. info::
+
+        The values in ``datetimes`` are assumed to be the precise times of the
+        observations and are converted to second precision for internal calculations. If
+        the datetimes are at a _coarser_ precision and represent a sampling time span,
+        then they should first be converted to a reasonable choice of observation time,
+        such as the midpoint of the timespan.
+
+    Args:
+        datetimes: A sequence of datetimes for observations at a subdaily scale.
+        alpha: A weighting used to set the speed of acclimation
+        allow_holdover:
+        allow_partial_data:
+        fill_method:
+        previous_realised:
+
+        previous_value: An array with dimensions equal to a slice across the first
+            axis of the values array.
+        update_point: The point in the acclimation window at which the plant updates
+            to the new daily value: one of 'mean' or 'max'.
+        kind: The kind of interpolation to use to fill between daily values: one of
+            'previous' or 'linear',
+
+
+    """
+
+    def __init__(
+        self,
+        datetimes: NDArray[np.datetime64],
+        alpha: float = 1 / 15,
+        update_point: str = "max",
+        fill_method: str = "previous",
+        allow_holdover: bool = False,
+        allow_partial_data: bool = False,
+        # initial_values: dict[str, NDArray] | None = None,
+    ) -> None:
+        # __init__ arguments
+        self.datetimes: NDArray[np.datetime64]
+        """The datetimes used to create the instance."""
+        self.alpha: float = alpha
+        """The weighting term for estimation of acclimated values."""
+        self.allow_holdover: bool = allow_holdover
+        """TODO."""
+        self.allow_partial_data: bool = allow_partial_data
+        """TODO."""
+        self.fill_method: str = fill_method
+        """TODO."""
+        # self.initial_values: dict[str, NDArray] | None = initial_values
+        # """TODO."""
+        self.update_point: str = update_point
+        """TODO."""
+
+        # Validation of __init__ arguments
+
+        if not (0 <= self.alpha <= 1):
+            raise ValueError("The alpha value must be in [0,1]")
+
+        if self.update_point not in ("mean", "max"):
+            raise ValueError(
+                f"The update_point option must be one of "
+                f"'mean' or 'max', not: '{self.update_point}'"
+            )
+
+        if self.fill_method not in ("linear", "previous"):
+            raise ValueError(
+                f"The fill_method option must be one of "
+                f"'linear' or 'previous', not: '{self.fill_method}'"
+            )
+
+        # if self.initial_values is not None:
+        #     missing_initial_vars = set(["xi", "jmax25", "vcmax25"]).difference(
+        #         self.initial_values.keys()
+        #     )
+
+        #     if missing_initial_vars:
+        #         raise ValueError(
+        #             f"The initial_values dictionary does not provide values for: "
+        #             f"{', '.join(missing_initial_vars)}"
+        #         )
+
+        # Attributes populated during initialisation by _validate_and_set_datetimes()
+        self.spacing: np.timedelta64
+        """The time interval between observations"""
+        self.observation_dates: NDArray[np.datetime64]
+        """The dates covered by the observations"""
+        self.n_days: int
+        """The number of days covered by the observations"""
+        self.observation_times: NDArray[np.timedelta64]
+        """The times of observations through the day as timedelta64 values in seconds"""
+        self.n_obs: int
+        """The number of daily observations"""
+        self.padding: tuple[int, int]
+        """The number of missing observations on the first and last days.
+
+        Provides the number of observations to add to the start and end of the provided
+        datetime sequence to give complete days."""
+        self.padded_datetimes: NDArray[np.datetime64]
+        """TODO."""
+
+        # Run the initialisation logic steps
+        self._validate_and_set_datetimes(datetimes=datetimes)
+
+        # Attributes populated by the set_* methods
+
+        self.include: NDArray[np.bool_]
+        """Logical index of which daily observations are included in daily samples."""
+        self.sample_datetimes: NDArray[np.datetime64]
+        """Datetimes included in daily samples.
+
+        This array is two-dimensional: the first axis is of length n_days and the second
+        axis is of length n_samples.
+        """
+        self.sample_datetimes_mean: NDArray[np.datetime64]
+        """The mean datetime of for each daily sample."""
+        self.sample_datetimes_max: NDArray[np.datetime64]
+        """The maximum datetime of for each daily sample."""
+
+    def _validate_and_set_datetimes(self, datetimes: NDArray[np.datetime64]) -> None:
+        """Validates the datetimes and sets key timing attributes.
+
+        Args:
+            datetimes: The datetimes to be validated and used to setup the model.
+        """
+
+        # The inputs must be:
+        # - a one dimensional numpy datetime64 array
+        # - stored with second precision
+        # - with strictly increasing time deltas that are both evenly spaced and evenly
+        #   divisible into a day
+        if (
+            not isinstance(datetimes, np.ndarray)
+            or (datetimes.ndim > 1)
+            or not np.issubdtype(datetimes.dtype, np.datetime64)
+        ):
+            raise ValueError(
+                "Datetimes are not a 1 dimensional array with dtype datetime64"
+            )
+
+        # Update precision
+        datetimes = datetimes.astype("datetime64[s]")
+
+        # Check spacings between datetimes are all equal
+        all_spacings = set(np.diff(datetimes))
+        if len(all_spacings) > 1:
+            raise ValueError("Datetime sequence not evenly spaced")
+
+        spacing = all_spacings.pop()
+
+        if spacing < 0:
+            raise ValueError("Datetime sequence must be increasing")
+
+        # Work out observations by date and look for incomplete dates at the start and
+        # end of the time sequence
+        dates = datetimes.astype("datetime64[D]")
+        unique_dates, date_counts = np.unique(dates, return_counts=True)
+
+        # Do we have at least three complete day to ensure we have a complete set of
+        # observation times on day 2. Three days is not sensible for the model but this
+        # ensures the padding can de determined.
+        if len(unique_dates) < 3:
+            ValueError("Not enough data to validate observation times")
+
+        # Get the maximum number of observations per day and check it is evenly
+        # divisible by the number of seconds in a day.
+        obs_per_date = date_counts.max()
+        day_remainder = (24 * 60 * 60) % obs_per_date
+        if day_remainder:
+            raise ValueError("Datetime spacing is not evenly divisible into a day")
+
+        # Now populate attributes
+
+        self.datetimes = datetimes
+        self.spacing = spacing
+
+        # Set the datetime padding
+        self.padding = (
+            obs_per_date - date_counts[0],
+            obs_per_date - date_counts[-1],
+        )
+
+        # Get a complete set of observation times from day 2 - we have guaranteed
+        # that the second day is complete.
+        complete_times = datetimes[dates == unique_dates[1]]
+        observation_timedeltas = complete_times - complete_times[0].astype(
+            "datetime64[D]"
+        )
+
+        # Add padded datetimes as a time series containing only complete days, using an
+        # offset to the last observations to avoid an off by one error from np.arange.
+        self.padded_datetimes = np.arange(
+            unique_dates[0] + observation_timedeltas[0],
+            unique_dates[-1] + (observation_timedeltas[-1] + np.timedelta64(1, "s")),
+            np.diff(observation_timedeltas)[0],
+        )
+
+        self.observation_dates = unique_dates
+        self.n_days = len(self.observation_dates)
+        self.observation_times = observation_timedeltas
+        self.n_obs = len(self.observation_times)
+
+    def _set_sampling_times(self) -> None:
+        """Sets the times at which representative values are sampled.
+
+        This private method should be called by all ``set_`` methods. It is used to
+        update the instance to populate the following attributes:
+
+        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes`: An
+          array of the datetimes of observations included in daily samples of shape
+          (n_day, n_sample).
+        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_mean`:
+          An array of the mean daily datetime of observations included in daily samples.
+        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_max`:
+          An array of the maximum daily datetime of observations included in daily
+          samples.
+        """
+
+        # Get a view of the complete padded datetimes and then reshape along the first
+        # axis into daily subarrays.
+        times_by_day = self.padded_datetimes.view()
+        times_by_day.shape = tuple([self.n_days, self.n_obs])
+
+        # subset to the included daily values
+        self.sample_datetimes = times_by_day[:, self.include]
+
+        # Cannot use mean directly, so calculate the mean of the values expressed
+        # as seconds and then add the mean values back onto the epoch.
+        now = np.datetime64("now", "s")
+        epoch = now - np.timedelta64(now.astype(int), "s")
+        datetimes_as_seconds = self.sample_datetimes.astype(int)
+        mean_since_epoch = datetimes_as_seconds.mean(axis=1).round().astype(int)
+        max_since_epoch = datetimes_as_seconds.max(axis=1).round().astype(int)
+
+        self.sample_datetimes_mean = epoch + mean_since_epoch.astype("timedelta64[s]")
+        self.sample_datetimes_max = epoch + max_since_epoch.astype("timedelta64[s]")
+
+    def set_window(
+        self, window_center: np.timedelta64, half_width: np.timedelta64
+    ) -> None:
+        """Set a daily window to sample.
+
+        This method sets the daily values to sample using a time window, given the time
+        of the window centre and its width. Both of these values must be provided as
+        :class:`~numpy.timedelta64` values.
+
+        Args:
+            window_center: A timedelta since midnight to use as the window center
+            half_width: A timedelta to use as a window width on each side of the center
+        """
+
+        if not (
+            isinstance(window_center, np.timedelta64)
+            and isinstance(half_width, np.timedelta64)
+        ):
+            raise ValueError(
+                "window_center and half_width must be np.timedelta64 values"
+            )
+
+        # Find the timedeltas of the window start and end, using second resolution
+        win_start = (window_center - half_width).astype("timedelta64[s]")
+        win_end = (window_center + half_width).astype("timedelta64[s]")
+
+        # Does that include more than one day?
+        # NOTE - this might actually be needed at some point!
+        if (win_start < 0) or (win_end > 86400):
+            raise ValueError("window_center and half_width cover more than one day")
+
+        # Now find which observation fall inclusively within that time window
+        self.include = np.logical_and(
+            win_start <= self.observation_times,
+            win_end >= self.observation_times,
+        )
+        self.set_method = f"Window ({window_center}, {half_width})"
+        self._set_sampling_times()
+
+    def set_include(self, include: NDArray[np.bool_]) -> None:
+        """Set a sequence of daily values to sample.
+
+        This method sets which daily values will be sampled directly, by providing a
+        boolean array for the daily observation times. The ``include`` array must be of
+        the same length as the number of daily observations.
+
+        Args:
+            include: A boolean array indicating which daily observations to include.
+        """
+
+        if not (isinstance(include, np.ndarray) and include.dtype == np.bool_):
+            raise ValueError("The include argument must be a boolean array")
+
+        if self.n_obs != len(include):
+            raise ValueError("The include array length is of the wrong length")
+
+        self.include = include
+        self.method = "Include array"
+        self._set_sampling_times()
+
+    def set_nearest(self, time: np.timedelta64) -> None:
+        """Sets a single observation closest to a target time to be sampled.
+
+        This method finds the daily observation time closest to a value provided as a
+        :class:`~numpy.timedelta64` value since midnight. If the provided time is
+        exactly between two observation times, the earlier observation will be used.
+        The resulting single observation will then as the daily sample.
+
+        Args:
+            time: A :class:`~numpy.timedelta64` value.
+        """
+
+        if not isinstance(time, np.timedelta64):
+            raise ValueError("The time argument must be a timedelta64 value.")
+
+        # Convert to seconds and check it is in range
+        time = time.astype("timedelta64[s]")
+        if not (time >= 0 and time < 24 * 60 * 60):
+            raise ValueError("The time argument is not >= 0 and < 24 hours.")
+
+        # Calculate the observation time closest to the provided value
+        nearest = np.argmin(abs(self.observation_times - time))
+        include = np.zeros(self.n_obs, dtype=np.bool_)
+        include[nearest] = True
+
+        self.include = include
+        self.method = f"Set nearest: {time}"
+        self._set_sampling_times()
+
+    def _raise_if_sampling_times_unset(self) -> None:
+        """Check sampling times are set.
+
+        This private method provides shared checking functionality for class methods
+        that require the user to have run one of the ``set_`` methods to set sampling
+        times.
+        """
+
+        if not hasattr(self, "include"):
+            raise AttributeError(
+                "Use a set_ method to select which daily observations "
+                "are used for acclimation"
+            )
+
+    def _pad_values(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Pad values array to full days.
+
+        This method takes an array representing daily values and pads the first and
+        last day with NaN values so that they correspond to full days, similar to the
+        datetimes array of this class.
+
+        Args:
+            values: An array containing the sample values. The first dimension should be
+              matching the number of measurements, i.e., the first dimension of
+              datetimes in
+              :class:`~pyrealm.pmodel.scaler.SubdailyScaler`.
+        """
+
+        if self.padding == (0, 0):
+            return values
+
+        # Construct a padding iterable for np.pad, to pad only the first time axis
+        padding_dims = list((self.padding,))
+        padding_dims.extend([(0, 0)] * (values.ndim - 1))
+
+        return np.pad(values, padding_dims, constant_values=(np.nan, np.nan))
+
+    def get_window_values(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Extract acclimation window values for a variable.
+
+        This method takes an array of values which has the same shape along the first
+        axis as the datetimes used to create the instance and extracts the values from
+        the acclimation window set using one of the ``set_`` methods.
+
+        Args:
+            values: An array of values for each observation.
+
+        Returns:
+            An array of the values within the defined acclimation window
+        """
+
+        self._raise_if_sampling_times_unset()
+
+        # Check that the first axis has the same shape as the number of
+        # datetimes in the init
+        if values.shape[0] != self.datetimes.shape[0]:
+            raise ValueError(
+                "The first dimension of values is not the same length "
+                "as the datetime sequence"
+            )
+
+        # Get a view of the values wrapped by date and then reshape along the first
+        # axis into daily subarrays, leaving any remaining dimensions untouched.
+        # When the values are padded the returned value is automatically a padded copy
+        # of the original data, but if there is no padding, the original data is
+        # returned and using a view and reshape should avoid copying the data.
+        padded_values = self._pad_values(values)
+        values_by_day = padded_values.view()
+        values_by_day.shape = tuple([self.n_days, self.n_obs, *list(values.shape[1:])])
+
+        # subset to the included daily values
+        return values_by_day[:, self.include, ...]
+
+    def get_daily_means(
+        self, values: NDArray[np.float64], allow_partial_data: bool = False
+    ) -> NDArray[np.float64]:
+        """Get the daily means of a variable during the acclimation window.
+
+        This method extracts values from a given variable during a defined acclimation
+        window set using one of the ``set_`` methods, and then calculates the daily mean
+        of those values.
+
+        The `allow_partial_data` option switches between using :func:`numpy.mean` and
+        :func:`numpy.nanmean`, so that daily mean values can be calculated even if the
+        data in the acclimation window is incomplete. Note that this will still return
+        `np.nan` if _no_ data is present in the acclimation window. It also has no
+        effect if the
+        :meth:`~pyrealm.pmodel.scaler.SubdailyScaler.set_nearest` method has
+        been used to set the acclimation observations, because this method only ever
+        sets a single observation.
+
+        The values can have any number of dimensions, but the first dimension must
+        represent the time axis and have the same length as the original set of
+        observation times.
+
+        Args:
+            values: An array of values to reduce to daily averages.
+            allow_partial_data: Exclude missing data from the calculation of the daily
+                average value.
+
+        Returns:
+            An array of mean daily values during the acclimation window
+        """
+
+        self._raise_if_sampling_times_unset()
+
+        daily_values = self.get_window_values(values)
+
+        if allow_partial_data:
+            return np.nanmean(daily_values, axis=1)
+
+        return daily_values.mean(axis=1)
+
+    def fill_daily_to_subdaily(
+        self,
+        values: NDArray[np.float64],
+        initial_values: NDArray[np.float64],
+    ) -> NDArray[np.float64]:
+        """Resample daily variables onto the subdaily time scale.
+
+        This method takes an array representing daily values and interpolates those
+        values back onto the subdaily timescale used to create the
+        :class:`~pyrealm.pmodel.scaler.SubdailyScaler` instance. The first
+        axis of the `values` must be the same length as the number of days used to
+        create the instance.
+
+        The update point defaults to the maximum time of day during the acclimation
+        window. It can also be set to the mean time of day during the acclimation
+        period, but note that this implies that the plant can predict the daily values
+        between the mean and max observation time.
+
+        Two interpolation kinds are currently implemented:
+
+        * ``previous`` interpolates the daily value as a constant, until updating to the
+          next daily value. This option will fill values until the end of the time
+          series. The
+        * ``linear`` interpolates linearly between the update points of the daily
+          values. The interpolated values are held constant for the first day and then
+          interpolated linearly: this is to avoid plants adapting optimally to future
+          conditions.
+
+        Subdaily observations before the update point on the first day of the time
+        series are filled with ``np.nan``. The ``initial_values`` argument can be used
+        to provide alternative initial values, allowing time series to be processed in
+        blocks, but this option is only currently implemented for the ``previous``
+        interpolation method.
+
+        Args:
+            values: An array with the first dimension matching the number of days in the
+                instances :class:`~pyrealm.pmodel.scaler.SubdailyScaler` object.
+            initial_values: An array of initial values for the first value.
+        """
+
+        self._raise_if_sampling_times_unset()
+
+        if values.shape[0] != self.n_days:
+            raise ValueError(f"Values is not of length {self.n_days} on its first axis")
+
+        if self.update_point == "max":
+            update_time = self.sample_datetimes_max
+        elif self.update_point == "mean":
+            update_time = self.sample_datetimes_mean
+
+        # Check initial values settings - only allow with previous interpolation and
+        # check the previous value shape matches
+        if initial_values is not None:
+            if self.fill_method == "linear":
+                raise NotImplementedError(
+                    "Using initial_values with kind='linear' is not implemented"
+                )
+
+            # Use np.broadcast_shapes here to handle checking array shapes. This is
+            # mostly to catch the fact that () and (1,) are equivalent.
+            try:
+                np.broadcast_shapes(initial_values.shape, values.shape)
+            except ValueError:
+                raise ValueError(
+                    "The input to initial_values is not congruent with "
+                    "the shape of the observed data"
+                )
+
+        # Use fill_value to handle extrapolation before or after update point:
+        # - previous will fill the last value forward to the end of the time series,
+        #   although this will be bogus if the interpolation time series extends beyond
+        #   the next update point
+        # - linear has a 1 day offset: the plant cannot adapt towards the next optimal
+        #   value until _after_ the update point.
+
+        if self.fill_method == "previous":
+            # The fill values here are used to extend the last daily value out to the
+            # end of the subdaily observations but also to fill any provided previous
+            # values for subdaily observations _before_ the first daily value. If
+            # the default previous value of None is supplied, this inserts np.nan as
+            # expected.
+            fill_value = (initial_values, values[-1])
+        elif self.fill_method == "linear":
+            # Shift the values forward by a day, inserting a copy of the first day at
+            # the start. This then avoids plants seeing the future and provides values
+            # up until the last observation.
+            values = np.insert(values, 0, values[0], axis=0)
+            update_time = np.append(
+                update_time, update_time[-1] + np.timedelta64(1, "D")
+            )
+            fill_value = (np.array(np.nan), np.array(np.nan))
+
+        # Note that interp1d cannot handle datetime64 inputs, so need to interpolate
+        # using datetimes cast to integer types
+        interp_fun = interp1d(
+            update_time.astype("int"),
+            values,
+            axis=0,
+            kind=self.fill_method,
+            bounds_error=False,
+            fill_value=fill_value,
+            assume_sorted=True,
+        )
+
+        # TODO - The kind "previous" might be replaceable with bottleneck.push
+        #
+        # v = np.empty_like(tk)
+        # v[:] = np.nan
+
+        # v[values_idx] = values
+        # v = bn.push(v)
+
+        return interp_fun(self.datetimes.astype("int"))
+
+    def apply_acclimation(
+        self,
+        values: NDArray[np.float64],
+        initial_values: NDArray[np.float64] | None = None,
+    ) -> NDArray[np.float64]:
+        r"""Apply acclimation to optimal values.
+
+        Three key photosynthetic parameters (:math:`\xi`, :math:`V_{cmax25}` and
+        :math:`J_{max25}`) show slow responses to changing environmental conditions and
+        do not instantaneously adopt optimal values. This function applies exponential
+        weighted averaging to the input values in order to calculate a lagged response.
+        The ``alpha`` parameter of the ``AcclimationModel`` is used to control the speed
+        of acclimation.
+
+        The weighted average process iterates over daily observations and so cannot
+        normally be calculated with missing data. However, missing forcing data is
+        common and both :math:`V_{cmax}` and :math:`J_{max}` are not estimable in some
+        conditions (namely when :math:`m \le c^{\ast}`, see
+        :class:`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14`) and so missing values
+        in P Model predictions can arise even when the forcing data is complete. The
+        ``allow_holdover`` setting for the ``AcclimationModel` is used to allow the
+        exponential weighted average function to handle missing data (see
+        :func:`~pyrealm.core.utilities.exponential_moving_average` for details).
+
+        Args:
+            values: An array of daily optimal values
+            initial_values: Alternative starting values for the acclimated values
+        """
+
+        try:
+            return exponential_moving_average(
+                values=values,
+                initial_values=initial_values,
+                alpha=self.alpha,
+                allow_holdover=self.allow_holdover,
+            )
+        except ValueError:
+            raise ValueError(
+                "Missing data in input values, try setting allow_holdover=True"
+            )

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -31,12 +31,12 @@ class AcclimationModel:
     The model can handle incomplete days at the start and end of the time series and
     will internally pad the datetimes to complete days in order to ensure correct
     sampling. The values in ``datetimes`` are assumed to be the precise times of the
-    observations. If the datetimes are represent the start or end of a sampling time
-    span, then they should first be converted to a reasonable choice of observation
-    time, such as the midpoint of the timespan.
+    observations. If the datetimes represent the start or end of a sampling time span,
+    then they should first be converted to a reasonable choice of observation time, such
+    as the midpoint of the timespan.
 
     An acclimation window must then be set, defining a period of the day representing
-    the environmental conditions that plants will acclimate to. This will typically by
+    the environmental conditions that plants will acclimate to. This will typically be
     the time of day with highest productivity - usually around noon - when the light use
     efficiency of the plant can best make use of high levels of sunlight. This window is
     set using one of the following methods:
@@ -77,18 +77,31 @@ class AcclimationModel:
         settings are shared for all variables to which the given Acclimation model is
         applied.
 
+        The argument description below describes the role of each setting but more
+        details are also provided in the linked method descriptions.
+
     Args:
         datetimes: A sequence of datetimes for observations at a subdaily scale.
-        allow_partial_data: See
+        allow_partial_data: Allows the
             :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_daily_means`
-        alpha: See
+            method to switch between using :func:`numpy.mean` and :func:`numpy.nanmean`,
+            so that daily mean values can be calculated even if the data in the
+            acclimation window is incomplete.
+        alpha: A float value that controls the speed of acclimation in the
             :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.apply_acclimation`
-        allow_holdover: See
+            method. The value must be in the range [0, 1], with smaller values giving
+            slower acclimation and larger values giving quicker acclimation.
+        allow_holdover: Allows the
             :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.apply_acclimation`
-        update_point: See
+            method to adapt to missing values in the acclimation time series.
+        update_point: Used in the
             :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.fill_daily_to_subdaily`
-        fill_method: See
+            method to set when plant behaviour updates to the conditions within the
+            acclimation window. One of ``max`` (default) or ``mean``.
+        fill_method: Used in the
             :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.fill_daily_to_subdaily`
+            method to set the interpolation method used to fill subdaily observations.
+            One of ``previous`` (default) or ``linear``.
     """
 
     def __init__(
@@ -359,7 +372,7 @@ class AcclimationModel:
         This method finds the daily observation time closest to a value provided as a
         :class:`~numpy.timedelta64` value since midnight. If the provided time is
         exactly between two observation times, the earlier observation will be used.
-        The resulting single observation will then as the daily sample.
+        The resulting single observation will then be used as the daily sample.
 
         Args:
             time: A :class:`~numpy.timedelta64` value.
@@ -561,7 +574,7 @@ class AcclimationModel:
           the plant updates acclimating variables to the new daily realised value. The
           default is ``max`` - the plant starts to acclimate to a new value at the end
           of the acclimation window - but this can also be set to ``mean`` to start
-          acclimation from the middle of the acclimation  window. Note that this setting
+          acclimation from the middle of the acclimation window. Note that this setting
           implies the plant can predict the daily values between the mean and max
           observation time.
 

--- a/tests/unit/core/test_exponential_moving_average.py
+++ b/tests/unit/core/test_exponential_moving_average.py
@@ -25,9 +25,9 @@ import pytest
 def test_exponential_moving_average(inputs, alpha):
     """Test the exponential_moving_average.
 
-    This uses matrix maths to calculate expected by calculating the coefficients of the
-    recursive equation. Does not scale well, but a useful parallel implementation for
-    testing.
+    This uses matrix maths to calculate expected values by calculating the coefficients
+    of the recursive equation. Does not scale well, but a useful parallel implementation
+    for testing.
     """
     from pyrealm.core.utilities import exponential_moving_average
 

--- a/tests/unit/core/test_exponential_moving_average.py
+++ b/tests/unit/core/test_exponential_moving_average.py
@@ -70,7 +70,7 @@ def test_exponential_moving_average(inputs, alpha):
     ],
 )
 @pytest.mark.parametrize(argnames="alpha", argvalues=(0.0, 0.5, 1.0))
-def test_memory_effect_chunked(inputs_whole, alpha):
+def test_exponential_moving_average_chunked(inputs_whole, alpha):
     """Test the implementation of initial values in exponential_moving_average.
 
     This compares the output of a single run to the same data fed in as two sequential

--- a/tests/unit/core/test_exponential_moving_average.py
+++ b/tests/unit/core/test_exponential_moving_average.py
@@ -1,0 +1,142 @@
+"""Tests the implementation of the exponential moving average function."""
+
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    argnames="inputs",
+    argvalues=[
+        pytest.param(np.arange(0, 10), id="1D"),
+        pytest.param(
+            np.column_stack([np.arange(0, 10)] * 4) + np.arange(4),
+            id="2D",
+        ),
+        pytest.param(
+            np.dstack([np.column_stack([np.arange(0, 10)] * 4)] * 4)
+            + np.arange(16).reshape(4, 4),
+            id="3D",
+        ),
+    ],
+)
+@pytest.mark.parametrize(argnames="alpha", argvalues=(0.0, 0.2, 0.4, 0.6, 0.8, 1.0))
+def test_exponential_moving_average(inputs, alpha):
+    """Test the exponential_moving_average.
+
+    This uses matrix maths to calculate expected by calculating the coefficients of the
+    recursive equation. Does not scale well, but a useful parallel implementation for
+    testing.
+    """
+    from pyrealm.core.utilities import exponential_moving_average
+
+    result = exponential_moving_average(inputs, alpha=alpha)
+
+    # Calculate the coefficients for product sum of the elements along the time axis
+    one_minus_alpha = 1 - alpha
+    n = len(inputs)
+    ident = np.identity(n)
+    nan = np.ones_like(ident) * np.nan
+    rw, cl = np.indices(ident.shape)
+    rwcl = rw - cl
+    one_minus_alpha_exp = np.where(rwcl >= 0, rwcl, nan)
+    alpha_exp = np.where(rwcl >= 0, 1, nan)
+    alpha_exp[:, 0] = 0
+
+    coef = one_minus_alpha**one_minus_alpha_exp * alpha**alpha_exp
+    coef = np.where(np.triu(coef, k=1), 0, coef)
+
+    # Calculate the tensor dot product of the coefficients and the inputs along the
+    # first (time) axis.
+    expected = np.tensordot(coef, inputs, axes=1)
+
+    assert np.allclose(result, expected)
+
+
+@pytest.mark.parametrize(
+    argnames="inputs_whole",
+    argvalues=[
+        pytest.param(np.arange(0, 10), id="1D"),
+        pytest.param(
+            np.column_stack([np.arange(0, 10)] * 4) + np.arange(4),
+            id="2D",
+        ),
+        pytest.param(
+            np.dstack([np.column_stack([np.arange(0, 10)] * 4)] * 4)
+            + np.arange(16).reshape(4, 4),
+            id="3D",
+        ),
+    ],
+)
+@pytest.mark.parametrize(argnames="alpha", argvalues=(0.0, 0.5, 1.0))
+def test_memory_effect_chunked(inputs_whole, alpha):
+    """Test the implementation of initial values in exponential_moving_average.
+
+    This compares the output of a single run to the same data fed in as two sequential
+    time chunks but with the second one set to use the correct initial conditions.
+    """
+    from pyrealm.core.utilities import exponential_moving_average
+
+    result_whole = exponential_moving_average(inputs_whole, alpha=alpha)
+
+    [inputs_chunk1, inputs_chunk2] = np.split(inputs_whole, [5], axis=0)
+
+    result_chunk1 = exponential_moving_average(inputs_chunk1, alpha=alpha)
+
+    result_chunk2 = exponential_moving_average(
+        inputs_chunk2, initial_values=result_chunk1[-1], alpha=alpha
+    )
+
+    assert np.allclose(result_whole[-1], result_chunk2[-1])
+
+
+@pytest.mark.parametrize(
+    argnames="inputs,allow_holdover,context_manager,expected",
+    argvalues=[
+        pytest.param(
+            np.arange(1, 8),
+            False,
+            does_not_raise(),
+            np.array([1.0, 1.1, 1.29, 1.561, 1.9049, 2.31441, 2.782969]),
+            id="no missing data",
+        ),
+        pytest.param(
+            np.array([1, 2, 3, 4, np.nan, np.nan, 7]),
+            False,
+            pytest.raises(ValueError),
+            None,
+            id="unhandled missing data",
+        ),
+        pytest.param(
+            np.array([1, 2, 3, 4, np.nan, np.nan, 7]),
+            True,
+            does_not_raise(),
+            np.array([1.0, 1.1, 1.29, 1.561, 1.561, 1.561, 2.1049]),
+            id="handled missing data",
+        ),
+    ],
+)
+@pytest.mark.parametrize(argnames="ndim", argvalues=(1, 2, 3))
+def test_exponential_moving_average_inputs(
+    inputs, allow_holdover, context_manager, expected, ndim
+):
+    """Simple testing of nan handling and predictions across multiple dimensions."""
+    from pyrealm.core.utilities import exponential_moving_average
+
+    if ndim == 2:
+        inputs = np.broadcast_to(inputs[:, np.newaxis], (7, 2))
+        if expected is not None:
+            expected = np.broadcast_to(expected[:, np.newaxis], (7, 2))
+
+    if ndim == 3:
+        inputs = np.broadcast_to(inputs[:, np.newaxis, np.newaxis], (7, 2, 2))
+        if expected is not None:
+            expected = np.broadcast_to(expected[:, np.newaxis, np.newaxis], (7, 2, 2))
+
+    with context_manager:
+        results = exponential_moving_average(
+            inputs, allow_holdover=allow_holdover, alpha=0.1
+        )
+
+        assert np.allclose(results, expected)

--- a/tests/unit/pmodel/test_acclimation_model.py
+++ b/tests/unit/pmodel/test_acclimation_model.py
@@ -737,31 +737,44 @@ class Test_AcclimationModel_get_daily_means_window_and_include:
     """
 
     def test_AcclimationModel_get_daily_means_with_set_window(
-        self, fixture_AcclimationModel, values, expected_means, allow_partial_data
+        self, values, expected_means, allow_partial_data
     ):
         """Test get_daily_means with set_window."""
-        fixture_AcclimationModel.set_window(
+        from pyrealm.pmodel.acclimation import AcclimationModel
+
+        # Setup the acclimation model
+
+        acclim_model = AcclimationModel(
+            datetimes=DATES, allow_partial_data=allow_partial_data
+        )
+
+        """Test get_daily_means with set_window."""
+        acclim_model.set_window(
             window_center=np.timedelta64(12, "h"),
             half_width=np.timedelta64(2, "h"),
         )
-        calculated_means = fixture_AcclimationModel.get_daily_means(
-            values, allow_partial_data=allow_partial_data
-        )
+        calculated_means = acclim_model.get_daily_means(values)
 
         assert np.allclose(calculated_means, expected_means, equal_nan=True)
 
     def test_AcclimationModel_get_daily_means_with_set_include(
-        self, fixture_AcclimationModel, values, expected_means, allow_partial_data
+        self, values, expected_means, allow_partial_data
     ):
         """Test get_daily_means with set_include."""
+
+        from pyrealm.pmodel.acclimation import AcclimationModel
+
+        # Setup the acclimation model
+
+        acclim_model = AcclimationModel(
+            datetimes=DATES, allow_partial_data=allow_partial_data
+        )
 
         # This duplicates the selection of the window test but using direct include
         inc = np.zeros(48, dtype=np.bool_)
         inc[20:29] = True
-        fixture_AcclimationModel.set_include(inc)
-        calculated_means = fixture_AcclimationModel.get_daily_means(
-            values, allow_partial_data=allow_partial_data
-        )
+        acclim_model.set_include(inc)
+        calculated_means = acclim_model.get_daily_means(values)
 
         assert np.allclose(calculated_means, expected_means, equal_nan=True)
 

--- a/tests/unit/pmodel/test_acclimation_model.py
+++ b/tests/unit/pmodel/test_acclimation_model.py
@@ -1,0 +1,1153 @@
+"""This module tests the AcclimationModel class.
+
+This class handles estimating daily reference values and then interpolating estimates of
+daily acclimated values back to subdaily time scales.
+"""
+
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+# --------------------------------------------------------------------------------
+# Testing AcclimationModel __init__ and _validate_and_set_datetimes
+# --------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    argnames="ctext_mngr, msg, kwargs",
+    argvalues=[
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetimes are not a 1 dimensional array with dtype datetime64",
+            dict(datetimes="not_even_a_numpy_array"),
+            id="Not an array datetimes",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetimes are not a 1 dimensional array with dtype datetime64",
+            dict(datetimes=np.arange(0, 144)),
+            id="Non-datetime64 datetimes",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetimes are not a 1 dimensional array with dtype datetime64",
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ).reshape((2, 144))
+            ),
+            id="Non-1D datetimes",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetime sequence not evenly spaced",
+            dict(
+                datetimes=np.datetime64("2014-06-01 12:00")
+                + np.cumsum(np.random.randint(25, 35, 144)).astype("timedelta64[m]")
+            ),
+            id="Uneven sampling",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetime sequence must be increasing",
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-07 00:00"),
+                    np.datetime64("2014-06-01 00:00"),
+                    np.timedelta64(-30, "m"),
+                    dtype="datetime64[s]",
+                )
+            ),
+            id="Negative timedeltas",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "Datetime spacing is not evenly divisible into a day",
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(21, "m"),
+                    dtype="datetime64[s]",
+                )
+            ),
+            id="Spacing not evenly divisible",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 12:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                )
+            ),
+            id="Not complete days by length",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 12:00"),
+                    np.datetime64("2014-06-07 12:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                )
+            ),
+            id="Not complete days by wrapping",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                )
+            ),
+            id="Correct",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The alpha value must be in [0,1]",
+            dict(
+                alpha=-0.01,
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Bad alpha low",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The alpha value must be in [0,1]",
+            dict(
+                alpha=1.01,
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Bad alpha high",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                alpha=0.5,
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Alpha OK",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The update_point option must be one of 'mean' or 'max', not: 'min'",
+            dict(
+                alpha=0.5,
+                update_point="min",
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Update point bad",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                alpha=0.5,
+                update_point="mean",
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Update point OK",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The fill_method option must be one of 'linear' or "
+            "'previous', not: 'cubic'",
+            dict(
+                alpha=0.5,
+                update_point="max",
+                fill_method="cubic",
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="Update point bad",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                alpha=0.5,
+                update_point="mean",
+                fill_method="previous",
+                datetimes=np.arange(
+                    np.datetime64("2014-06-01 00:00"),
+                    np.datetime64("2014-06-07 00:00"),
+                    np.timedelta64(30, "m"),
+                    dtype="datetime64[s]",
+                ),
+            ),
+            id="fill method ok",
+        ),
+    ],
+)
+def test_AcclimationModel_init(ctext_mngr, msg, kwargs):
+    """Test the AcclimationModel __init__ handling.
+
+    This also tests the private method _validate_and_set_datetimes, which is called from
+    within __init__.
+    """
+    from pyrealm.pmodel.acclimation import AcclimationModel
+
+    with ctext_mngr as cman:
+        _ = AcclimationModel(**kwargs)
+
+    if msg is not None:
+        assert str(cman.value) == msg
+
+
+# --------------------------------------------------------------------------------
+# Testing AcclimationModel set_* methods
+# --------------------------------------------------------------------------------
+
+
+# Some widely used arrays in the tests - data series with initial np.nans to test
+# the behaviour of allow_partial_data. Three days of half hourly data = 144 values.
+PARTIAL_ONES = np.repeat([np.nan, 1], [24, 144 - 24])
+PARTIAL_VARYING = np.concatenate([[np.nan] * 24, np.arange(24, 144)])
+DATES = np.arange(
+    np.datetime64("2014-06-01 00:00"),
+    np.datetime64("2014-06-04 00:00"),
+    np.timedelta64(30, "m"),
+    dtype="datetime64[s]",
+)
+
+
+@pytest.fixture
+def fixture_AcclimationModel():
+    """A fixture providing an AcclimationModel object."""
+    from pyrealm.pmodel.acclimation import AcclimationModel
+
+    return AcclimationModel(datetimes=DATES)
+
+
+@pytest.mark.parametrize(
+    argnames=["ctext_mngr", "msg", "kwargs", "samp_mean", "samp_max"],
+    argvalues=[
+        pytest.param(
+            pytest.raises(ValueError),
+            "window_center and half_width must be np.timedelta64 values",
+            dict(window_center=21, half_width=12),
+            None,
+            None,
+            id="not np.timedeltas",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "window_center and half_width cover more than one day",
+            dict(
+                window_center=np.timedelta64(21, "h"),
+                half_width=np.timedelta64(6, "h"),
+            ),
+            None,
+            None,
+            id="window > day",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            dict(
+                window_center=np.timedelta64(12, "h"),
+                half_width=np.timedelta64(1, "h"),
+            ),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([0, 24, 48], dtype="timedelta64[h]"),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([1, 25, 49], dtype="timedelta64[h]"),
+            id="correct",
+        ),
+    ],
+)
+def test_AcclimationModel_set_window(
+    fixture_AcclimationModel, ctext_mngr, msg, kwargs, samp_mean, samp_max
+):
+    """Test the SubdailyScaler set_window method."""
+
+    with ctext_mngr as cman:
+        fixture_AcclimationModel.set_window(**kwargs)
+
+    if msg is not None:
+        assert str(cman.value) == msg
+    else:
+        # Check that _set_times has run correctly. Can't use allclose directly on
+        # datetimes and since these are integers under the hood, don't need float
+        # testing
+        assert np.all(fixture_AcclimationModel.sample_datetimes_mean == samp_mean)
+        assert np.all(fixture_AcclimationModel.sample_datetimes_max == samp_max)
+
+
+@pytest.mark.parametrize(
+    argnames=["ctext_mngr", "msg", "include", "samp_mean", "samp_max"],
+    argvalues=[
+        pytest.param(
+            pytest.raises(ValueError),
+            "The include array length is of the wrong length",
+            np.ones(76, dtype=np.bool_),
+            None,
+            None,
+            id="wrong length",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The include argument must be a boolean array",
+            np.ones(48),
+            None,
+            None,
+            id="wrong dtype",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The include argument must be a boolean array",
+            "not an array at all",
+            None,
+            None,
+            id="wrong type",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            np.repeat([False, True, False], (22, 5, 21)),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([0, 24, 48], dtype="timedelta64[h]"),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([1, 25, 49], dtype="timedelta64[h]"),
+            id="correct - noon window",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            np.ones(48, dtype=np.bool_),
+            np.datetime64("2014-06-01 11:45:00")
+            + np.array([0, 24, 48], dtype="timedelta64[h]"),
+            np.datetime64("2014-06-01 11:30:00")
+            + np.array([12, 36, 60], dtype="timedelta64[h]"),
+            id="correct - whole day",
+        ),
+    ],
+)
+def test_AcclimationModel_set_include(
+    fixture_AcclimationModel, ctext_mngr, msg, include, samp_mean, samp_max
+):
+    """Test the SubdailyScaler set_include method."""
+    with ctext_mngr as cman:
+        fixture_AcclimationModel.set_include(include)
+
+    if msg is not None:
+        assert str(cman.value) == msg
+
+    else:
+        # Check that _set_times has run correctly. Can't use allclose directly on
+        # datetimes and since these are integers under the hood, don't need float
+        # testing
+        assert np.all(fixture_AcclimationModel.sample_datetimes_mean == samp_mean)
+        assert np.all(fixture_AcclimationModel.sample_datetimes_max == samp_max)
+
+
+@pytest.mark.parametrize(
+    argnames=["ctext_mngr", "msg", "time", "samp_mean", "samp_max"],
+    argvalues=[
+        pytest.param(
+            pytest.raises(ValueError),
+            "The time argument must be a timedelta64 value.",
+            "not a time",
+            None,
+            None,
+            id="string input",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The time argument must be a timedelta64 value.",
+            12,
+            None,
+            None,
+            id="float input",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The time argument is not >= 0 and < 24 hours.",
+            np.timedelta64(-1, "h"),
+            None,
+            None,
+            id="time too low",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The time argument is not >= 0 and < 24 hours.",
+            np.timedelta64(24, "h"),
+            None,
+            None,
+            id="time too high",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            np.timedelta64(12, "h"),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([0, 24, 48], dtype="timedelta64[h]"),
+            np.datetime64("2014-06-01 12:00:00")
+            + np.array([0, 24, 48], dtype="timedelta64[h]"),
+            id="correct",
+        ),
+    ],
+)
+def test_AcclimationModel_set_nearest(
+    fixture_AcclimationModel, ctext_mngr, msg, time, samp_mean, samp_max
+):
+    """Test the SubdailyScaler set_nearest method."""
+    with ctext_mngr as cman:
+        fixture_AcclimationModel.set_nearest(time)
+
+    if msg is not None:
+        assert str(cman.value) == msg
+
+    else:
+        # Check that _set_times has run correctly. Can't use allclose directly on
+        # datetimes and since these are integers under the hood, don't need float
+        # testing
+        assert np.all(fixture_AcclimationModel.sample_datetimes_mean == samp_mean)
+        assert np.all(fixture_AcclimationModel.sample_datetimes_max == samp_max)
+
+
+# --------------------------------------------------------------------------------
+# Testing AcclimationModel get_window_values
+# --------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    argnames="values, padding, expected",
+    argvalues=[
+        pytest.param(  # Wrong shape
+            np.ones(10), (0, 0), np.ones(10), id="1D_no_pad"
+        ),
+        pytest.param(
+            np.ones(10),
+            (5, 0),
+            np.repeat((np.nan, 1, np.nan), (5, 10, 0)),
+            id="1D_start_pad",
+        ),
+        pytest.param(
+            np.ones(10),
+            (0, 5),
+            np.repeat((np.nan, 1, np.nan), (0, 10, 5)),
+            id="1D_end_pad",
+        ),
+        pytest.param(
+            np.ones(10),
+            (5, 5),
+            np.repeat((np.nan, 1, np.nan), (5, 10, 5)),
+            id="1D_both_pad",
+        ),
+        pytest.param(
+            np.ones((10, 5)),
+            (3, 2),
+            np.tile(np.repeat((np.nan, 1, np.nan), (3, 10, 2)), (5, 1)).T,
+            id="2D_both_pad",
+        ),
+        pytest.param(
+            np.ones((10, 5, 5)),
+            (2, 3),
+            np.tile(np.repeat((np.nan, 1, np.nan), (2, 10, 3)), (5, 5, 1)).T,
+            id="3D_both_pad",
+        ),
+    ],
+)
+def test_AcclimationModel__pad_values(
+    fixture_AcclimationModel, values, padding, expected
+):
+    """Test padding of values along time axis."""
+    fixture_AcclimationModel.padding = padding
+
+    res = fixture_AcclimationModel._pad_values(values)
+
+    assert_allclose(res, expected)
+
+
+@pytest.mark.parametrize(
+    argnames="ctext_mngr, msg, values, set_window",
+    argvalues=[
+        pytest.param(
+            pytest.raises(AttributeError),
+            "Use a set_ method to select which daily observations "
+            "are used for acclimation",
+            None,
+            False,
+            id="window not set",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The first dimension of values is not the same length "
+            "as the datetime sequence",
+            np.arange(288),
+            True,
+            id="1D too long",
+        ),
+        pytest.param(
+            pytest.raises(ValueError),
+            "The first dimension of values is not the same length "
+            "as the datetime sequence",
+            np.arange(144).reshape((-1, 2)),
+            True,
+            id="2D too short",
+        ),
+        pytest.param(
+            does_not_raise(),
+            None,
+            np.arange(144),
+            True,
+            id="All good",
+        ),
+    ],
+)
+def test_AcclimationModel_get_window_values_errors(
+    fixture_AcclimationModel,
+    ctext_mngr,
+    msg,
+    values,
+    set_window,
+):
+    """Test errors arising in the SubdailyScaler get_window_value method."""
+
+    if set_window:
+        fixture_AcclimationModel.set_window(
+            window_center=np.timedelta64(12, "h"),
+            half_width=np.timedelta64(2, "h"),
+        )
+
+    with ctext_mngr as cman:
+        _ = fixture_AcclimationModel.get_window_values(values)
+
+    if not isinstance(ctext_mngr, does_not_raise):
+        assert str(cman.value) == msg
+
+
+@pytest.mark.parametrize(
+    argnames="values, expected_means, allow_partial_data",
+    argvalues=[
+        pytest.param(np.ones(144), np.array([1, 1, 1]), False, id="1d_shape_correct"),
+        pytest.param(
+            PARTIAL_ONES,
+            np.array([np.nan, 1, 1]),
+            False,
+            id="1d_shape_correct_partial-",
+        ),
+        pytest.param(
+            PARTIAL_ONES,
+            np.array([1, 1, 1]),
+            True,
+            id="1d_shape_correct_partial+",
+        ),
+        pytest.param(np.ones((144, 5)), np.ones((3, 5)), False, id="2d_shape_correct"),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 144)).T,
+            np.broadcast_to([np.nan, 1, 1], (5, 3)).T,
+            False,
+            id="2d_shape_correct_partial-",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 144)).T,
+            np.ones((3, 5)),
+            True,
+            id="2d_shape_correct_partial+",
+        ),
+        pytest.param(  # Simple 3D - shape is correct
+            np.ones((144, 5, 5)), np.ones((3, 5, 5)), False, id="3d_shape_correct"
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 5, 144)).T,
+            np.broadcast_to([np.nan, 1, 1], (5, 5, 3)).T,
+            False,
+            id="3d_shape_correct_partial-",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 5, 144)).T,
+            np.ones((3, 5, 5)),
+            True,
+            id="3d_shape_correct_partial+",
+        ),
+        pytest.param(  # 1D - values are correct
+            np.arange(144), np.array([24, 72, 120]), False, id="1d_values_correct"
+        ),
+        pytest.param(
+            PARTIAL_VARYING,
+            np.array([np.nan, 72, 120]),
+            False,
+            id="1d_values_correct_partial-",
+        ),
+        pytest.param(
+            PARTIAL_VARYING,
+            np.array([26, 72, 120]),
+            True,
+            id="1d_values_correct_partial+",
+        ),
+        pytest.param(  # 2D - values are correct
+            np.broadcast_to(np.arange(144), (5, 144)).T,
+            np.tile([24, 72, 120], (5, 1)).T,
+            False,
+            id="2d_values_correct",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 144)).T,
+            np.broadcast_to([np.nan, 72, 120], (5, 3)).T,
+            False,
+            id="2d_values_correct_partial-",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 144)).T,
+            np.broadcast_to([26, 72, 120], (5, 3)).T,
+            True,
+            id="2d_values_correct_partial+",
+        ),
+        pytest.param(  # 3D - values are correct
+            np.broadcast_to(np.arange(144), (5, 5, 144)).T,
+            np.tile([24, 72, 120], (5, 5, 1)).T,
+            False,
+            id="3d_values_correct",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 5, 144)).T,
+            np.broadcast_to([np.nan, 72, 120], (5, 5, 3)).T,
+            False,
+            id="3d_values_correct_partial-",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 5, 144)).T,
+            np.broadcast_to([26, 72, 120], (5, 5, 3)).T,
+            True,
+            id="3d_values_correct_partial+",
+        ),
+        pytest.param(  # 3D - values are correct with spatial variation
+            np.arange(144 * 25).reshape(144, 5, 5),
+            (
+                np.tile([600, 1800, 3000], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            False,
+            id="3d_values_correct_complex",
+        ),
+        pytest.param(
+            np.concatenate(
+                [
+                    np.full((24, 5, 5), np.nan),
+                    np.arange(144 * 25, dtype="float").reshape(144, 5, 5)[24:, :, :],
+                ]
+            ),
+            (
+                np.tile([np.nan, 1800, 3000], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            False,
+            id="3d_values_correct_complex_partial-",
+        ),
+        pytest.param(
+            np.concatenate(
+                [
+                    np.full((29, 5, 5), np.nan),
+                    np.arange(144 * 25, dtype="float").reshape(144, 5, 5)[29:, :, :],
+                ]
+            ),
+            (
+                np.tile([np.nan, 1800, 3000], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            True,
+            id="3d_values_correct_complex_partial+_but_all_nan",
+        ),
+        pytest.param(
+            np.concatenate(
+                [
+                    np.full((24, 5, 5), np.nan),
+                    np.arange(144 * 25, dtype="float").reshape(144, 5, 5)[24:, :, :],
+                ]
+            ),
+            (
+                np.tile([650, 1800, 3000], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            True,
+            id="3d_values_correct_complex_partial+",
+        ),
+    ],
+)
+class Test_AcclimationModel_get_daily_means_window_and_include:
+    """Test AcclimationModel get_daily_means method for set_window and set_include.
+
+    The daily values extracted using the set_window and set_include methods can be the
+    same, by setting the window and the include to cover the same observations, so these
+    tests can share a parameterisation. This doesn't follow for set_nearest because
+    that only ever selects a single value and allow_partial_data has no effect and so
+    get_daily_means with that method are tested separately.
+
+    This test checks that the correct values are extracted from daily representative
+    and that the mean is correctly calculated.
+
+    It also checks the allow_partial_data option by feeding in values that are np.nan
+    until half way through the first window. Depending on the setting of
+    allow_partial_data, the return values either have np.nan in the first day or a
+    slightly higher value calculated from the mean of the available data.
+
+    The allow_partial_data=True is also checked when _all_ the extracted daily values
+    are np.nan - this should revert to setting np.nan in the first day.
+    """
+
+    def test_AcclimationModel_get_daily_means_with_set_window(
+        self, fixture_AcclimationModel, values, expected_means, allow_partial_data
+    ):
+        """Test get_daily_means with set_window."""
+        fixture_AcclimationModel.set_window(
+            window_center=np.timedelta64(12, "h"),
+            half_width=np.timedelta64(2, "h"),
+        )
+        calculated_means = fixture_AcclimationModel.get_daily_means(
+            values, allow_partial_data=allow_partial_data
+        )
+
+        assert np.allclose(calculated_means, expected_means, equal_nan=True)
+
+    def test_SubdailyScaler_get_daily_means_with_set_include(
+        self, fixture_AcclimationModel, values, expected_means, allow_partial_data
+    ):
+        """Test get_daily_means with set_include."""
+
+        # This duplicates the selection of the window test but using direct include
+        inc = np.zeros(48, dtype=np.bool_)
+        inc[20:29] = True
+        fixture_AcclimationModel.set_include(inc)
+        calculated_means = fixture_AcclimationModel.get_daily_means(
+            values, allow_partial_data=allow_partial_data
+        )
+
+        assert np.allclose(calculated_means, expected_means, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    argnames="values, expected_means",
+    argvalues=[
+        pytest.param(np.ones(144), np.array([1, 1, 1]), id="1d_shape_correct"),
+        pytest.param(PARTIAL_ONES, np.array([np.nan, 1, 1]), id="1d_shape_correct_nan"),
+        pytest.param(np.ones((144, 5)), np.ones((3, 5)), id="2d_shape_correct"),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 144)).T,
+            np.broadcast_to([np.nan, 1, 1], (5, 3)).T,
+            id="2d_shape_correct_nan",
+        ),
+        pytest.param(np.ones((144, 5, 5)), np.ones((3, 5, 5)), id="3d_shape_correct"),
+        pytest.param(
+            np.broadcast_to(PARTIAL_ONES, (5, 5, 144)).T,
+            np.broadcast_to([np.nan, 1, 1], (5, 5, 3)).T,
+            id="3d_shape_correct_nan",
+        ),
+        pytest.param(  # 1D - values are correct
+            np.arange(144), np.array([23, 71, 119]), id="1d_values_correct"
+        ),
+        pytest.param(
+            PARTIAL_VARYING, np.array([np.nan, 71, 119]), id="1d_values_correct_nan"
+        ),
+        pytest.param(  # 2D - values are correct
+            np.broadcast_to(np.arange(144), (5, 144)).T,
+            np.tile([23, 71, 119], (5, 1)).T,
+            id="2d_values_correct",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 144)).T,
+            np.broadcast_to([np.nan, 71, 119], (5, 3)).T,
+            id="2d_values_correct_nan",
+        ),
+        pytest.param(  # 3D - values are correct
+            np.broadcast_to(np.arange(144), (5, 5, 144)).T,
+            np.tile([23, 71, 119], (5, 5, 1)).T,
+            id="3d_values_correct",
+        ),
+        pytest.param(
+            np.broadcast_to(PARTIAL_VARYING, (5, 5, 144)).T,
+            np.broadcast_to([np.nan, 71, 119], (5, 5, 3)).T,
+            id="3d_values_correct_nan",
+        ),
+        pytest.param(  # 3D - values are correct with spatial variation
+            np.arange(144 * 25).reshape(144, 5, 5),
+            (
+                np.tile([575, 1775, 2975], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            id="3d_values_correct_complex",
+        ),
+        pytest.param(
+            np.concatenate(
+                [
+                    np.full((24, 5, 5), np.nan),
+                    np.arange(144 * 25, dtype="float").reshape(144, 5, 5)[24:, :, :],
+                ]
+            ),
+            (
+                np.tile([np.nan, 1775, 2975], (5, 5, 1)).T
+                + np.indices((3, 5, 5))[2]
+                + 5 * np.indices((3, 5, 5))[1]
+            ),
+            id="3d_values_correct_complex_nan",
+        ),
+    ],
+)
+def test_AcclimationModel_get_daily_means_with_set_nearest(
+    fixture_AcclimationModel, values, expected_means
+):
+    """Test get_daily_means with set_nearest.
+
+    This tests the specific behaviour when set_nearest is used and a single observation
+    is selected as the daily acclimation conditions: allow_partial_data has no effect
+    here, so this just tests that np.nan appears as expected.
+    """
+
+    # Select the 11:30 observation, which is missing in PARTIAL_ONES and PARTIAL_VARYING
+    fixture_AcclimationModel.set_nearest(np.timedelta64(11 * 60 + 29, "m"))
+    calculated_means = fixture_AcclimationModel.get_daily_means(values)
+
+    assert np.allclose(calculated_means, expected_means, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    argnames=["method_name", "kwargs", "update_point"],
+    argvalues=[
+        pytest.param(
+            "set_window",
+            dict(
+                window_center=np.timedelta64(12, "h"),
+                half_width=np.timedelta64(1, "h"),
+            ),
+            "max",
+            id="window_max",
+        ),
+        pytest.param(
+            "set_window",
+            dict(
+                window_center=np.timedelta64(13, "h"),
+                half_width=np.timedelta64(1, "h"),
+            ),
+            "mean",
+            id="window_mean",
+        ),
+        pytest.param(
+            "set_include",
+            dict(
+                include=np.repeat([False, True, False], (22, 5, 21)),
+            ),
+            "max",
+            id="include_max",
+        ),
+        pytest.param(
+            "set_include",
+            dict(
+                include=np.repeat([False, True, False], (24, 5, 19)),
+            ),
+            "mean",
+            id="include_mean",
+        ),
+        pytest.param(
+            "set_nearest",
+            dict(
+                time=np.timedelta64(13, "h"),
+            ),
+            "max",
+            id="nearest_max",
+        ),
+        pytest.param(
+            "set_nearest",
+            dict(
+                time=np.timedelta64(13, "h"),
+            ),
+            "mean",
+            id="nearest_mean",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    argnames=["input_values", "exp_values", "initial_values"],
+    argvalues=[
+        pytest.param(
+            np.array([1, 2, 3]),
+            np.repeat([np.nan, 1, 2, 3], (26, 48, 48, 22)),
+            None,
+            id="1D test",
+        ),
+        pytest.param(
+            np.array([1, 2, 3]),
+            np.repeat([0, 1, 2, 3], (26, 48, 48, 22)),
+            np.array([0]),
+            id="1D test - previous value 1D",
+        ),
+        pytest.param(
+            np.array([1, 2, 3]),
+            np.repeat([0, 1, 2, 3], (26, 48, 48, 22)),
+            np.array(0),
+            id="1D test - previous value 0D",
+        ),
+        pytest.param(
+            np.array([[[1, 4], [7, 10]], [[2, 5], [8, 11]], [[3, 6], [9, 12]]]),
+            np.repeat(
+                a=[
+                    [[np.nan, np.nan], [np.nan, np.nan]],
+                    [[1, 4], [7, 10]],
+                    [[2, 5], [8, 11]],
+                    [[3, 6], [9, 12]],
+                ],
+                repeats=[26, 48, 48, 22],
+                axis=0,
+            ),
+            None,
+            id="3D test",
+        ),
+        pytest.param(
+            np.array([[[1, 4], [7, 10]], [[2, 5], [8, 11]], [[3, 6], [9, 12]]]),
+            np.repeat(
+                a=[
+                    [[0, 3], [6, 9]],
+                    [[1, 4], [7, 10]],
+                    [[2, 5], [8, 11]],
+                    [[3, 6], [9, 12]],
+                ],
+                repeats=[26, 48, 48, 22],
+                axis=0,
+            ),
+            np.array([[0, 3], [6, 9]]),
+            id="3D test - previous value 2D",
+        ),
+        pytest.param(
+            np.array([[1, 4], [2, 5], [3, 6]]),
+            np.repeat(
+                a=[[np.nan, np.nan], [1, 4], [2, 5], [3, 6]],
+                repeats=[26, 48, 48, 22],
+                axis=0,
+            ),
+            None,
+            id="2D test",
+        ),
+    ],
+)
+def test_AcclimationModel_fill_daily_to_subdaily_previous(
+    method_name,
+    kwargs,
+    update_point,
+    input_values,
+    exp_values,
+    initial_values,
+):
+    """Test AcclimationModel.fill_daily_to_subdaily using method previous.
+
+    The first parameterisation sets the exact same acclimation windows in a bunch of
+    different ways. The second paramaterisation provides inputs with different
+    dimensionality.
+    """
+
+    from pyrealm.pmodel.acclimation import AcclimationModel
+
+    # Setup the acclimation model
+
+    acclim_model = AcclimationModel(
+        datetimes=DATES,
+        update_point=update_point,
+    )
+
+    # Get a reference to the requested "set_" method from AcclimationModel and use it to
+    # set the included observations - the different parameterisations here and for
+    # the update point should all select the same update point.
+    func = getattr(acclim_model, method_name)
+    func(**kwargs)
+
+    # Call fill daily to subdaily
+    res = acclim_model.fill_daily_to_subdaily(
+        values=input_values, initial_values=initial_values
+    )
+
+    assert np.allclose(res, exp_values, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    argnames=["update_point", "input_values", "exp_values"],
+    argvalues=[
+        pytest.param(
+            "max",
+            np.array([0, 48, 0]),
+            np.concatenate(
+                [
+                    np.repeat([np.nan], 28),  # before first window
+                    np.repeat([0], 48),  # repeated first value of 0
+                    np.arange(0, 49),  # offset increase up to 48
+                    np.arange(47, 28, -1),  # truncated decrease back down to 0
+                ]
+            ),
+            id="1D test max",
+        ),
+        pytest.param(
+            "mean",
+            np.array([0, 48, 0]),
+            np.concatenate(
+                [
+                    np.repeat([np.nan], 26),
+                    np.repeat([0], 48),
+                    np.arange(0, 49),
+                    np.arange(47, 26, -1),
+                ]
+            ),
+            id="1D test mean",
+        ),
+        pytest.param(
+            "max",
+            np.array([[0, 0], [48, -48], [0, 0]]),
+            np.dstack(
+                [
+                    np.concatenate(
+                        [
+                            np.repeat([np.nan], 28),
+                            np.repeat([0], 48),
+                            np.arange(0, 49),
+                            np.arange(47, 28, -1),
+                        ]
+                    ),
+                    np.concatenate(
+                        [
+                            np.repeat([np.nan], 28),
+                            np.repeat([0], 48),
+                            np.arange(0, -49, -1),
+                            np.arange(-47, -28, 1),
+                        ]
+                    ),
+                ]
+            ),
+            id="2D test max",
+        ),
+    ],
+)
+def test_SubdailyScaler_fill_daily_to_subdaily_linear(
+    fixture_SubdailyScaler,
+    update_point,
+    input_values,
+    exp_values,
+):
+    """Test fill_daily_to_subdaily using SubdailyScaler with method linear."""
+
+    # Set the included observations
+    fixture_SubdailyScaler.set_window(
+        window_center=np.timedelta64(13, "h"), half_width=np.timedelta64(1, "h")
+    )
+
+    res = fixture_SubdailyScaler.fill_daily_to_subdaily(
+        input_values, update_point=update_point, kind="linear"
+    )
+
+    assert np.allclose(res, exp_values, equal_nan=True)
+
+
+@pytest.mark.parametrize(
+    argnames="inputs, outcome, msg",
+    argvalues=[
+        pytest.param(
+            {"values": np.arange(12)},
+            pytest.raises(ValueError),
+            "Values is not of length n_days on its first axis",
+            id="values wrong shape",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "fill_from": 3},
+            pytest.raises(ValueError),
+            "The fill_from argument must be a timedelta64 value",
+            id="fill_from not timedelta64",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "fill_from": np.timedelta64(12, "D")},
+            pytest.raises(ValueError),
+            "The fill_from argument is not >= 0 and < 24 hours",
+            id="fill_from too large",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "fill_from": np.timedelta64(-1, "s")},
+            pytest.raises(ValueError),
+            "The fill_from argument is not >= 0 and < 24 hours",
+            id="fill_from negative",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "update_point": "noon"},
+            pytest.raises(ValueError),
+            "Unknown update point",
+            id="unknown update point",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "previous_value": np.array(1), "kind": "linear"},
+            pytest.raises(NotImplementedError),
+            "Using previous value with kind='linear' is not implemented",
+            id="previous_value with linear",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "previous_value": np.ones(4)},
+            pytest.raises(ValueError),
+            "The input to previous_value is not congruent with "
+            "the shape of the observed data",
+            id="previous_value shape issue",
+        ),
+        pytest.param(
+            {"values": np.arange(3), "kind": "quadratic"},
+            pytest.raises(ValueError),
+            "Unsupported interpolation option",
+            id="unsupported interpolation",
+        ),
+    ],
+)
+def test_SubdailyScaler_fill_daily_to_subdaily_failure_modes(
+    fixture_SubdailyScaler, inputs, outcome, msg
+):
+    """Test fill_daily_to_subdaily using SubdailyScaler with method linear."""
+
+    # Set the included observations
+    fixture_SubdailyScaler.set_window(
+        window_center=np.timedelta64(13, "h"), half_width=np.timedelta64(1, "h")
+    )
+
+    with outcome as excep:
+        _ = fixture_SubdailyScaler.fill_daily_to_subdaily(**inputs)
+
+    assert str(excep.value) == msg


### PR DESCRIPTION
# Description

Another major piece of surgery to the PModel implementation to  add the new `AcclimationModel` class to the 2.0.0 branch. The PR:

* adds the `AcclimationModel` in `pyrealm/pmodel/acclimation.py`. This is very similar to the `SubdailyScaler`, but moves most of the methods arguments to instance attributes so that the model can be defined once and then used consistently and with shorter signatures.
* moves the `pyrealm.pmodel.subdaily.memory_effect` to `pyrealm.core.utilities.calculate_exponential_weighted_average` for wider use and then wraps it in `AcclimationModel.apply_acclimation` for this specific use case.
* adds a new test file for the model in `tests/unit/pmodel/test_acclimation_model.py`

One thing I haven't done is to include the `previous_values/initial_values` in this. These are arrays that need to match to dimensions of the `PModelEnvironment` data of the `SubdailyPModel`, so there is no real way to validate the inputs within this - which only knows about the date axis of that environment. It makes more sense then to keep that argument in the  `SubdailyPModel` signature.

> [!important]
> This is another partial contribution to the 2.0.0 branch. Things left to do after merging:
> * I've again left the original implementations in place. 
> * I haven't updated `SubdailyPModelNew` to use this yet. 
> * I haven't checked the docs build.
> 
> My main aim here is to get a review of the new proposed structure. 

Fixes #415 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
