### PR TITLE
Actually use the new AcclimationModel

### DIFF
--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -277,12 +277,12 @@ class AcclimationModel:
         This private method must be called by all ``set_`` methods. It is used to
         update the instance to populate the following attributes:
 
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes`: An
+        * :attr:`~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes`: An
           array of the datetimes of observations included in daily samples of shape
           (n_day, n_sample).
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_mean`:
+        * :attr:`~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes_mean`:
           An array of the mean daily datetime of observations included in daily samples.
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_max`:
+        * :attr:`~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes_max`:
           An array of the maximum daily datetime of observations included in daily
           samples.
         """
@@ -419,8 +419,7 @@ class AcclimationModel:
         Args:
             values: An array containing the sample values. The first dimension should be
               matching the number of measurements, i.e., the first dimension of
-              datetimes in
-              :class:`~pyrealm.pmodel.scaler.SubdailyScaler`.
+              datetimes in :class:`~pyrealm.pmodel.acclimation.AcclimationModel`.
         """
 
         if self.padding == (0, 0):
@@ -601,7 +600,7 @@ class AcclimationModel:
 
         Args:
             values: An array with the first dimension matching the number of days in the
-                instances :class:`~pyrealm.pmodel.scaler.SubdailyScaler` object.
+               :class:`~pyrealm.pmodel.acclimation.AcclimationModel` instance.
             previous_values: An array of previous values from which to fill the
                 variable.
         """

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -510,7 +510,7 @@ class SubdailyPModelNew(PModelABC):
       to provide a :class:`~pyrealm.pmodel.acclimation.AcclimationModel` instance that
       sets the dates and time of those observations. One of the ``set_`` methods to that
       class must also be used to define a daily acclimation window that will be used to
-      estimate the optimal daily behaviour of the plant
+      estimate the optimal daily behaviour of the plant.
     * The
       :meth:`AcclimationModel.get_daily_means<pyrealm.pmodel.acclimation.AcclimationModel.get_daily_means>`
       method is then used to extract daily average values for forcing variables from

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -1,8 +1,15 @@
-"""The module :mod:`~pyrealm.pmodel.pmodel` provides the implementation of
-the following pmodel core class:
+"""The module :mod:`~pyrealm.pmodel.new_pmodel` provides the implementation of
+the following  classes:
 
-* :class:`~pyrealm.pmodel.pmodel.PModel`:
-    Applies the PModel to locations.
+* :class:`~pyrealm.pmodel.new_pmodel.PModelABC`: An abstract base class providing some
+     of the core functionality for initialising PModel subclasses.
+
+* :class:`~pyrealm.pmodel.new_pmodel.PModelNew`: A subclass providing the standard
+     implementation of the P Model.
+
+* :class:`~pyrealm.pmodel.new_pmodel.SubdailyPModelNew`: A subclass providing the
+     subdaily implementation of the P Model, which accounts for slow acclimation of core
+     photosynthetic processes.
 
 
 """  # noqa D210, D415
@@ -18,6 +25,7 @@ from numpy.typing import NDArray
 
 from pyrealm.constants import CoreConst, PModelConst
 from pyrealm.core.utilities import summarize_attrs
+from pyrealm.pmodel.acclimation import AcclimationModel
 from pyrealm.pmodel.arrhenius import ARRHENIUS_METHOD_REGISTRY, ArrheniusFactorABC
 from pyrealm.pmodel.functions import calc_ftemp_inst_rd
 from pyrealm.pmodel.jmax_limitation import (
@@ -27,12 +35,19 @@ from pyrealm.pmodel.jmax_limitation import (
 from pyrealm.pmodel.optimal_chi import OPTIMAL_CHI_CLASS_REGISTRY, OptimalChiABC
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 from pyrealm.pmodel.quantum_yield import QUANTUM_YIELD_CLASS_REGISTRY, QuantumYieldABC
-from pyrealm.pmodel.scaler import SubdailyScaler
-from pyrealm.pmodel.subdaily import memory_effect
 
 
 class PModelABC(ABC):
     r"""Abstract base class for the PModel and SubdailyPModel.
+
+    The base class __init__ implements the core arguments to the PModel subclasses: the
+    forcing data to be used for the model and various methodological options for the
+    calculation of the model parameters.
+
+    Subclasses should define an `__init__` method that first calls
+    `super().__init__(...)` to run the shared core functionality and then define any
+    model specific attributes. The abstract base method `_fit_model` should then be
+    defined and used to execute the model specific logic of the base class.
 
     Args:
         env: A :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` instance
@@ -260,7 +275,7 @@ class PModelABC(ABC):
         """Electron transfer rate."""
 
     @abstractmethod
-    def _fit_model(self) -> None:
+    def _fit_model(self, *args: Any, **kwargs: Any) -> None:
         pass
 
     def __repr__(self) -> str:
@@ -448,10 +463,8 @@ class PModelNew(PModelABC):
 
     def to_subdaily(
         self,
-        fs_scaler: SubdailyScaler,
-        alpha: float = 1 / 15,
-        allow_holdover: bool = False,
-        fill_kind: str = "previous",
+        acclim_model: AcclimationModel,
+        previous_realised: tuple[NDArray, NDArray, NDArray] | None = None,
     ) -> SubdailyPModelNew:
         r"""Convert a standard PModel to a subdaily P Model.
 
@@ -460,15 +473,10 @@ class PModelNew(PModelABC):
         settings.
 
         Args:
-            fs_scaler: A SubdailyScaler instance giving the acclimation window for the
-                subdaily model.
-            alpha: The :math:`\alpha` weight.
-            allow_holdover: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect`
-            function be allowed to hold over values to fill missing values.
-            fill_kind: The approach used to fill daily realised values to the subdaily
-            timescale, currently one of 'previous' or 'linear'.
+            acclim_model: An AcclimationModel instance for the subdaily model.
+            previous_realised: An optional set of arrays giving previous realised values
+                for `xi`, `vcmax25` and `jmax25`.
         """
-        # Check that productivity has been estimated
 
         return SubdailyPModelNew(
             env=self.env,
@@ -477,10 +485,7 @@ class PModelNew(PModelABC):
             method_jmaxlim=self.method_jmaxlim,
             method_kphio=self.method_kphio,
             reference_kphio=self.kphio.reference_kphio,
-            fs_scaler=fs_scaler,
-            alpha=alpha,
-            allow_holdover=allow_holdover,
-            fill_kind=fill_kind,
+            acclim_model=acclim_model,
         )
 
 
@@ -589,17 +594,13 @@ class SubdailyPModelNew(PModelABC):
     def __init__(
         self,
         env: PModelEnvironment,
-        fs_scaler: SubdailyScaler,
+        acclim_model: AcclimationModel,
         method_optchi: str = "prentice14",
         method_jmaxlim: str = "wang17",
         method_kphio: str = "temperature",
         method_arrhenius: str = "simple",
         reference_kphio: float | NDArray | None = None,
-        alpha: float = 1 / 15,
-        allow_holdover: bool = False,
-        allow_partial_data: bool = False,
-        fill_kind: str = "previous",
-        previous_realised: tuple[NDArray, NDArray, NDArray] | None = None,
+        previous_realised: dict[str, NDArray] | None = None,
     ) -> None:
         # Initialise the superclass
         super().__init__(
@@ -611,13 +612,13 @@ class SubdailyPModelNew(PModelABC):
             reference_kphio=reference_kphio,
         )
 
-        # Subclass specific arguments
-        self.fs_scaler = fs_scaler
-        self.alpha = alpha
-        self.allow_holdover = allow_holdover
-        self.allow_partial_data = allow_partial_data
-        self.fill_kind = fill_kind
-        self.previous_realised = previous_realised
+        # Subclass specific attributes
+        self.acclim_model: AcclimationModel
+        """The acclimation model used in the subdaily P Model."""
+        self.previous_realised: dict[str, NDArray | None]
+        """A dictionary of arrays of previous realised values for the acclimating
+        variables 'xi', 'jmax25' and 'vcmax25'. If none were provided, the dictionary
+        values are None."""
 
         # Other attributes
         self.datetimes: NDArray[np.datetime64]
@@ -652,23 +653,73 @@ class SubdailyPModelNew(PModelABC):
         # xi	self.pmodel_acclim.optchi.xi - add a getter?	subdaily_xi
 
         # Fit the model
-        self._fit_model()
+        self._fit_model(acclim_model=acclim_model, previous_realised=previous_realised)
 
-    def _fit_model(self) -> None:
-        # Check that the length of the fast slow scaler is congruent with the
-        # first axis of the photosynthetic environment
-        n_datetimes = self.fs_scaler.datetimes.shape[0]
+    def _fit_model(
+        self,
+        acclim_model: AcclimationModel,
+        previous_realised: dict[str, NDArray] | None,
+    ) -> None:
+        # Validate subdaily model specific arguments
+
+        # * Check that the length of the fast slow scaler is congruent with the
+        #   first axis of the photosynthetic environment and that the one of the set
+        #   methods has been run on the acclimation model.
+        n_datetimes = self.acclim_model.datetimes.shape[0]
         n_env_first_axis = self.env.tc.shape[0]
 
         if n_datetimes != n_env_first_axis:
             raise ValueError("env and fs_scaler do not have congruent dimensions")
 
-        # Has a set method been run on the fast slow scaler
-        if not hasattr(self.fs_scaler, "include"):
+        if not hasattr(self.acclim_model, "include"):
             raise ValueError("The daily sampling window has not been set on fs_scaler")
 
         # Store the datetimes for reference
-        self.datetimes = self.fs_scaler.datetimes
+        self.datetimes = self.acclim_model.datetimes
+
+        # * Validate the previous realised values
+        if self.previous_realised is None:
+            self.previous_realised = {"xi": None, "jmax25": None, "vcmax25": None}
+        else:
+            # Is the fill method set to previous
+            if self.acclim_model.fill_method != "previous":
+                raise NotImplementedError(
+                    "Using previous_realised is only implemented for "
+                    "fill_method = 'previous'"
+                )
+
+            # Check it is a dictionary of numpy arrays for the three required variables
+            if not (
+                isinstance(self.previous_realised, dict)
+                and (set(["xi", "jmax25", "vcmax25"]) == self.previous_realised.keys())
+                and all(
+                    [
+                        isinstance(val, np.ndarray)
+                        for val in self.previous_realised.values()
+                    ]
+                )
+            ):
+                raise ValueError(
+                    "previous_realised must be a dictionary of arrays, with entries "
+                    "for 'xi', 'jmax25' and 'vcmax25'."
+                )
+
+            # All variables should share the shape of a slice along the first axis of
+            # the environmental forcings. Need to tell mypy to shut up - it does not
+            # know that the values in previous_realised are confirmed to be arrays by
+
+            # the code above
+            expected_shape = self.env.tc[0].shape
+
+            if not all(
+                [
+                    arr[0].shape == expected_shape  # type: ignore[index]
+                    for arr in self.previous_realised.values()
+                ]
+            ):
+                raise ValueError(
+                    "`previous_realised` entries have wrong shape in Subdaily PModel"
+                )
 
         # 1) Generate a PModelEnvironment containing the average conditions within the
         #    daily acclimation window. This daily average environment also needs to also
@@ -694,9 +745,8 @@ class SubdailyPModelNew(PModelABC):
         for env_var_name in daily_environment_vars:
             env_var = getattr(self.env, env_var_name)
             if env_var is not None:
-                daily_environment[env_var_name] = self.fs_scaler.get_daily_means(
+                daily_environment[env_var_name] = self.acclim_model.get_daily_means(
                     values=env_var,
-                    allow_partial_data=self.allow_partial_data,
                 )
 
         # Calculate the acclimation environment passing on the constants definitions.
@@ -721,10 +771,7 @@ class SubdailyPModelNew(PModelABC):
         # calculate the daily acclimation value behaviour and set the kphio method to be
         # fixed to avoid altering the inputs.
         if self.kphio.reference_kphio.size > 1:
-            daily_reference_kphio = self.fs_scaler.get_daily_means(
-                self.kphio.kphio,
-                allow_partial_data=self.allow_partial_data,
-            )
+            daily_reference_kphio = self.acclim_model.get_daily_means(self.kphio.kphio)
             daily_method_kphio = "fixed"
         else:
             daily_reference_kphio = self.kphio.reference_kphio
@@ -742,15 +789,18 @@ class SubdailyPModelNew(PModelABC):
         )
         self.pmodel_acclim._fit_model()
 
-        # 4) Calculate the optimal jmax and vcmax at 25°C
-        # - get an instance of the requested Arrhenius scaling method
+        # 4) Calculate the daily optimal values. Xi is simply the value from the optimal
+        #   chi calculation but jmax and vcmax are scaled to values at 25°C using an
+        #   instance of the requested Arrhenius scaling method .
+
+        self.xi_daily_optimal = self.pmodel_acclim.optchi.xi
+
         arrhenius_daily = self._arrhenius_class(
             env=self.pmodel_acclim.env,
             reference_temperature=self.pmodel_acclim.env.pmodel_const.plant_T_ref,
             core_const=self.env.core_const,
         )
 
-        # - Calculate and apply the scaling factors.
         self.vcmax25_daily_optimal = (
             self.pmodel_acclim.vcmax
             / arrhenius_daily.calculate_arrhenius_factor(
@@ -764,73 +814,36 @@ class SubdailyPModelNew(PModelABC):
             )
         )
 
-        """Instantaneous optimal :math:`x_{i}`, :math:`V_{cmax}` and :math:`J_{max}`"""
-        # Check the shape of previous realised values are congruent with a slice across
-        # the time axis
-        if self.previous_realised is not None:
-            if self.fill_kind != "previous":
-                raise NotImplementedError(
-                    "Using previous_realised is only implemented for "
-                    "fill_kind = 'previous'"
-                )
-
-            # All variables should share the shape of a slice along the first axis of
-            # the environmental forcings
-            expected_shape = self.env.tc[0].shape
-            if not (
-                (self.previous_realised[0].shape == expected_shape)
-                and (self.previous_realised[1].shape == expected_shape)
-                and (self.previous_realised[2].shape == expected_shape)
-            ):
-                raise ValueError(
-                    "`previous_realised` entries have wrong shape in Subdaily PModel"
-                )
-            else:
-                previous_xi_real, previous_vcmax25_real, previous_jmax25_real = (
-                    self.previous_realised
-                )
-        else:
-            previous_xi_real, previous_vcmax25_real, previous_jmax25_real = [
-                None,
-                None,
-                None,
-            ]
-
         # 5) Calculate the realised daily values from the instantaneous optimal values
-        self.xi_daily_optimal = self.pmodel_acclim.optchi.xi
-        self.xi_daily_realised = memory_effect(
+
+        self.xi_daily_realised = self.acclim_model.apply_acclimation(
             values=self.xi_daily_optimal,
-            previous_values=previous_xi_real,
-            alpha=self.alpha,
-            allow_holdover=self.allow_holdover,
+            initial_values=self.previous_realised["xi"],
         )
 
-        self.vcmax25_daily_realised = memory_effect(
+        self.vcmax25_daily_realised = self.acclim_model.apply_acclimation(
             values=self.vcmax25_daily_optimal,
-            previous_values=previous_vcmax25_real,
-            alpha=self.alpha,
-            allow_holdover=self.allow_holdover,
+            initial_values=self.previous_realised["vcmax25"],
         )
-        self.jmax25_daily_realised = memory_effect(
+
+        self.jmax25_daily_realised = self.acclim_model.apply_acclimation(
             values=self.jmax25_daily_optimal,
-            previous_values=previous_jmax25_real,
-            alpha=self.alpha,
-            allow_holdover=self.allow_holdover,
+            initial_values=self.previous_realised["jmax25"],
         )
 
         # 6) Fill the realised xi, jmax25 and vcmax25 from daily values back to the
         # subdaily timescale.
-        self.xi = self.fs_scaler.fill_daily_to_subdaily(
-            self.xi_daily_realised,
-            previous_value=previous_xi_real,
+        self.xi = self.acclim_model.fill_daily_to_subdaily(
+            values=self.xi_daily_realised,
+            previous_values=self.previous_realised["xi"],
         )
-        self.vcmax25 = self.fs_scaler.fill_daily_to_subdaily(
+        self.vcmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.vcmax25_daily_realised,
-            previous_value=previous_vcmax25_real,
+            previous_values=self.previous_realised["vcmax25"],
         )
-        self.jmax25 = self.fs_scaler.fill_daily_to_subdaily(
+        self.jmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.jmax25_daily_realised,
-            previous_value=previous_jmax25_real,
+            previous_values=self.previous_realised["jmax25"],
         )
 
         # 7) Adjust subdaily jmax25 and vcmax25 back to jmax and vcmax given the

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -716,18 +716,14 @@ class SubdailyPModelNew(PModelABC):
             # All variables should share the shape of a slice along the first axis of
             # the environmental forcings. Need to tell mypy to shut up - it does not
             # know that the values in previous_realised are confirmed to be arrays by
-
             # the code above
-            expected_shape = self.env.tc[0].shape
 
-            if not all(
-                [
-                    arr[0].shape == expected_shape  # type: ignore[index]
-                    for arr in previous_realised.values()
-                ]
-            ):
+            try:
+                for values in previous_realised.values():
+                    _ = np.broadcast_shapes(self.env.tc.shape, values.shape)
+            except ValueError:
                 raise ValueError(
-                    "`previous_realised` entries have wrong shape in Subdaily PModel"
+                    "`previous_realised` arrays have wrong shape in SubdailyPModel"
                 )
 
             self.previous_realised = previous_realised

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -561,21 +561,21 @@ class SubdailyPModelNew(PModelABC):
         options include:
 
         * The ``allow_partial_data`` argument is passed on to
-          :meth:`~pyrealm.pmodel.scaler.SubdailyScaler.get_daily_means` to
+          :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_daily_means` to
           allow daily optimum conditions to be calculated when the data in the
           acclimation window is incomplete. This does not fix problems when no data is
           present in the window or when the P Model predictions for a day are undefined.
 
         * The ``allow_holdover`` argument is passed on to
-          :meth:`~pyrealm.pmodel.subdaily.memory_effect` to set whether missing values
-          in the optimal predictions can be filled by holding over previous valid
-          values.
+          :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.apply_acclimation` to set
+          whether missing values in the optimal predictions can be filled by holding
+          over previous valid values.
 
     Args:
         env: An instance of
           :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
-        fs_scaler: An instance of
-          :class:`~pyrealm.pmodel.scaler.SubdailyScaler`.
+        acclim_nodel: An instance of
+          :class:`~pyrealm.pmodel.acclimation.AcclimationModel`.
         alpha: The :math:`\alpha` weight.
         allow_holdover: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect`
           function be allowed to hold over values to fill missing values.

--- a/tests/profiling/pmodel/test_profiling_subdaily.py
+++ b/tests/profiling/pmodel/test_profiling_subdaily.py
@@ -7,22 +7,19 @@ import pytest
 @pytest.mark.profiling
 def test_profiling_subdaily(pmodel_profile_data):
     """Profiling the subdaily submodule."""
-    from pyrealm.pmodel import SubdailyScaler
+    from pyrealm.pmodel.acclimation import AcclimationModel
     from pyrealm.pmodel.new_pmodel import SubdailyPModelNew
 
     # Unpack feature components
     pm_env, local_time = pmodel_profile_data
 
     # SubdailyPModel with 1 hour noon acclimation window
-    fsscaler = SubdailyScaler(local_time)
-    fsscaler.set_window(
-        window_center=np.timedelta64(12, "h"),
-        half_width=np.timedelta64(1, "h"),
+    acclim_model = AcclimationModel(local_time, allow_holdover=True, alpha=1 / 15)
+    acclim_model.set_window(
+        window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(1, "h")
     )
     subdaily_pmod = SubdailyPModelNew(
         env=pm_env,
-        fs_scaler=fsscaler,
-        allow_holdover=True,
-        alpha=1 / 15,
+        acclim_model=acclim_model,
     )
     return subdaily_pmod

--- a/tests/regression/phenology/test_phenology_gpp.py
+++ b/tests/regression/phenology/test_phenology_gpp.py
@@ -9,7 +9,8 @@ import pytest
 def test_phenology_gpp_calculation(de_gri_half_hourly_data):
     """Test the provided GPP values for phenology can be recreated."""
 
-    from pyrealm.pmodel import PModelEnvironment, SubdailyScaler
+    from pyrealm.pmodel import PModelEnvironment
+    from pyrealm.pmodel.acclimation import AcclimationModel
     from pyrealm.pmodel.new_pmodel import PModelNew, SubdailyPModelNew
 
     # Calculate the PModel photosynthetic environment
@@ -24,8 +25,10 @@ def test_phenology_gpp_calculation(de_gri_half_hourly_data):
     )
 
     # Set up the datetimes of the observations and set the acclimation window
-    scaler = SubdailyScaler(datetimes=de_gri_half_hourly_data["time"].to_numpy())
-    scaler.set_window(
+    acclim_model = AcclimationModel(
+        datetimes=de_gri_half_hourly_data["time"].to_numpy()
+    )
+    acclim_model.set_window(
         window_center=np.timedelta64(12, "h"),
         half_width=np.timedelta64(31, "m"),
     )
@@ -33,7 +36,7 @@ def test_phenology_gpp_calculation(de_gri_half_hourly_data):
     # Fit the potential GPP: fAPAR = 1 and phi0 = 1/8
     de_gri_subdaily_pmodel = SubdailyPModelNew(
         env=env,
-        fs_scaler=scaler,
+        acclim_model=acclim_model,
         reference_kphio=1 / 8,
     )
 

--- a/tests/unit/pmodel/test_acclimation_model.py
+++ b/tests/unit/pmodel/test_acclimation_model.py
@@ -304,7 +304,7 @@ def fixture_AcclimationModel():
 def test_AcclimationModel_set_window(
     fixture_AcclimationModel, ctext_mngr, msg, kwargs, samp_mean, samp_max
 ):
-    """Test the SubdailyScaler set_window method."""
+    """Test the AcclimationModel set_window method."""
 
     with ctext_mngr as cman:
         fixture_AcclimationModel.set_window(**kwargs)
@@ -371,7 +371,7 @@ def test_AcclimationModel_set_window(
 def test_AcclimationModel_set_include(
     fixture_AcclimationModel, ctext_mngr, msg, include, samp_mean, samp_max
 ):
-    """Test the SubdailyScaler set_include method."""
+    """Test the AcclimationModel set_include method."""
     with ctext_mngr as cman:
         fixture_AcclimationModel.set_include(include)
 
@@ -436,7 +436,7 @@ def test_AcclimationModel_set_include(
 def test_AcclimationModel_set_nearest(
     fixture_AcclimationModel, ctext_mngr, msg, time, samp_mean, samp_max
 ):
-    """Test the SubdailyScaler set_nearest method."""
+    """Test the AcclimationModel set_nearest method."""
     with ctext_mngr as cman:
         fixture_AcclimationModel.set_nearest(time)
 
@@ -548,7 +548,7 @@ def test_AcclimationModel_get_window_values_errors(
     values,
     set_window,
 ):
-    """Test errors arising in the SubdailyScaler get_window_value method."""
+    """Test errors arising in the AcclimationModel get_window_value method."""
 
     if set_window:
         fixture_AcclimationModel.set_window(
@@ -1137,7 +1137,7 @@ def test_AcclimationModel_fill_daily_to_subdaily_linear(
 def test_AcclimationModel_fill_daily_to_subdaily_failure_modes(
     ac_mod_args, fill_args, outcome, msg
 ):
-    """Test fill_daily_to_subdaily using SubdailyScaler with method linear."""
+    """Test fill_daily_to_subdaily using AcclimationModel with method linear."""
 
     from pyrealm.pmodel.acclimation import AcclimationModel
 

--- a/tests/unit/pmodel/test_arrhenius.py
+++ b/tests/unit/pmodel/test_arrhenius.py
@@ -218,10 +218,8 @@ def test_pmodel_equivalence():
     implementation give equal Vcmax and Jmax values.
     """
 
-    from pyrealm.pmodel import (
-        PModelEnvironment,
-        SubdailyScaler,
-    )
+    from pyrealm.pmodel import PModelEnvironment
+    from pyrealm.pmodel.acclimation import AcclimationModel
     from pyrealm.pmodel.new_pmodel import PModelNew, SubdailyPModelNew
 
     # One year time sequence at half hour resolution
@@ -244,8 +242,12 @@ def test_pmodel_equivalence():
     )
 
     # Setup the Subdaily Model using a 1 hour acclimation window around noon
-    fsscaler = SubdailyScaler(datetimes=datetimes)
-    fsscaler.set_window(
+    acclim_model = AcclimationModel(
+        datetimes=datetimes,
+        alpha=1 / 15,
+        allow_holdover=True,
+    )
+    acclim_model.set_window(
         window_center=np.timedelta64(12, "h"),  # 12:00 PM
         half_width=np.timedelta64(30, "m"),  # ±0.5 hours
     )
@@ -253,10 +255,8 @@ def test_pmodel_equivalence():
     # Fit the two models
     fix_subdaily = SubdailyPModelNew(
         env=fixed_env,
+        acclim_model=acclim_model,
         method_optchi="prentice14",
-        fs_scaler=fsscaler,
-        alpha=1 / 15,
-        allow_holdover=True,
         reference_kphio=1 / 8,
     )
 

--- a/tests/unit/pmodel/test_quantum_yield_array_kphio.py
+++ b/tests/unit/pmodel/test_quantum_yield_array_kphio.py
@@ -198,14 +198,14 @@ def variable_kphio_subdaily(be_vie_data_components):
     of a subdaily model.
     """
 
-    from pyrealm.pmodel import SubdailyScaler
+    from pyrealm.pmodel.acclimation import AcclimationModel
     from pyrealm.pmodel.new_pmodel import SubdailyPModelNew
 
     env, datetime, expected_gpp = be_vie_data_components.get()
 
-    # Get the fast slow scaler and set window
-    fsscaler = SubdailyScaler(datetime)
-    fsscaler.set_window(
+    # Get the acclimation model and set window
+    acclim_model = AcclimationModel(datetime, allow_holdover=True)
+    acclim_model.set_window(
         window_center=np.timedelta64(12, "h"),
         half_width=np.timedelta64(30, "m"),
     )
@@ -220,8 +220,7 @@ def variable_kphio_subdaily(be_vie_data_components):
             env=env,
             method_kphio="fixed",
             reference_kphio=kphio,
-            fs_scaler=fsscaler,
-            allow_holdover=True,
+            acclim_model=acclim_model,
         )
         gpp[:, idx] = subdaily_pmodel.gpp
 
@@ -237,15 +236,16 @@ def test_kphio_arrays_subdaily(
 ):
     """Check behaviour with array inputs of kphio."""
 
-    from pyrealm.pmodel import PModelEnvironment, SubdailyScaler
+    from pyrealm.pmodel import PModelEnvironment
+    from pyrealm.pmodel.acclimation import AcclimationModel
     from pyrealm.pmodel.new_pmodel import SubdailyPModelNew
 
     env, datetime, expected_gpp = be_vie_data_components.get()
     kphio_vals, expected_gpp = variable_kphio_subdaily
 
-    # Get the fast slow scaler and set window
-    fsscaler = SubdailyScaler(datetime)
-    fsscaler.set_window(
+    # Get the acclimation model and set window
+    acclim_model = AcclimationModel(datetime, allow_holdover=True)
+    acclim_model.set_window(
         window_center=np.timedelta64(12, "h"),
         half_width=np.timedelta64(30, "m"),
     )
@@ -265,8 +265,7 @@ def test_kphio_arrays_subdaily(
         env=env,
         method_kphio="fixed",
         reference_kphio=np.broadcast_to(kphio_vals.reshape(shape[1:]), shape),
-        fs_scaler=fsscaler,
-        allow_holdover=True,
+        acclim_model=acclim_model,
     )
 
     assert np.allclose(subdaily_pmodel.gpp, expected_gpp.reshape(shape), equal_nan=True)

--- a/tests/unit/pmodel/test_subdaily.py
+++ b/tests/unit/pmodel/test_subdaily.py
@@ -120,7 +120,7 @@ def test_SubdailyPModel_previous_realised(be_vie_data_components):
     # Run all in one model
     env, datetime, _ = be_vie_data_components.get(mode="crop", start=0, end=17520)
 
-    # Get the fast slow scaler and set window
+    # Get the acclimation model and set window
     acclim_model = AcclimationModel(datetime, allow_holdover=True)
     acclim_model.set_window(
         window_center=np.timedelta64(12, "h"),

--- a/tests/unit/pmodel/test_subdaily.py
+++ b/tests/unit/pmodel/test_subdaily.py
@@ -231,7 +231,7 @@ def test_SubdailyPModel_previous_realised(be_vie_data_components):
     )
 
     # Run as a subdaily model using the kphio used in the reference implementation.
-    # Note the explicit use of [[-1]] to give array values, not scalar np.floating
+    # Note the explicit use of [[-1]] to give array values, not scalar np.float
     part_2_subdaily_pmodel = SubdailyPModelNew(
         env=env2,
         reference_kphio=1 / 8,


### PR DESCRIPTION
# Description

PR #415 added the new class `pyrealm.pmodel.acclimation.AcclimationModel` to replace `SubdailyScaler`, but the updated `SubdailyPModelNew` was still using the old implementation.

This PR:
* Updates `SubdailyPModelNew` and all it's testing to now use the new signature.
* It also updates the handling of `previous_realised`: this input has changed from a tuple of arrays to a dict of arrays to provide deeper checking and clearer handling of values. I've added a new test to check that handling

It does not update usage in docs, which are expected to fail, but I will address this in a separate docs review once the codebase has settled down.

Closes #423 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
