### PR TITLE
Update docs to new P Model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,12 @@ from pyrealm.pmodel import PModelEnvironment, PModel
 # Calculate the photosynthetic environment given the conditions
 env = PModelEnvironment(
     tc=np.array([20]), vpd=np.array([1000]),
-    co2=np.array([400]), patm=np.array([101325.0])
+    co2=np.array([400]), patm=np.array([101325.0],
+    fapar=1, ppfd=300)
 )
 
 # Calculate the predictions of the P Model for a C3 plant
 pmodel_c3 = PModel(env)
-
-# Estimate the GPP from the model given the absorbed photosynthetically active light
-pmodel_c3.estimate_productivity(fapar=1, ppfd=300)
 
 # Report the GPP in micrograms of carbon per m2 per second.
 pmodel_c3.gpp

--- a/docs/source/api/pmodel_api.md
+++ b/docs/source/api/pmodel_api.md
@@ -60,6 +60,16 @@ language_info:
 .. automodule:: pyrealm.pmodel.optimal_chi
     :autosummary:
     :members:
+    :inherited-members:
+```
+
+## The {mod}`~pyrealm.pmodel.arrhenius` submodule
+
+```{eval-rst}
+.. automodule:: pyrealm.pmodel.arrhenius
+    :autosummary:
+    :members:
+    :inherited-members:
 ```
 
 ## The {mod}`~pyrealm.pmodel.quantum_yield` submodule
@@ -68,6 +78,7 @@ language_info:
 .. automodule:: pyrealm.pmodel.quantum_yield
     :autosummary:
     :members:
+    :inherited-members:
 ```
 
 ## The {mod}`~pyrealm.pmodel.functions` submodule
@@ -109,4 +120,21 @@ language_info:
 .. automodule:: pyrealm.pmodel.subdaily
     :autosummary:
     :members:
+```
+
+## The {mod}`~pyrealm.pmodel.acclimation` submodule
+
+```{eval-rst}
+.. automodule:: pyrealm.pmodel.acclimation
+    :autosummary:
+    :members:
+```
+
+## The {mod}`~pyrealm.pmodel.new_pmodel` submodule
+
+```{eval-rst}
+.. automodule:: pyrealm.pmodel.new_pmodel
+    :autosummary:
+    :members:
+    :inherited-members:
 ```

--- a/docs/source/api/pmodel_api.md
+++ b/docs/source/api/pmodel_api.md
@@ -28,14 +28,6 @@ language_info:
 .. automodule:: pyrealm.pmodel
 ```
 
-## The {mod}`~pyrealm.pmodel.pmodel` submodule
-
-```{eval-rst}
-.. automodule:: pyrealm.pmodel.pmodel
-    :autosummary:
-    :members:
-```
-
 ## The {mod}`~pyrealm.pmodel.pmodel_environment` submodule
 
 ```{eval-rst}
@@ -101,23 +93,6 @@ language_info:
 
 ```{eval-rst}
 .. automodule:: pyrealm.pmodel.competition
-    :autosummary:
-    :members:
-```
-
-## The {mod}`~pyrealm.pmodel.scaler` submodule
-
-```{eval-rst}
-.. automodule:: pyrealm.pmodel.scaler
-    :autosummary:
-    :members:
-    :private-members:
-```
-
-## The {mod}`~pyrealm.pmodel.subdaily` submodule
-
-```{eval-rst}
-.. automodule:: pyrealm.pmodel.subdaily
     :autosummary:
     :members:
 ```

--- a/docs/source/development/code_testing.md
+++ b/docs/source/development/code_testing.md
@@ -61,7 +61,7 @@ We have configured `pytest` to automatically also run `doctest`, but you can man
 check the tests in files using, for example:
 
 ```bash
-poetry run python -m doctest pyrealm/pmodel/pmodel.py
+poetry run python -m doctest pyrealm/pmodel/new_pmodel.py
 ```
 
 Normally, `doctest` is just used to test a return value: the value tested is the value

--- a/docs/source/users/pmodel/c3c4model.md
+++ b/docs/source/users/pmodel/c3c4model.md
@@ -35,8 +35,8 @@ This gives C4 plants a substantial competitive advantage in warm, dry and low CO
 environments. The {class}`~pyrealm.pmodel.competition.C3C4Competition` class provides an
 implementation of a model {cite:p}`lavergne:2022a` that estimates the expected fraction
 of GPP from C4 plants. It uses predictions of GPP from the
-{class}`~pyrealm.pmodel.pmodel.PModel` assuming communities consisting solely of C3 or
-C4 plants to calculate the expected fraction of C4 plants in the community and the
+{class}`~pyrealm.pmodel.new_pmodel.PModelNew` assuming communities consisting solely of
+C3 or C4 plants to calculate the expected fraction of C4 plants in the community and the
 contributions to GPP from C3 and C4 plants at each site.
 
 ## Step 1: Proportional GPP advantage

--- a/docs/source/users/pmodel/c3c4model.md
+++ b/docs/source/users/pmodel/c3c4model.md
@@ -56,7 +56,7 @@ $F_4$ changes with $A_4$, given differing estimates of tree cover.
 :tags: [hide-input]
 
 import numpy as np
-import matplotlib.plt as plt
+import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
 from pyrealm.pmodel.new_pmodel import PModelNew

--- a/docs/source/users/pmodel/c3c4model.md
+++ b/docs/source/users/pmodel/c3c4model.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.6
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
@@ -56,11 +56,11 @@ $F_4$ changes with $A_4$, given differing estimates of tree cover.
 :tags: [hide-input]
 
 import numpy as np
-from matplotlib import pyplot
+import matplotlib.plt as plt
 from matplotlib.lines import Line2D
 
+from pyrealm.pmodel.new_pmodel import PModelNew
 from pyrealm.pmodel import (
-    PModel,
     PModelEnvironment,
     CalcCarbonIsotopes,
     C3C4Competition,
@@ -78,13 +78,14 @@ frac_c4 = convert_gpp_advantage_to_c4_fraction(gpp_adv_c4_2d, treecover_2d)
 
 # Plot the results
 for idx, lev in enumerate(treecover_1d):
-    pyplot.plot(gpp_adv_c4_2d[idx, :], frac_c4[idx, :], label=f"{int(lev)}%")
+    plt.plot(gpp_adv_c4_2d[idx, :], frac_c4[idx, :], label=f"{int(lev)}%")
 
-pyplot.legend(title="Forest cover", frameon=False)
-pyplot.title(r"Initial C4 fraction prediction from $A_4$ and tree cover")
-pyplot.xlabel("Proportion C4 GPP advantage $A_4$")
-pyplot.ylabel("Expected C4 fraction ($F_4$)")
-pyplot.axvline(0, ls="--", c="grey")
+plt.legend(title="Forest cover", frameon=False)
+plt.title(r"Initial C4 fraction prediction from $A_4$ and tree cover")
+plt.xlabel("Proportion C4 GPP advantage $A_4$")
+plt.ylabel("Expected C4 fraction ($F_4$)")
+plt.axvline(0, ls="--", c="grey")
+plt.show()
 ```
 
 ## Step 3: Account for shading by C3 trees
@@ -104,12 +105,13 @@ shading of C4 plants.
 # Just use the competition model to predict h across a GPP gradient
 gpp_c3_kg = np.linspace(0, 5, 101)
 prop_trees = calculate_tree_proportion(gpp_c3_kg)
-pyplot.plot(gpp_c3_kg, prop_trees)
-pyplot.axvline(2.8, ls="--", c="grey")
+plt.plot(gpp_c3_kg, prop_trees)
+plt.axvline(2.8, ls="--", c="grey")
 
-pyplot.title("Proportion of GPP from C3 trees")
-pyplot.xlabel("GPP from C3 plants (kg m-2 yr-1)")
-pyplot.ylabel("Proportion of GPP from C3 trees (h, -)")
+plt.title("Proportion of GPP from C3 trees")
+plt.xlabel("GPP from C3 plants (kg m-2 yr-1)")
+plt.ylabel("Proportion of GPP from C3 trees (h, -)")
+plt.show()
 ```
 
 ## Step 4: Filtering cold areas and cropland
@@ -138,17 +140,13 @@ cover of 0.5.
 # Use a simple temperature sequence to generate a range of optimal chi values
 n_pts = 51
 tc_1d = np.linspace(-10, 45, n_pts)
-ppfd = 450
-fapar = 0.9
 
 # Fit C3 and C4 P models
 env = PModelEnvironment(tc=tc_1d, patm=101325, co2=400, vpd=1000, ppfd=450, fapar=0.9)
 
-mod_c3 = PModel(env, method_optchi="prentice14")
-mod_c3.estimate_productivity(fapar=fapar, ppfd=ppfd)
+mod_c3 = PModelNew(env, method_optchi="prentice14")
 
-mod_c4 = PModel(env, method_optchi="c4")
-mod_c4.estimate_productivity(fapar=fapar, ppfd=ppfd)
+mod_c4 = PModelNew(env, method_optchi="c4")
 
 # Competition, using annual GPP from µgC m2 s to g m2 yr
 gpp_c3_annual = mod_c3.gpp * (60 * 60 * 24 * 365) * 1e-6
@@ -216,7 +214,7 @@ Panel F
 :tags: [hide-input]
 
 # Generate the plots
-fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = pyplot.subplots(3, 2, figsize=(10, 12))
+fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = plt.subplots(3, 2, figsize=(10, 12))
 
 # GPP predictions
 ax1.plot(tc_1d, gpp_c3_annual, label="C3 alone")
@@ -280,5 +278,5 @@ for letter, ax in zip(("A", "B", "C", "D", "E", "F"), (ax1, ax2, ax3, ax4, ax5, 
         backgroundcolor="w",
     )
 
-pyplot.tight_layout()
+plt.tight_layout()
 ```

--- a/docs/source/users/pmodel/isotopic_discrimination.md
+++ b/docs/source/users/pmodel/isotopic_discrimination.md
@@ -33,7 +33,7 @@ depends on the photosynthetic pathway.
 The {mod}`~pyrealm.pmodel` module provides the
 {class}`~pyrealm.pmodel.isotopes.CalcCarbonIsotopes` class, which takes the predicted
 optimal chi ($\chi$) and photosynthetic pathway from a fitted
-{class}`~pyrealm.pmodel.pmodel.PModel` instance and predicts various isotopic
+{class}`~pyrealm.pmodel.new_pmodel.PModelNew` instance and predicts various isotopic
 discrimination and composition values.
 
 The predictions from the {class}`~pyrealm.pmodel.isotopes.CalcCarbonIsotopes` class are
@@ -74,7 +74,7 @@ plt.show()
 ## Calculation of values
 
 The {class}`~pyrealm.pmodel.isotopes.CalcCarbonIsotopes` class takes a
-{class}`~pyrealm.pmodel.pmodel.PModel` instance, along with estimates of the atmospheric
+{class}`~pyrealm.pmodel.new_pmodel.PModelNew` instance, along with estimates of the atmospheric
 isotopic ratios for Carbon 13 ($\delta13C$, permil) and Carbon 14 ($\Delta14C$, permil)
 and calculates the following predictions:
 
@@ -92,7 +92,7 @@ and calculates the following predictions:
   permil), given a parameterized post-photosynthetic fractionation.
 
 The calculations differ between C3 and C4 plants, and this is set by the selection of
-the `method_optchi` argument used for the {class}`~pyrealm.pmodel.pmodel.PModel`
+the `method_optchi` argument used for the {class}`~pyrealm.pmodel.new_pmodel.PModelNew`
 instance.
 
 ```{code-cell} ipython3

--- a/docs/source/users/pmodel/isotopic_discrimination.md
+++ b/docs/source/users/pmodel/isotopic_discrimination.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.6
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
@@ -46,26 +46,29 @@ below for C3 and C4 plants.
 :tags: [hide-input]
 
 import numpy as np
-from matplotlib import pyplot
+import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
-from pyrealm.pmodel import PModel, PModelEnvironment, CalcCarbonIsotopes
+from pyrealm.pmodel.new_pmodel import PModelNew
+from pyrealm.pmodel import PModelEnvironment, CalcCarbonIsotopes
 
 # Use a simple temperature sequence to generate a range of optimal chi values
 n_pts = 31
 tc_1d = np.linspace(-10, 40, n_pts)
 
-# Fit models - GPP estimation not needed so fapar and ppfd set to unity
+# Fit models. Since only relative light use efficiency is needed,
+# fAPAR and PPFD are set to unity.
 env = PModelEnvironment(tc=tc_1d, patm=101325, co2=400, vpd=1000, fapar=1, ppfd=1)
-mod_c3 = PModel(env, method_optchi="prentice14")
-mod_c4 = PModel(env, method_optchi="c4")
+mod_c3 = PModelNew(env, method_optchi="prentice14")
+mod_c4 = PModelNew(env, method_optchi="c4")
 
-pyplot.scatter(tc_1d, mod_c3.optchi.chi.flatten(), label="C3")
-pyplot.scatter(tc_1d, mod_c4.optchi.chi.flatten(), label="C4")
-pyplot.title(r"Variation in $\chi$ with temperature")
-pyplot.xlabel("Temperature (°C)")
-pyplot.ylabel(r"Predicted optimal $\chi$")
-pyplot.legend()
+plt.plot(tc_1d, mod_c3.optchi.chi.flatten(), label="C3", marker=".")
+plt.plot(tc_1d, mod_c4.optchi.chi.flatten(), label="C4", marker=".")
+plt.title(r"Variation in $\chi$ with temperature")
+plt.xlabel("Temperature (°C)")
+plt.ylabel(r"Predicted optimal $\chi$")
+plt.legend(frameon=False)
+plt.show()
 ```
 
 ## Calculation of values
@@ -110,7 +113,7 @@ isotopic signature of relative contributions of the two pathways.
 :tags: [hide-input]
 
 # Create side by side subplots
-fig, axes = pyplot.subplots(2, 3, figsize=(12, 8))
+fig, axes = plt.subplots(2, 3, figsize=(12, 8))
 
 attrs = [
     "Delta13C_simple",
@@ -128,7 +131,7 @@ for attr, ax in zip(attrs, axes.flatten()):
     ax.set_title(attr)
     ax.set_ylabel(attr)
     ax.set_xlabel("Optimal Chi (-)")
-    ax.legend()
+    ax.legend(frameon=False)
 
 fig.tight_layout()
 ```

--- a/docs/source/users/pmodel/module_overview.md
+++ b/docs/source/users/pmodel/module_overview.md
@@ -41,7 +41,7 @@ ecophysiological model of optimal carbon dioxide uptake by plants
   * estimation of [electron transfer rate limitation](pmodel_details/jmax_limitation),
     and
   * the estimation of [gross primary
-    productivity](pmodel_details/envt_variation_outputs.md#estimating-productivity).
+    productivity](pmodel_details/envt_variation_outputs.md#productivity-outputs).
 
 * Approaches to the impacts of [soil moisture stress](pmodel_details/soil_moisture).
 * The behaviour of P Model equations with [extreme forcing

--- a/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
+++ b/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
@@ -124,9 +124,11 @@ environmental variables:
 * Vapour pressure deficit: 500 Pa and 2000 Pa
 * $\ce{CO2}$ concentration: 280 ppm and 410 ppm.
 
-All of the predictions are made using the same estimate of absorbed irradiance,
-calculate as the product of the fraction of absorbed photosynthetically active radiation
-($f_{APAR}= 0.91$) and photosynetic photon flux density (PPFD =  600 µmol m-2 s-1).
+For the plots below, productivity has been estimated using a representative
+irradiance values at the top of a tropical rainforest canopy:
+
+* $f_{APAR}$: 0.91 (unitless)
+* PPFD: 600 µmol m-2 s-1
 
 ```{warning}
 
@@ -220,15 +222,11 @@ unit of water, in units of $\mu\mathrm{mol}\;\mathrm{mol}^{-1}$.
 plot_fun("iwue", r"IWUE ($\mu\mathrm{mol}\;\mathrm{mol}^{-1}$)")
 ```
 
-(estimating-productivity)=
-
-## Estimating productivity
+## Productivity outputs
 
 The remaining key outputs are measures of photosynthetic productivity, such as
-GPP, which are calculated by providing the P Model with estimates of the
-fraction of absorbed photosynthetically active radiation (`fapar`) and the
-photosynthetic photon flux density (`ppfd`). The product of these two variables
-is an estimate of absorbed irradiance ($I_{abs}$).
+GPP, which are calculated using the provided estimates of PPFD and FAPAR and the
+resulting absorbed irradiance ($I_{abs}$).
 
 The productivity variables and their units are:
 
@@ -241,16 +239,6 @@ The productivity variables and their units are:
 * Maximum rate of electron transport.
     (``jmax``, $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$)
 * Stomatal conductance (``gs``, $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$)
-
-For the plots below, productivity has been estimated using a representative
-irradiance values at the top of a tropical rainforest canopy:
-
-* $f_{APAR}$: 0.91 (unitless)
-* PPFD: 600 $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$
-
-If required, productivity estimates per unit absorbed irradiance can be simply
-calculated using ``fapar=1, ppfd=1``, which are the default values to
-{meth}`~pyrealm.pmodel.pmodel.PModel.estimate_productivity`.
 
 ### Gross primary productivity (``gpp``, GPP)
 
@@ -299,9 +287,8 @@ plot_fun("jmax", r"$J_{max}$   ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-
 Stomatal conductance is estimated using the difference between ambient and optimal
 internal leaf $\ce{CO2}$ concentration. When vapour pressure deficit is zero, the
 difference between $c_a$ and $c_i$ will tend to zero, which leads to numerical
-instability in estimates of $g_s$. The
-{meth}`~pyrealm.pmodel.pmodel.PModel.estimate_productivity` method will set $g_s$ to be
-undefined (`np.nan`) when VPD is zero or when $c_a - c_i = 0$.
+instability in estimates of $g_s$, which will be set as undefined (`np.nan`) when VPD is
+zero or when $c_a - c_i = 0$.
 
 ```{code-cell} ipython3
 :tags: [hide-input]

--- a/docs/source/users/pmodel/pmodel_details/jmax_limitation.md
+++ b/docs/source/users/pmodel/pmodel_details/jmax_limitation.md
@@ -27,9 +27,10 @@ language_info:
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-from matplotlib import pyplot
+import matplotlib.pyplot as plt
 import numpy as np
-from pyrealm.pmodel import PModel, PModelEnvironment
+from pyrealm.pmodel.new_pmodel import PModelNew
+from pyrealm.pmodel import PModelEnvironment
 
 %matplotlib inline
 
@@ -41,7 +42,7 @@ tc_1d = np.linspace(-25, 50, n_pts)
 ```
 
 Environmental conditions can also lead to limitation of both the electron transfer rate
-($J_{max})and the carboxylation capacity ($V_{cmax}$) of leaves. The
+($J_{max}$)and the carboxylation capacity ($V_{cmax}$) of leaves. The
 {class}`~pyrealm.pmodel.pmodel` module implements three alternative approaches to the
 calculation of $J_{max}$ and $V_{cmax}$ and these are specified when fitting a P Model
 using the argument `method_jmaxlim`. These options implement alternative calculations of
@@ -68,24 +69,24 @@ temperature gradient. The other forcing variables are fixed ($P=101325.0 , \ce{C
 # so set fapar and ppfd to unity
 env = PModelEnvironment(tc=tc_1d, patm=101325, vpd=820, co2=400, fapar=1, ppfd=1)
 
-model_jmax_simple = PModel(
+model_jmax_simple = PModelNew(
     env, method_jmaxlim="none", method_kphio="fixed", reference_kphio=0.08
 )
-model_jmax_wang17 = PModel(
+model_jmax_wang17 = PModelNew(
     env, method_jmaxlim="wang17", method_kphio="fixed", reference_kphio=0.08
 )
-model_jmax_smith19 = PModel(
+model_jmax_smith19 = PModelNew(
     env, method_jmaxlim="smith19", method_kphio="fixed", reference_kphio=0.08
 )
 
 # Create a line plot of the resulting values of m_j
-pyplot.plot(tc_1d, model_jmax_simple.lue, label="simple")
-pyplot.plot(tc_1d, model_jmax_wang17.lue, label="wang17")
-pyplot.plot(tc_1d, model_jmax_smith19.lue, label="smith19")
+plt.plot(tc_1d, model_jmax_simple.lue, label="simple")
+plt.plot(tc_1d, model_jmax_wang17.lue, label="wang17")
+plt.plot(tc_1d, model_jmax_smith19.lue, label="smith19")
 
-pyplot.title("Effects of J_max limitation")
-pyplot.xlabel("Temperature °C")
-pyplot.ylabel("Light Use Efficiency (g C mol-1)")
-pyplot.legend()
-pyplot.show()
+plt.title("Effects of J_max limitation")
+plt.xlabel("Temperature °C")
+plt.ylabel("Light Use Efficiency (g C mol-1)")
+plt.legend()
+plt.show()
 ```

--- a/docs/source/users/pmodel/pmodel_details/jmax_limitation.md
+++ b/docs/source/users/pmodel/pmodel_details/jmax_limitation.md
@@ -43,11 +43,11 @@ tc_1d = np.linspace(-25, 50, n_pts)
 
 Environmental conditions can also lead to limitation of both the electron transfer rate
 ($J_{max}$)and the carboxylation capacity ($V_{cmax}$) of leaves. The
-{class}`~pyrealm.pmodel.pmodel` module implements three alternative approaches to the
-calculation of $J_{max}$ and $V_{cmax}$ and these are specified when fitting a P Model
-using the argument `method_jmaxlim`. These options implement alternative calculations of
-two factor ($f_j$ and $f_v$) which are applied to the calculation of $J_{max}$ and
-$V_{cmax}$. The options for this setting are:
+{class}`~pyrealm.pmodel.jmax_limitation` module implements three alternative approaches
+to the calculation of $J_{max}$ and $V_{cmax}$ and these are specified when fitting a P
+Model using the argument `method_jmaxlim`. These options implement alternative
+calculations of two factor ($f_j$ and $f_v$) which are applied to the calculation of
+$J_{max}$ and $V_{cmax}$. The options for this setting are:
 
 * `none`: This approach implements $f_j  = f_v = 1$ and hence no modification.
 * `wang17`: This is the default setting for `method_jmaxlim` and applies the

--- a/docs/source/users/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/users/pmodel/pmodel_details/optimal_chi.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.6
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
@@ -84,7 +84,8 @@ from matplotlib import pyplot
 from matplotlib.lines import Line2D
 
 from pyrealm.pmodel.optimal_chi import OptimalChiPrentice14
-from pyrealm.pmodel import PModelEnvironment, PModel
+from pyrealm.pmodel import PModelEnvironment
+from pyrealm.pmodel.new_pmodel import PModelNew
 
 # Create inputs for a temperature curve at:
 # - two atmospheric pressures
@@ -213,7 +214,7 @@ This **C3 method** follows the approach detailed in {cite:t}`Prentice:2014bc`, s
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
-pmodel_c3 = PModel(pmodel_env, method_optchi="prentice14")
+pmodel_c3 = PModelNew(pmodel_env, method_optchi="prentice14")
 plot_opt_chi(pmodel_c3)
 ```
 
@@ -227,7 +228,7 @@ See {class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4` for details.
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
-pmodel_c4 = PModel(pmodel_env, method_optchi="c4")
+pmodel_c4 = PModelNew(pmodel_env, method_optchi="c4")
 plot_opt_chi(pmodel_c4)
 ```
 
@@ -245,7 +246,7 @@ and also also sets $m_j = 1$, but $m_c$ is calculated as in
 :tags: [hide-input]
 
 # Run the P Model and plot predictions
-pmodel_c4 = PModel(pmodel_env, method_optchi="c4_no_gamma")
+pmodel_c4 = PModelNew(pmodel_env, method_optchi="c4_no_gamma")
 plot_opt_chi(pmodel_c4)
 ```
 

--- a/docs/source/users/pmodel/pmodel_details/optimal_chi.md
+++ b/docs/source/users/pmodel/pmodel_details/optimal_chi.md
@@ -45,9 +45,9 @@ The  {class}`~pyrealm.pmodel.optimal_chi` module provides the following methods 
 calculating these values, providing options to handle C3 and C4 photosynthesis and
 different implementations of water stress. In normal practice, a given method is
 selected using the `method_optchi` argument when fitting a
-{class}`~pyrealm.pmodel.pmodel.PModel`. In the background, those method names are used
-to select from a set of classes that implement the different calculations. Some of the
-examples below show these classes being used directly. The methods and classes built
+{class}`~pyrealm.pmodel.new_pmodel.PModelNew`. In the background, those method names are
+used to select from a set of classes that implement the different calculations. Some of
+the examples below show these classes being used directly. The methods and classes built
 into `pyrealm` are shown below, but it is possible for users to add alternative methods
 for use within a P Model.
 

--- a/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
+++ b/docs/source/users/pmodel/pmodel_details/pmodel_overview.md
@@ -112,10 +112,10 @@ take care when selecting methods for fitting the P model.
 
 :::
 
-As a final stage, once the LUE has been calculated, then estimates of the actual
-absorbed irradiance for a section of canopy (µmols of photons per m2 per second) can
-then be used to estimate [gross primary productivity](estimating-productivity) (GPP) and
-other key rates within the leaf.
+Once the LUE has been calculated, then estimates of the actual absorbed irradiance
+(µmols of photons per m2 per second) are used to estimate [gross primary
+productivity](./envt_variation_outputs.md#productivity-outputs) (GPP) and other key
+rates within the leaf.
 
 ## Variable graph
 

--- a/docs/source/users/pmodel/pmodel_details/quantum_yield.md
+++ b/docs/source/users/pmodel/pmodel_details/quantum_yield.md
@@ -75,7 +75,7 @@ a parameter representing canopy-scale effective quantum yield.
 * The maximum quantum yield can vary with environmental conditions, such as temperature
 variation in $\phi_0$ {cite}`Bernacchi:2003dc`.
 
-For these reasons, the {class}`~pyrealm.pmodel.pmodel.PModel` provides alternative
+For these reasons, the {class}`~pyrealm.pmodel.new_pmodel.PModelNew` provides alternative
 approaches to estimating the value of $\phi{0}$, using the `method_kphio` argument. The
 currently implemented approaches are described below. Note that each approach has a
 specific **reference value for $\phi_{0}$**, which is used as the baseline for further

--- a/docs/source/users/pmodel/pmodel_details/quantum_yield.md
+++ b/docs/source/users/pmodel/pmodel_details/quantum_yield.md
@@ -34,12 +34,11 @@ language_info:
 # arrays of repeating values (`_2d`) to generate response surfaces for functions
 # with multuple inputs.
 
-from matplotlib import pyplot
+import matplotlib.pyplot as plt
 import numpy as np
-from pyrealm.pmodel import PModel, PModelEnvironment
+from pyrealm.pmodel import PModelEnvironment
+from pyrealm.pmodel.new_pmodel import PModelNew
 from pyrealm.pmodel.quantum_yield import QuantumYieldTemperature, QuantumYieldSandoval
-
-%matplotlib inline
 
 # Set the resolution of examples
 n_pts = 201
@@ -100,14 +99,14 @@ fkphio_c3 = QuantumYieldTemperature(env=env, use_c4=False)
 fkphio_c4 = QuantumYieldTemperature(env=env, use_c4=True)
 
 # Create a line plot of ftemp kphio
-pyplot.plot(tc_1d, fkphio_c3.kphio, label="C3")
-pyplot.plot(tc_1d, fkphio_c4.kphio, label="C4")
+plt.plot(tc_1d, fkphio_c3.kphio, label="C3")
+plt.plot(tc_1d, fkphio_c4.kphio, label="C4")
 
-pyplot.title("Temperature dependence of quantum yield efficiency")
-pyplot.xlabel("Temperature °C")
-pyplot.ylabel("Quantum yield efficiency ($\phi_0$)")
-pyplot.legend()
-pyplot.show()
+plt.title("Temperature dependence of quantum yield efficiency")
+plt.xlabel("Temperature °C")
+plt.ylabel("Quantum yield efficiency ($\phi_0$)")
+plt.legend()
+plt.show()
 ```
 
 ## Fixed $\phi_0$
@@ -143,14 +142,14 @@ env = PModelEnvironment(
     fapar=np.repeat(1, n_vals),
     ppfd=np.repeat(1, n_vals),
 )
-model_var_kphio = PModel(env, method_kphio="fixed", reference_kphio=kphio_values)
+model_var_kphio = PModelNew(env, method_kphio="fixed", reference_kphio=kphio_values)
 
 # Create a line plot of ftemp kphio
-pyplot.plot(kphio_values, model_var_kphio.lue)
-pyplot.title("Variation in LUE with changing $\phi_0$")
-pyplot.xlabel("$\phi_0$")
-pyplot.ylabel("LUE")
-pyplot.show()
+plt.plot(kphio_values, model_var_kphio.lue)
+plt.title("Variation in LUE with changing $\phi_0$")
+plt.xlabel("$\phi_0$")
+plt.ylabel("LUE")
+plt.show()
 ```
 
 ## Temperature and aridity effects on $\phi_0$
@@ -189,13 +188,13 @@ env = PModelEnvironment(
 
 sandoval_kphio = QuantumYieldSandoval(env)
 
-fig, ax = pyplot.subplots(1, 1)
+fig, ax = plt.subplots(1, 1)
 ax.plot(aridity_index, sandoval_kphio.kphio)
 ax.set_title("Change in $\phi_0$ with aridity index (P/PET).")
 ax.set_ylabel("$\phi_0$")
 ax.set_xlabel("Aridity Index")
 ax.set_xscale("log")
-pyplot.show()
+plt.show()
 ```
 
 In addition to capping the peak $\phi_0$ as a function of the aridity index, this
@@ -229,7 +228,7 @@ env = PModelEnvironment(
 
 sandoval_kphio = QuantumYieldSandoval(env)
 
-fig, axes = pyplot.subplots(ncols=3, nrows=1, sharey=True, figsize=(10, 6))
+fig, axes = plt.subplots(ncols=3, nrows=1, sharey=True, figsize=(10, 6))
 
 for ai_idx, (ax, ai_val) in enumerate(zip(axes, aridity_values)):
 
@@ -245,5 +244,5 @@ for ai_idx, (ax, ai_val) in enumerate(zip(axes, aridity_values)):
 
 
 ax.legend(frameon=False)
-pyplot.show()
+plt.show()
 ```

--- a/docs/source/users/pmodel/pmodel_details/rpmodel.md
+++ b/docs/source/users/pmodel/pmodel_details/rpmodel.md
@@ -79,14 +79,14 @@ The implementations differ in a number of ways:
    requiring the logical flag. However, the function also include steps that
    could be provided by the user. That means a user can put in all the variables
    in one function, but makes for a more confusing interface and is less
-   flexible. The {class}`~pyrealm.pmodel.pmodel.PModel` class reduces this to a simpler
+   flexible. The {class}`~pyrealm.pmodel.new_pmodel.PModelNew` class reduces this to a simpler
    core of inputs and methods and functions reproduce the rest of the
    functionality in the P Model.
 
-   One key difference here is that the ``rpmodel`` function extended the
-   implementation of the empirical soil moisture factor $\beta(\theta)$ from a simple
-   factor on light use efficiency (LUE) to estimate the underlying values of $J_{max}$
-   and $V_{cmax}$. In the {mod}`~pyrealm.pmodel` module, the $\beta(\theta)$ is _only_
-   applied as a post-hoc penalty factor to {attr}`~pyrealm.pmodel.pmodel.PModel.gpp` and
-   so does not implement any correction of $J_{max}$ and $V_{cmax}$ for soil moisture
+   One key difference here is that the ``rpmodel`` function extended the implementation
+   of the empirical soil moisture factor $\beta(\theta)$ from a simple factor on light
+   use efficiency (LUE) to estimate the underlying values of $J_{max}$ and $V_{cmax}$.
+   In the {mod}`~pyrealm.pmodel` module, the $\beta(\theta)$ is _only_ applied as a
+   post-hoc penalty factor to {attr}`~pyrealm.pmodel.new_pmodel.PModelNew.gpp` and so
+   does not implement any correction of $J_{max}$ and $V_{cmax}$ for soil moisture
    effects.

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.6
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
@@ -102,7 +102,7 @@ the examples below, the default $\theta_0 = 0$ has been changed to $\theta_0 =
 from matplotlib import pyplot as plt
 import numpy as np
 from pyrealm import pmodel
-from pyrealm.pmodel.pmodel import PModel
+from pyrealm.pmodel.new_pmodel import PModelNew
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 from pyrealm.constants import PModelConst
 
@@ -151,8 +151,6 @@ ax2.set_ylabel(r"Empirical soil moisture factor, $\beta(\theta)$")
 plt.show()
 ```
 
-+++ {"user_expressions": []}
-
 ### Application of the {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` factor
 
 The factor can be applied to the P Model by using
@@ -168,8 +166,8 @@ tc = np.array([20] * 101)
 sm_gradient = np.linspace(0, 1.0, 101)
 
 env = PModelEnvironment(tc=tc, patm=101325.0, vpd=820, co2=400, fapar=1, ppfd=1000)
-model = PModel(env)
-model.estimate_productivity(fapar=1, ppfd=1000)
+model = PModelNew(env)
+
 
 # Calculate the soil moisture stress factor across a soil moisture gradient
 # at differing aridities
@@ -318,8 +316,4 @@ plt.xlabel(r"Relative soil moisture $\theta$")
 plt.ylabel("GPP")
 plt.legend()
 plt.show()
-```
-
-```{code-cell} ipython3
-
 ```

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -155,7 +155,7 @@ plt.show()
 
 The factor can be applied to the P Model by using
 {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` to calculate the factor
-values and then multiplying calculated GPP ({attr}`~pyrealm.pmodel.pmodel.PModel.gpp`)
+values and then multiplying calculated GPP ({attr}`~pyrealm.pmodel.new_pmodel.PModelNew.gpp`)
 by the resulting factor. The example below shows how the predicted light use
 efficiency from the P Model changes across an aridity gradient both with and without the
 soil moisture factor.
@@ -304,7 +304,7 @@ under drier conditions.
 
 As with  {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker`, the factor is first
 calculated and then applied to the GPP calculated for a model
-({attr}`~pyrealm.pmodel.pmodel.PModel.gpp`). In the example below, the result is
+({attr}`~pyrealm.pmodel.new_pmodel.PModelNew.gpp`). In the example below, the result is
 obviously just $\beta(\theta)$ from above scaled to the constant GPP.
 
 ```{code-cell} ipython3

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -103,7 +103,7 @@ env.summarize()
 ### Fitting the P Model
 
 Next, the P Model can be fitted to the photosynthetic environment using the
-({class}`~pyrealm.pmodel.pmodel.PModel`) class:
+({class}`~pyrealm.pmodel.new_pmodel.PModelNew`) class:
 
 ```{code-cell} ipython3
 model = PModelNew(env)
@@ -116,8 +116,8 @@ model object shows a terse display of the settings used to run the model:
 model
 ```
 
-A {class}`~pyrealm.pmodel.pmodel.PModel` instance also has a
-{meth}`~pyrealm.pmodel.pmodel.PModel.summarize` method that summarizes settings and
+A {class}`~pyrealm.pmodel.new_pmodel.PModelNew` instance also has a
+{meth}`~pyrealm.pmodel.new_pmodel.PModelNew.summarize` method that summarizes settings and
 displays a summary of calculated predictions. Initially, this shows two measures of
 photosynthetic efficiency: the intrinsic water use efficiency (``iwue``) and the light
 use efficiency (``lue``).

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -33,6 +33,18 @@ data to be be passed to all inputs. Input arrays can be a single scalar value, b
 non-scalar inputs must be **arrays with the same shape**: the `pyrealm` packages does
 not attempt to resolve the broadcasting of array dimensions.
 
+```{code-cell} ipython3
+from importlib import resources
+
+from matplotlib import pyplot as plt
+import numpy as np
+import xarray
+
+from pyrealm.pmodel.new_pmodel import PModelNew
+from pyrealm.pmodel import PModelEnvironment
+from pyrealm.core.pressure import calc_patm
+```
+
 ## Simple point estimate
 
 This example calculates a single point estimate of GPP. The first step is to use
@@ -47,31 +59,42 @@ The example shows the steps required using a single site with:
 * a vapour pressure deficit of 0.82 kPa (~ 65% relative humidity), and
 * an atmospheric $\ce{CO2}$ concentration of 400 ppm.
 
-### Estimate photosynthetic environment
+### Estimating productivity
+
+The {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` also accepts estimates
+of the fraction of absorbed photosynthetically active radiation ($f_{APAR}$, `fapar`,
+unitless) and the photosynthetic photon flux density (PPFD,`ppfd`, µmol m-2 s-1).
+Together these are used to calculate the asorbed irradiance, which is used to scale up
+the estimated light use efficiency to estimate the actual productivity of the model.
+Here we are using:
+
+* An absorption fraction of 0.91 (-), and
+* a PPFD of 834 µmol m-2 s-1.
+
+```{warning}
+
+In the {meth}`~pyrealm.pmodel.pmodel.PModelEnvironment`, the estimated PPFD
+must be expressed as **µmol m-2 s-1**.
+
+Estimates of PPFD sometimes use different temporal or spatial scales - for
+example daily moles of photons per hectare. Although GPP can also be expressed
+with different units, many other predictions of the P Model ($J_{max}$,
+$V_{cmax}$, $g_s$ and $r_d$) _must_ be expressed as µmol m-2 s-1 and so this
+standard unit must also be used for PPFD.
+```
 
 ```{code-cell} ipython3
-from importlib import resources
-
-from matplotlib import pyplot as plt
-import numpy as np
-import xarray
-
-from pyrealm.pmodel import PModel, PModelEnvironment
-from pyrealm.core.pressure import calc_patm
-
 # Calculate the PModelEnvironment
 env = PModelEnvironment(tc=20.0, patm=101325.0, vpd=820, co2=400, fapar=0.91, ppfd=834)
-```
-
-The `env` object now holds the photosynthetic environment, which can be re-used
-with different P Model settings. The representation of `env` is deliberately
-terse - just the shape of the data - but the
-{meth}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment.summarize` method provides a
-more detailed summary of the attributes.
-
-```{code-cell} ipython3
 env
 ```
+
+The `env` object now holds the photosynthetic environment, which can be re-used with
+different P Model settings. The representation of a
+{class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` object (`env`) is
+deliberately terse - just the shape of the data - but the
+{class}`PModelEnvironment.summarize<pyrealm.pmodel.pmodel_environment.PModelEnvironment.summarize>`
+method provides a more detailed summary of the attributes.
 
 ```{code-cell} ipython3
 env.summarize()
@@ -83,7 +106,7 @@ Next, the P Model can be fitted to the photosynthetic environment using the
 ({class}`~pyrealm.pmodel.pmodel.PModel`) class:
 
 ```{code-cell} ipython3
-model = PModel(env)
+model = PModelNew(env)
 ```
 
 The returned model object holds a lot of information. The representation of the
@@ -113,35 +136,6 @@ method:
 
 ```{code-cell} ipython3
 model.optchi.summarize()
-```
-
-### Estimating productivity outputs
-
-The productivity of the model can be calculated using estimates of the fraction
-of absorbed photosynthetically active radiation ($f_{APAR}$, `fapar`, unitless)
-and the photosynthetic photon flux density (PPFD,`ppfd`, µmol m-2 s-1), using the
-{meth}`~pyrealm.pmodel.pmodel.PModel.estimate_productivity` method.
-
-Here we are using:
-
-* An absorption fraction of 0.91 (-), and
-* a PPFD of 834 µmol m-2 s-1.
-
-```{code-cell} ipython3
-model.estimate_productivity(fapar=0.91, ppfd=834)
-model.summarize()
-```
-
-```{warning}
-
-To use {meth}`~pyrealm.pmodel.pmodel.PModel.estimate_productivity`, the estimated PPFD
-must be expressed as **µmol m-2 s-1**.
-
-Estimates of PPFD sometimes use different temporal or spatial scales - for
-example daily moles of photons per hectare. Although GPP can also be expressed
-with different units, many other predictions of the P Model ($J_{max}$,
-$V_{cmax}$, $g_s$ and $r_d$) _must_ be expressed as µmol m-2 s-1 and so this
-standard unit must also be used for PPFD.
 ```
 
 ## 3D grid example
@@ -193,27 +187,26 @@ env = PModelEnvironment(tc=temp, co2=co2, patm=patm, vpd=vpd, fapar=fapar, ppfd=
 env.summarize()
 ```
 
-That environment can then be run to calculate the P model predictions for light use
-efficiency:
+That environment can then be run to calculate the P model predictions for GPP:
 
 ```{code-cell} ipython3
 # Run the P model
-model = PModel(env)
+model = PModelNew(env)
+
+fig, (ax1, ax2) = plt.subplots(2, 1)
 
 # Plot LUE for first month
-im = plt.imshow(model.lue[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
-plt.colorbar(im, fraction=0.022, pad=0.03)
-plt.title("Light use efficiency")
+im = ax1.imshow(model.lue[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
+plt.colorbar(im, fraction=0.022, pad=0.03, ax=ax1)
+ax1.set_title("LUE")
+
+im = ax2.imshow(model.gpp[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
+plt.colorbar(im, fraction=0.022, pad=0.03, ax=ax2)
+ax2.set_title("GPP")
+
+plt.tight_layout()
 ```
 
-Finally, the light use efficiency can be used to calculate GPP given the
-photosynthetic photon flux density and fAPAR.
-
 ```{code-cell} ipython3
-# Scale the outputs from values per unit iabs to realised values
-model.estimate_productivity(fapar, ppfd)
 
-im = plt.imshow(model.gpp[0, :, :], origin="lower", extent=[-180, 180, -90, 90])
-plt.colorbar(im, fraction=0.022, pad=0.03)
-plt.title("GPP")
 ```

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -73,7 +73,7 @@ Here we are using:
 
 ```{warning}
 
-In the {meth}`~pyrealm.pmodel.pmodel.PModelEnvironment`, the estimated PPFD
+In the {meth}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`, the estimated PPFD
 must be expressed as **µmol m-2 s-1**.
 
 Estimates of PPFD sometimes use different temporal or spatial scales - for

--- a/docs/source/users/pmodel/subdaily_details/acclimation.md
+++ b/docs/source/users/pmodel/subdaily_details/acclimation.md
@@ -57,7 +57,7 @@ from pyrealm.pmodel.acclimation import AcclimationModel
 ## The acclimation model
 
 Defining the model to be used for estimating acclimation uses the
-{class}`~pyrealm.pmodel.acclimation import AcclimationModel`. This class is used to:
+{class}`~pyrealm.pmodel.acclimation.AcclimationModel`. This class is used to:
 
 * define the timing of observations on a subdaily scale,
 * define an daily acclimation window that sets the daily conditions that plants will

--- a/docs/source/users/pmodel/subdaily_details/acclimation.md
+++ b/docs/source/users/pmodel/subdaily_details/acclimation.md
@@ -7,7 +7,7 @@ jupytext:
     format_version: 0.13
     jupytext_version: 1.16.6
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
@@ -51,18 +51,25 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle, Patch
 import matplotlib.dates as mdates
 
-from pyrealm.pmodel import SubdailyScaler, memory_effect
+from pyrealm.pmodel.acclimation import AcclimationModel
 ```
 
-## The acclimation window
+## The acclimation model
 
-Defining the acclimation window uses the
-{class}`~pyrealm.pmodel.scaler.SubdailyScaler`:  this class is used to define
-the timing of observations on a fast time scale and then set the daily window. The code
+Defining the model to be used for estimating acclimation uses the
+{class}`~pyrealm.pmodel.acclimation import AcclimationModel`. This class is used to:
+
+* define the timing of observations on a subdaily scale,
+* define an daily acclimation window that sets the daily conditions that plants will
+  optimise their behaviour towards,
+* apply acclimation lags to optimal behaviour to give daily realised values, and
+* sample daily realised values back to the subdaily time scale.
+
+The code
 below creates a simple time series representing a parameter responding instantaneously
 to changing environmental conditions on a fast scale.
 
-The code then sets up a `SubdailyScaler` instance using the observations time on the
+The code then sets up a `AcclimationModel` instance using the observations time on the
 fast scale and sets a 6 hour acclimation window around noon. This is a particularly wide
 acclimation window, chosen to make it easier to see different approaches to
 interpolating data back to subdaily timescales. In practice {cite:t}`mengoli:2022a`
@@ -71,19 +78,22 @@ noon.
 
 ```{code-cell} ipython3
 # Define a set of observations at a subdaily timescale
-fast_datetimes = np.arange(
+subdaily_datetimes = np.arange(
     np.datetime64("1970-01-01"), np.datetime64("1970-01-08"), np.timedelta64(30, "m")
 )
 
 # A simple artificial variable showing daily patterns and a temporal trend
-fast_data = -np.cos((fast_datetimes.astype("int")) / ((60 * 24) / (2 * np.pi)))
-fast_data = fast_data * np.linspace(1, 0.1, len(fast_data))
-fast_data = np.where(fast_data < 0, 0, fast_data)
+subdaily_data = -np.cos((subdaily_datetimes.astype("int")) / ((60 * 24) / (2 * np.pi)))
+subdaily_data = subdaily_data * np.linspace(1, 0.1, len(subdaily_data))
+subdaily_data = np.where(subdaily_data < 0, 0, subdaily_data)
 
-# Create a scaler, using a deliberately wide 6 hour window around noon
-demo_scaler = SubdailyScaler(fast_datetimes)
+# Create an acclimation model, using a deliberately wide 6 hour window around noon
+acclim_model = AcclimationModel(datetimes=subdaily_datetimes)
+
+window_center = np.timedelta64(12, "h")
 half_width = np.timedelta64(3, "h")
-demo_scaler.set_window(window_center=np.timedelta64(12, "h"), half_width=half_width)
+
+acclim_model.set_window(window_center=window_center, half_width=half_width)
 ```
 
 The plot below shows the rapidly changing variable and the defined daily acclimation
@@ -99,13 +109,13 @@ acclim_windows = [
     Rectangle(
         (win_center - half_width, 0), 2 * half_width, 1, facecolor="salmon", alpha=0.3
     )
-    for win_center in demo_scaler.sample_datetimes_mean
+    for win_center in acclim_model.sample_datetimes_mean
 ]
 
 [ax.add_patch(copy(p)) for p in acclim_windows]
 
-# Show the variable at the fast timescale
-ax.plot(fast_datetimes, fast_data, "-", color="0.4", linewidth=0.7)
+# Show the variable at the subdaily timescale
+ax.plot(subdaily_datetimes, subdaily_data, "-", color="0.4", linewidth=0.7)
 
 # Format date axis
 myFmt = mdates.DateFormatter("%m/%d\n%H:%M")
@@ -141,13 +151,23 @@ the realised values are identical to the daily optimum value within the acclimat
 window.
 
 ```{code-cell} ipython3
-# Extract the optimal values within the daily acclimation windows
-daily_mean = demo_scaler.get_daily_means(fast_data)
+:lines_to_next_cell: 2
 
-# Get realised values with alpha = 1/8, 1/3 and 1
-real_8 = memory_effect(daily_mean, alpha=1 / 8)
-real_3 = memory_effect(daily_mean, alpha=1 / 3)
-real_1 = memory_effect(daily_mean, alpha=1)
+# Extract the optimal values within the daily acclimation windows
+daily_mean = acclim_model.get_daily_means(subdaily_data)
+
+# Build acclimation models with different alpha
+alpha_models = {}
+alpha_vals = (
+    (1 / 8, r"$\alpha = \frac{1}{8}$"),
+    (1 / 3, r"$\alpha = \frac{1}{3}$"),
+    (1, r"$\alpha = 1$"),
+)
+
+for alpha, _ in alpha_vals:
+    model = AcclimationModel(datetimes=subdaily_datetimes, alpha=alpha)
+    model.set_window(window_center=window_center, half_width=half_width)
+    alpha_models[alpha] = model
 ```
 
 ```{code-cell} ipython3
@@ -159,23 +179,26 @@ fig, ax = plt.subplots()
 [ax.add_patch(copy(p)) for p in acclim_windows]
 
 # Show the variable at the fast timescale
-ax.plot(fast_datetimes, fast_data, "-", color="0.4", linewidth=0.7)
+ax.plot(subdaily_datetimes, subdaily_data, "-", color="0.4", linewidth=0.7)
 
-# Show the three realised daily values and the optimal values
+# Show the optimal (daily mean) values
 ax.scatter(
-    demo_scaler.sample_datetimes_mean,
+    acclim_model.sample_datetimes_mean,
     daily_mean,
     facecolor="none",
     edgecolor="k",
     label=r"Daily optimum",
 )
-ax.plot(
-    demo_scaler.sample_datetimes_mean, real_8, "bx", label=r"$\alpha = \frac{1}{8}$"
-)
-ax.plot(
-    demo_scaler.sample_datetimes_mean, real_3, "gx", label=r"$\alpha = \frac{1}{3}$"
-)
-ax.plot(demo_scaler.sample_datetimes_mean, real_1, "rx", label=r"$\alpha = 1$")
+
+# Show the acclimated values under each of the three models
+for alpha, label in alpha_vals:
+    model = alpha_models[alpha]
+    ax.plot(
+        acclim_model.sample_datetimes_mean,
+        model.apply_acclimation(daily_mean),
+        "x",
+        label=label,
+    )
 
 ax.legend()
 
@@ -201,39 +224,11 @@ subdaily predictions. The interpolation process sets two things:
     is _always_ applied to avoid interpolating to a value that is not yet known.
 
 The code below shows how the
-{meth}`~pyrealm.pmodel.scaler.SubdailyScaler.fill_daily_to_subdaily` method is
+{meth}`~pyrealm.pmodel.acclimation.AcclimationModel.fill_daily_to_subdaily` method is
 used to interpolate realised values back to the subdaily scale, using different settings
 for the update point and interpolation method.
 
-```{code-cell} ipython3
-# Fill to the subdaily scale using the default settings:
-# - update at the end of the acclimation window
-# - hold the value constant between update points
-fast_real_8 = demo_scaler.fill_daily_to_subdaily(
-    real_8, kind="previous", update_point="max"
-)
-
-# Fill to the subdaily scale using:
-# - the default update point at the end of the acclimation window
-# - linear interpolation between update points.
-fast_real_3 = demo_scaler.fill_daily_to_subdaily(
-    real_3, kind="linear", update_point="max"
-)
-
-# Fill to the subdaily scale using:
-# - an update point at the middle of the acclimation window
-# - a constant value between update points.
-fast_real_1_prev = demo_scaler.fill_daily_to_subdaily(
-    real_1, kind="previous", update_point="mean"
-)
-
-# Fill to the subdaily scale using:
-# - an update point at the middle of the daily window
-# - linear interpolation between update points.
-fast_real_1_lin = demo_scaler.fill_daily_to_subdaily(
-    real_1, kind="linear", update_point="mean"
-)
-```
++++
 
 The plots below show the resulting interpolated values along with the instantaneous
 daily optimal values (grey circles):
@@ -262,121 +257,154 @@ Plot D
 ```{code-cell} ipython3
 :tags: [hide-input]
 
+scenarios = {
+    "A": dict(alpha=1 / 8, fill_method="previous", update_point="max"),
+    "B": dict(alpha=1 / 3, fill_method="linear", update_point="max"),
+    "C": dict(alpha=1, fill_method="previous", update_point="mean"),
+    "D": dict(alpha=1, fill_method="linear", update_point="mean"),
+}
+
 # Create the figure
-fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, figsize=(6, 8), sharex=True)
+fig, axes = plt.subplots(4, 1, figsize=(6, 8), sharex=True)
 
-for this_ax in [ax1, ax2, ax3, ax4]:
+for (scenario_id, scenario_details), axis in zip(scenarios.items(), axes):
+
     # Add the acclimation windows for each day
-    [this_ax.add_patch(copy(p)) for p in acclim_windows]
+    [axis.add_patch(copy(p)) for p in acclim_windows]
 
-    # Show the variable at the fast timescale and the daily optimal value
-    this_ax.plot(fast_datetimes, fast_data, "-", color="0.4", linewidth=0.7)
-    this_ax.scatter(
-        demo_scaler.sample_datetimes_mean,
-        daily_mean,
+    # Get the acclimation model for the scenario
+    model = AcclimationModel(subdaily_datetimes, **scenario_details)
+    model.set_window(window_center=window_center, half_width=half_width)
+
+    daily_optimal = model.get_daily_means(subdaily_data)
+    daily_realised = model.apply_acclimation(daily_mean)
+    subdaily_realised = model.fill_daily_to_subdaily(daily_realised)
+
+    # Show the variable at the subdaily timescale and the daily optimal value
+    axis.plot(subdaily_datetimes, subdaily_data, "-", color="0.4", linewidth=0.7)
+    axis.scatter(
+        model.sample_datetimes_mean,
+        daily_optimal,
         s=15,
         c="C3",
         marker="x",
         linewidth=1,
     )
+
+    axis.scatter(
+        model.sample_datetimes_max,  # change to sample_update_time?
+        daily_realised,
+        marker="d",
+        edgecolor="C0",
+        facecolor="none",
+    )
+    axis.plot(model.datetimes, subdaily_realised)
+
+    axis.text(0.95, 0.95, scenario_id, ha="right", va="top", transform=axis.transAxes)
+
     # Format date axis
     myFmt = mdates.DateFormatter("%m/%d\n%H:%M")
-    this_ax.xaxis.set_major_formatter(myFmt)
+    axis.xaxis.set_major_formatter(myFmt)
 
-# Show the alpha = 1/8 update point and fill back to the fast scale
-ax1.scatter(
-    demo_scaler.sample_datetimes_max,
-    real_8,
-    marker="d",
-    edgecolor="C0",
-    facecolor="none",
-)
-ax1.plot(demo_scaler.datetimes, fast_real_8, linewidth=0.5)
-ax1.text(0.95, 0.95, "(A)", ha="right", va="top", transform=ax1.transAxes)
+    # Add scenario label
+# # Show the alpha = 1/8 update point and fill back to the fast scale
+# ax1.scatter(
+#     demo_scaler.sample_datetimes_max,
+#     real_8,
+#     marker="d",
+#     edgecolor="C0",
+#     facecolor="none",
+# )
+# ax1.plot(demo_scaler.datetimes, fast_real_8, linewidth=0.5)
+# ax1.text(0.95, 0.95, "(A)", ha="right", va="top", transform=ax1.transAxes)
 
-# Show the alpha = 1/3 update point and fill back to the fast scale
-ax2.scatter(
-    demo_scaler.sample_datetimes_max,
-    real_3,
-    marker="d",
-    edgecolor="C0",
-    facecolor="none",
-)
-ax2.scatter(
-    demo_scaler.sample_datetimes_max + np.timedelta64(1, "D"),
-    real_3,
-    edgecolor="C1",
-    facecolor="none",
-    marker="s",
-)
-ax2.plot(demo_scaler.datetimes, fast_real_3, linewidth=0.5)
-ax2.text(0.95, 0.95, "(B)", ha="right", va="top", transform=ax2.transAxes)
+# # Show the alpha = 1/3 update point and fill back to the fast scale
+# ax2.scatter(
+#     demo_scaler.sample_datetimes_max,
+#     real_3,
+#     marker="d",
+#     edgecolor="C0",
+#     facecolor="none",
+# )
+# ax2.scatter(
+#     demo_scaler.sample_datetimes_max + np.timedelta64(1, "D"),
+#     real_3,
+#     edgecolor="C1",
+#     facecolor="none",
+#     marker="s",
+# )
+# ax2.plot(demo_scaler.datetimes, fast_real_3, linewidth=0.5)
+# ax2.text(0.95, 0.95, "(B)", ha="right", va="top", transform=ax2.transAxes)
 
-# Show the alpha = 1 update point and fill back to the fast scale using constant
-ax3.scatter(
-    demo_scaler.sample_datetimes_mean,
-    real_1,
-    marker="d",
-    edgecolor="C0",
-    facecolor="none",
-)
-ax3.plot(demo_scaler.datetimes, fast_real_1_prev, linewidth=0.5)
-ax3.text(0.95, 0.95, "(C)", ha="right", va="top", transform=ax3.transAxes)
+# # Show the alpha = 1 update point and fill back to the fast scale using constant
+# ax3.scatter(
+#     demo_scaler.sample_datetimes_mean,
+#     real_1,
+#     marker="d",
+#     edgecolor="C0",
+#     facecolor="none",
+# )
+# ax3.plot(demo_scaler.datetimes, fast_real_1_prev, linewidth=0.5)
+# ax3.text(0.95, 0.95, "(C)", ha="right", va="top", transform=ax3.transAxes)
 
-# Show the alpha = 1 update point and fill back to the fast scale
-ax4.scatter(
-    demo_scaler.sample_datetimes_mean,
-    real_1,
-    marker="d",
-    edgecolor="C0",
-    facecolor="none",
-)
-ax4.scatter(
-    demo_scaler.sample_datetimes_mean + np.timedelta64(1, "D"),
-    real_1,
-    edgecolor="C1",
-    facecolor="none",
-    marker="s",
-)
-ax4.plot(demo_scaler.datetimes, fast_real_1_lin, linewidth=0.5)
-ax4.text(0.95, 0.95, "(D)", ha="right", va="top", transform=ax4.transAxes)
+# # Show the alpha = 1 update point and fill back to the fast scale
+# ax4.scatter(
+#     demo_scaler.sample_datetimes_mean,
+#     real_1,
+#     marker="d",
+#     edgecolor="C0",
+#     facecolor="none",
+# )
+# ax4.scatter(
+#     demo_scaler.sample_datetimes_mean + np.timedelta64(1, "D"),
+#     real_1,
+#     edgecolor="C1",
+#     facecolor="none",
+#     marker="s",
+# )
+# ax4.plot(demo_scaler.datetimes, fast_real_1_lin, linewidth=0.5)
+# ax4.text(0.95, 0.95, "(D)", ha="right", va="top", transform=ax4.transAxes)
 
-ax1.legend(
-    loc="lower center",
-    bbox_to_anchor=[0.5, 1],
-    ncols=3,
-    frameon=False,
-    handles=[
-        Line2D([0], [0], label="Instantaneous response", color="0.4", linewidth=0.7),
-        Patch(color="salmon", alpha=0.3, label="Acclimation window"),
-        Line2D(
-            [0],
-            [0],
-            label="Daily optimal value",
-            color="C3",
-            linestyle="none",
-            marker="x",
-        ),
-        Line2D(
-            [0],
-            [0],
-            label="Daily realised value",
-            markeredgecolor="C0",
-            linestyle="none",
-            marker="d",
-            markerfacecolor="none",
-        ),
-        Line2D(
-            [0],
-            [0],
-            label="Offset daily realised value",
-            markeredgecolor="C1",
-            linestyle="none",
-            marker="s",
-            markerfacecolor="none",
-        ),
-        Line2D([0], [0], label="Slow response", color="C0", linewidth=0.7),
-    ],
-)
-plt.tight_layout()
+# ax1.legend(
+#     loc="lower center",
+#     bbox_to_anchor=[0.5, 1],
+#     ncols=3,
+#     frameon=False,
+#     handles=[
+#         Line2D([0], [0], label="Instantaneous response", color="0.4", linewidth=0.7),
+#         Patch(color="salmon", alpha=0.3, label="Acclimation window"),
+#         Line2D(
+#             [0],
+#             [0],
+#             label="Daily optimal value",
+#             color="C3",
+#             linestyle="none",
+#             marker="x",
+#         ),
+#         Line2D(
+#             [0],
+#             [0],
+#             label="Daily realised value",
+#             markeredgecolor="C0",
+#             linestyle="none",
+#             marker="d",
+#             markerfacecolor="none",
+#         ),
+#         Line2D(
+#             [0],
+#             [0],
+#             label="Offset daily realised value",
+#             markeredgecolor="C1",
+#             linestyle="none",
+#             marker="s",
+#             markerfacecolor="none",
+#         ),
+#         Line2D([0], [0], label="Slow response", color="C0", linewidth=0.7),
+#     ],
+# )
+# plt.tight_layout()
+```
+
+```{code-cell} ipython3
+
 ```

--- a/docs/source/users/pmodel/subdaily_details/acclimation.md
+++ b/docs/source/users/pmodel/subdaily_details/acclimation.md
@@ -281,9 +281,8 @@ for (scenario_id, scenario_details), axis in zip(scenarios.items(), axes):
     # inputs to the interpolation process
     daily_optimal = model.get_daily_means(subdaily_data)
     daily_realised = model.apply_acclimation(daily_mean)
-    subdaily_realised, interp_y, interp_x = model.fill_daily_to_subdaily(
-        daily_realised, return_interpolation_inputs=True
-    )
+    interp_x, interp_y, _ = model._get_subdaily_interpolation_xy(daily_realised)
+    subdaily_realised = model.fill_daily_to_subdaily(daily_realised)
 
     # Show the variable at the subdaily timescale and the daily optimal values
     axis.plot(subdaily_datetimes, subdaily_data, "-", color="0.4", linewidth=0.7)

--- a/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
@@ -42,48 +42,72 @@ The subdaily model provides two options to help deal with missing data.
    calculation of daily average values by ignoring missing data and taking the average
    of the available observations (`allow_partial_data`).
 
-   However, allowing partial data cannot solve the issue where no data is
-   present in the acclimation window for a day or where the P Model calculations are
-   undefined for the optimal behaviour on a day. Both of these cases will lead to a
-   missing value in the time series of daily optimal values, which would then be
+   However, allowing partial data cannot solve the issue where the forcing data is
+   missing throughout the acclimation window for a day or where the P Model
+   calculations are undefined throughout that window on a day. Both of these cases
+   give a missing value in the time series of daily optimal values, which would then be
    propagated through the calculation of realised values using weighted averages.
 
-1. Hence the second option is to allow the iterated calculation of daily realised values
-   to hold over the last valid value until the next valid daily optimal value is found
-   (`allow_holdover`). If the first value is missing, this is held over until the first
-   valid observation.
+1. Hence the second option is to allow the iterated calculation of daily realised
+   values to **hold over the last valid value** until the next valid daily optimal
+   value is found (`allow_holdover`). Note that this cannot fill missing values at
+   the start of  time series.
 
 The code below gives a concrete example - a time series that starts and ends during in
 the middle of a one hour acclimation window around noon. Only two of the three
 observations are provided for the first and last day
 
 ```{code-cell} ipython3
+from copy import copy
+
 import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle, Patch
+import matplotlib.dates as mdates
 
 from pyrealm.pmodel.acclimation import AcclimationModel
 
 # A five day time series running from noon until noon
 datetimes = np.arange(
-    np.datetime64("2012-05-06 12:00"),
-    np.datetime64("2012-05-12 12:00"),
+    np.datetime64("2012-05-01 00:00"),
+    np.datetime64("2012-05-05 23:30"),
     np.timedelta64(30, "m"),
 )
 
 # Example data with missing values
-data = np.arange(len(datetimes), dtype="float")
-data[datetimes == np.datetime64("2012-05-08 11:30")] = np.nan
+scale_trig = (60 * 24) / (2 * np.pi)
+amplitude = 5
+trend = 5
+complete_data = np.round(
+    (-amplitude * np.cos((datetimes - datetimes[0]).astype(np.float64) / scale_trig))
+    + amplitude,
+    2,
+) + np.linspace(0, trend, len(datetimes))
+
+data = complete_data.copy()
+
+data[datetimes <= np.datetime64("2012-05-01 15:30")] = np.nan
 data[
     np.logical_and(
-        datetimes >= np.datetime64("2012-05-10 11:30"),
-        datetimes <= np.datetime64("2012-05-10 12:30"),
+        datetimes >= np.datetime64("2012-05-03 11:00"),
+        datetimes <= np.datetime64("2012-05-03 13:00"),
+    )
+] = np.nan
+data[
+    np.logical_and(
+        datetimes >= np.datetime64("2012-05-04 09:30"),
+        datetimes <= np.datetime64("2012-05-04 15:30"),
     )
 ] = np.nan
 
+
 # Create a first default acclimation model
 acclim_model = AcclimationModel(datetimes)
-acclim_model.set_window(
-    window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(30, "m")
-)
+
+window_center = np.timedelta64(12, "h")
+half_width = np.timedelta64(150, "m")
+
+acclim_model.set_window(window_center=window_center, half_width=half_width)
 ```
 
 The :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_daily_values` method
@@ -99,7 +123,32 @@ problem of the missing data clearly:
 * One day has no data within the acclimation window.
 
 ```{code-cell} ipython3
-acclim_model.get_window_values(data)
+fig, ax = plt.subplots()
+
+# Add the acclimation windows for each day
+acclim_windows = [
+    Rectangle(
+        (win_center - half_width, 0),
+        2 * half_width,
+        2 * amplitude + trend,
+        facecolor="salmon",
+        alpha=0.3,
+    )
+    for win_center in acclim_model.sample_datetimes_mean
+]
+
+[ax.add_patch(copy(p)) for p in acclim_windows]
+
+ax.plot(datetimes, complete_data, color="grey", linewidth=0.5, linestyle="dashed")
+ax.plot(datetimes, data, marker=".")
+
+# Format date axis
+myFmt = mdates.DateFormatter("%m/%d\n%H:%M")
+_ = ax.xaxis.set_major_formatter(myFmt)
+```
+
+```{code-cell} ipython3
+acclim_model.get_window_values(data).round(1)
 ```
 
 The daily average conditions are calculated using the
@@ -109,23 +158,21 @@ all days with missing data is also missing (`np.nan`).
 
 ```{code-cell} ipython3
 partial_not_allowed = acclim_model.get_daily_means(data)
-partial_not_allowed
+partial_not_allowed.round(2)
 ```
 
 Using an acclimation model that sets `allow_partial_data = True` allows the daily
 average conditions to be calculated from the partial available information. This does
-not solve the problem for the day with no data in the acclimation window, which still
+not solve the problem for days with no data in the acclimation window, which still
 results in a missing value and also generates a warning.
 
 ```{code-cell} ipython3
 # Create an acclimation model that allows partial data
 acclim_model_partial = AcclimationModel(datetimes, allow_partial_data=True)
-acclim_model_partial.set_window(
-    window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(30, "m")
-)
+acclim_model_partial.set_window(window_center=window_center, half_width=half_width)
 
 partial_allowed = acclim_model_partial.get_daily_means(data)
-partial_allowed
+partial_allowed.round(2)
 ```
 
 The :func:`~pyrealm.pmodel.acclimation.AcclimationModel.apply_acclimation` method is
@@ -135,33 +182,35 @@ default, this function *will raise an error* when missing data are present:
 ```{code-cell} ipython3
 :tags: [raises-exception]
 
-acclim_model_partial.apply_acclimation(partial_not_allowed)
+try:
+    acclim_model_partial.apply_acclimation(partial_not_allowed)
+except ValueError as excep:
+    print("Error message: ", excep)
 ```
 
-Using an acclimation model set with `allow_holdover=True` allows the function to be run:
-the value for the first day is still `np.nan` but the missing observations on day 3, 5
-and 7 are filled by holding over the valid observations from the previous day.
+Using an acclimation model set with `allow_holdover=True` allows the function to be run.
+If the input to `apply_acclimation` *does not* allow partial data, then the gaps on day
+3 and 4 are filled by holding over the value from day 2.
 
 ```{code-cell} ipython3
 acclim_model_partial_and_holdover = AcclimationModel(datetimes, allow_holdover=True)
 acclim_model_partial_and_holdover.set_window(
-    window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(30, "m")
+    window_center=window_center, half_width=half_width
 )
 
-acclim_model_partial_and_holdover.apply_acclimation(
-    partial_not_allowed_TODO_FIX_THIS_SECTION
-)
+acclim_model_partial_and_holdover.apply_acclimation(partial_not_allowed).round(3)
 ```
 
-When the partial data is allowed, the `allow_holdover` is still required to fill the
-gap on day 5 by holding over the data from day 4.
+When partial data is allowed, the `allow_holdover` uses the value estimated from partial
+data on day 3 to fill the completely missing data on day 4.
 
 ```{code-cell} ipython3
-acclim_model_partial_and_holdover.apply_acclimation(partial_allowed)
+acclim_model_partial_and_holdover.apply_acclimation(partial_allowed).round(3)
 ```
 
-These options do not fix all problems: the best way forward depends partly on the source
-of the missing data and how common it is, as discussed below.
+These options do not fix all problems, such as the gap on day 1 that cannot be filled by
+holding over earlier values. The best way forward depends partly on the source of the
+missing data and how common it is, as discussed below.
 
 ## Sources of missing data
 

--- a/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
@@ -60,10 +60,11 @@ The implementation has the following steps:
   data is calculated as for the standard P Model. This estimates the fast responses of
   $\Gamma^*$, $K_{mm}$, $\eta^*$, and $c_a$.
 
-* A [daily window](acclimation.md#the-acclimation-window) is then set to define the
-  conditions towards which the slow responses will acclimate, typically noon conditions
-  that optimise light use efficiency during the daily period of highest photosynthetic
-  photon flux density (PPFD). This is used to calculate a daily time series of average
+* An [acclimation model](acclimation.md#the-acclimation-model) is then defined that sets
+  a window of observations during the day that define the conditions that the slow
+  responses will acclimate towards. Thease are typically noon conditions that optimise
+  light use efficiency during the daily period of highest photosynthetic photon flux
+  density (PPFD). This model is used to calculate a daily time series of average
   conditions during this acclimation window.
 
 * A standard P model is used to estimate *optimal* behaviour during the daily

--- a/docs/source/users/pmodel/subdaily_details/worked_example.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example.md
@@ -52,7 +52,8 @@ fAPAR data is interpolated to the same spatial and temporal resolution from MODI
 
 This notebook demonstrates fitting subdaily P Models in the `pyrealm` package. Model
 fitting basically takes all of the same arguments as the standard
-{class}`~pyrealm.pmodel.pmodel.PModel` class. There are three additional things to set:
+{class}`~pyrealm.pmodel.new_pmodel.PModelNew` class. There are three additional things
+to set:
 
 * The timing of the observations and the daily window that should be used to estimate
   [acclimation of slow responses](acclimation.md#the-acclimation-model).

--- a/docs/source/users/pmodel/subdaily_details/worked_example.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example.md
@@ -55,7 +55,7 @@ fitting basically takes all of the same arguments as the standard
 {class}`~pyrealm.pmodel.pmodel.PModel` class. There are three additional things to set:
 
 * The timing of the observations and the daily window that should be used to estimate
-  [acclimation of slow responses](acclimation.md#the-acclimation-window).
+  [acclimation of slow responses](acclimation.md#the-acclimation-model).
 * How rapidly plants [acclimate to daily optimal
   conditions](./acclimation.md#estimating-realised-responses).
 * Approaches to handling any [missing data](./subdaily_model_and_missing_data.md): since

--- a/docs/source/users/versions.md
+++ b/docs/source/users/versions.md
@@ -33,8 +33,8 @@ the API of `pyrealm` code.
 
 There are two major API changes to existing code.
 
-1. The signatures for both the {class}`~pyrealm.pmodel.pmodel.PModel` and
-   {class}`~pyrealm.pmodel.subdaily.SubdailyPModel` classes have changed the way in
+1. The signatures for both the {class}`~pyrealm.pmodel.new_pmodel.PModelNew` and
+   {class}`~pyrealm.pmodel.new_pmodel.SubdailyPModelNew` classes have changed the way in
    which the quantum yield parameter ($\phi_0$) is set. The classes now require a
    specific named method for setting $\phi_0$. Each method has an associated default
    reference value of $\phi_0$, but these can be overridden. This new API makes it

--- a/pyrealm/core/hygro.py
+++ b/pyrealm/core/hygro.py
@@ -1,8 +1,9 @@
 """The :mod:`~pyrealm.core.hygro` submodule provides conversion functions for
 common hygrometric variables. The module provides conversions to vapour pressure
-deficit, which is the required input for the :class:`~pyrealm.pmodel.pmodel.PModel`
-from vapour pressure, specific humidity and relative humidity. The implementation is
-drawn from and validated against the ``bigleaf`` R package.
+deficit, which is the required input for the
+:class:`~pyrealm.pmodel.new_pmodel.PModelNew` from vapour pressure, specific humidity
+and relative humidity. The implementation is drawn from and validated against the
+``bigleaf`` R package.
 """  # noqa: D205
 
 import numpy as np

--- a/pyrealm/pmodel/__init__.py
+++ b/pyrealm/pmodel/__init__.py
@@ -1,6 +1,6 @@
 """The :mod:`~pyrealm.pmodel` module includes the following submodules:
 
-* :mod:`~pyrealm.pmodel.pmodel`,
+* :mod:`~pyrealm.pmodel.new_pmodel`,
 * :mod:`~pyrealm.pmodel.pmodel_environment`,
 * :mod:`~pyrealm.pmodel.optimal_chi` and
 * :mod:`~pyrealm.pmodel.jmax_limitation` provide classes implementing the core

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -605,8 +605,10 @@ class AcclimationModel:
                 variable.
         """
 
-        interp_x_datetimes, interp_y_values, fill_value = self._get_interpolation_data(
-            values=values, previous_values=previous_values
+        interp_x_datetimes, interp_y_values, fill_value = (
+            self._get_subdaily_interpolation_xy(
+                values=values, previous_values=previous_values
+            )
         )
 
         # Note that interp1d cannot handle datetime64 inputs, so need to interpolate
@@ -623,7 +625,7 @@ class AcclimationModel:
 
         return interp_fun(self.datetimes.astype("int"))
 
-    def _get_interpolation_data(
+    def _get_subdaily_interpolation_xy(
         self,
         values: NDArray[np.float64],
         previous_values: NDArray[np.float64] | None = None,

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -557,7 +557,11 @@ class AcclimationModel:
         self,
         values: NDArray[np.float64],
         previous_values: NDArray[np.float64] | None = None,
-    ) -> NDArray[np.float64]:
+        return_interpolation_inputs: bool = False,
+    ) -> (
+        NDArray[np.float64]
+        | tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.datetime64]]
+    ):
         """Resample daily variables onto the subdaily time scale.
 
         This method takes an array representing daily values and interpolates those
@@ -598,11 +602,19 @@ class AcclimationModel:
         series to be processed in blocks. This option is only currently implemented for
         interpolation using the ``fill_method='previous'`` option.
 
+        The method returns an array of the daily values interpolated onto the subdaily
+        observation times. If ``return_interpolation_inputs=True`` is used, the method
+        returns a tuple of three arrays: the interpolated values and then arrays of the
+        values and times passed to the interpolation function. These are mostly of use
+        for plotting interpolation outputs.
+
         Args:
             values: An array with the first dimension matching the number of days in the
                :class:`~pyrealm.pmodel.acclimation.AcclimationModel` instance.
             previous_values: An array of previous values from which to fill the
                 variable.
+            return_interpolation_inputs: Also return input arrays to interpolation
+                function.
         """
 
         self._raise_if_sampling_times_unset()
@@ -671,5 +683,8 @@ class AcclimationModel:
             fill_value=fill_value,
             assume_sorted=True,
         )
+
+        if return_interpolation_inputs:
+            return (interp_fun(self.datetimes.astype("int")), values, update_time)
 
         return interp_fun(self.datetimes.astype("int"))

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -277,12 +277,12 @@ class AcclimationModel:
         This private method must be called by all ``set_`` methods. It is used to
         update the instance to populate the following attributes:
 
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes`: An
+        * :attr:`~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes`: An
           array of the datetimes of observations included in daily samples of shape
           (n_day, n_sample).
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_mean`:
+        * :attr:`~~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes_mean`:
           An array of the mean daily datetime of observations included in daily samples.
-        * :attr:`~pyrealm.pmodel.scaler.SubdailyScaler.sample_datetimes_max`:
+        * :attr:`~pyrealm.pmodel.acclimation.AcclimationModel.sample_datetimes_max`:
           An array of the maximum daily datetime of observations included in daily
           samples.
         """
@@ -419,8 +419,7 @@ class AcclimationModel:
         Args:
             values: An array containing the sample values. The first dimension should be
               matching the number of measurements, i.e., the first dimension of
-              datetimes in
-              :class:`~pyrealm.pmodel.scaler.SubdailyScaler`.
+              datetimes in :class:`~pyrealm.pmodel.acclimation.AcclimationModel`.
         """
 
         if self.padding == (0, 0):
@@ -601,7 +600,7 @@ class AcclimationModel:
 
         Args:
             values: An array with the first dimension matching the number of days in the
-                instances :class:`~pyrealm.pmodel.scaler.SubdailyScaler` object.
+                :class:`~pyrealm.pmodel.acclimation.AcclimationModel` object.
             previous_values: An array of previous values from which to fill the
                 variable.
         """

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -519,7 +519,7 @@ class AcclimationModel:
         Two attributes of the ``AcclimationModel`` class are used to tune the behaviour
         of this method:
 
-        * The ``alpha``attribute controls the speed of acclimation. This value must be
+        * The ``alpha`` attribute controls the speed of acclimation. This value must be
           between 0 and 1 and is used as the weight term in an exponential moving
           average of daily values. Values closer to 1 lead to faster acclimation, with 1
           giving instantaneous acclimation and 0 giving no acclimation.

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -125,7 +125,7 @@ class C3C4Competition:
     This class provides an implementation of the calculations of C3/C4 competition,
     described by :cite:t:`lavergne:2020a`. The key inputs ``ggp_c3`` and ``gpp_c4`` are
     gross primary productivity (GPP) estimates for C3 or C4 pathways `alone`  using the
-    :class:`~pyrealm.pmodel.pmodel.PModel`
+    :class:`~pyrealm.pmodel.new_pmodel.PModelNew`
 
     These estimates are used to calculate the relative advantage of C4 over C3
     photosynthesis (:math:`A_4`), the expected fraction of C4 plants in the community
@@ -257,9 +257,9 @@ class C3C4Competition:
         r"""Estimate CO2 isotopic discrimination values.
 
         Creating an instance of :class:`~pyrealm.pmodel.isotopes.CalcCarbonIsotopes`
-        from a :class:`~pyrealm.pmodel.pmodel.PModel` instance provides estimated total
-        annual descrimination against Carbon 13 (:math:`\Delta\ce{^13C}`) for a single
-        photosynthetic pathway.
+        from a :class:`~pyrealm.pmodel.new_pmodel.PModelNew` instance provides estimated
+        total annual descrimination against Carbon 13 (:math:`\Delta\ce{^13C}`) for a
+        single photosynthetic pathway.
 
         This method allows predictions from C3 and C4 pathways to be combined to
         calculate the contribution from C3 and C4 plants given the estimated fraction of

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -220,7 +220,8 @@ def calc_ftemp_kphio(
     The factor :math:`\phi(T)` is to be multiplied with leaf absorptance and the
     fraction of absorbed light that reaches photosystem II. In the P-model these
     additional factors are lumped into a single apparent quantum yield efficiency
-    parameter (argument `kphio` to the class :class:`~pyrealm.pmodel.pmodel.PModel`).
+    parameter (argument `kphio` to the class
+    :class:`~pyrealm.pmodel.new_pmodel.PModelNew`).
 
     Args:
         tc: Temperature, relevant for photosynthesis (°C)

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 
 from pyrealm.constants import IsotopesConst
 from pyrealm.core.utilities import check_input_shapes, summarize_attrs
-from pyrealm.pmodel.pmodel import PModel
+from pyrealm.pmodel.new_pmodel import PModelNew
 
 
 class CalcCarbonIsotopes:
@@ -18,7 +18,7 @@ class CalcCarbonIsotopes:
 
     This class estimates the fractionation of atmospheric CO2 by photosynthetic
     pathways to calculate the isotopic compositions and discrimination given the
-    predicted optimal chi from a :class:`~pyrealm.pmodel.pmodel.PModel` instance.
+    predicted optimal chi from a :class:`~pyrealm.pmodel.new_pmodel.PModelNew` instance.
 
     Discrimination against carbon 13 (:math:`\Delta\ce{^{13}C}`)  is calculated
     using C3 and C4 pathways specific methods, and then discrimination against
@@ -29,7 +29,7 @@ class CalcCarbonIsotopes:
     also reports the isotopic composition of leaves and wood.
 
     Args:
-        pmodel: A :class:`~pyrealm.pmodel.pmodel.PModel` instance providing the
+        pmodel: A :class:`~pyrealm.pmodel.new_pmodel.PModelNew` instance providing the
             photosynthetic pathway and estimated optimal chi.
         d13CO2: Atmospheric isotopic ratio for Carbon 13
             (:math:`\delta\ce{^{13}C}`, permil).
@@ -42,7 +42,7 @@ class CalcCarbonIsotopes:
 
     def __init__(
         self,
-        pmodel: PModel,
+        pmodel: PModelNew,
         D14CO2: NDArray[np.float64],
         d13CO2: NDArray[np.float64],
         isotopes_const: IsotopesConst = IsotopesConst(),
@@ -100,7 +100,7 @@ class CalcCarbonIsotopes:
         """Generates a string representation of a CalcCarbonIsotopes instance."""
         return f"CalcCarbonIsotopes(shape={self.shape}, method={self.c4})"
 
-    def calc_c4_discrimination(self, pmodel: PModel) -> None:
+    def calc_c4_discrimination(self, pmodel: PModelNew) -> None:
         r"""Calculate C4 isotopic discrimination.
 
         In this method, :math:`\delta\ce{^{13}C}` is calculated from optimal
@@ -137,7 +137,7 @@ class CalcCarbonIsotopes:
         )
         self.Delta13C = self.Delta13C_simple
 
-    def calc_c4_discrimination_vonC(self, pmodel: PModel) -> None:
+    def calc_c4_discrimination_vonC(self, pmodel: PModelNew) -> None:
         r"""Calculate C4 isotopic discrimination.
 
         In this method, :math:`\delta\ce{^{13}C}` is calculated from optimal
@@ -191,7 +191,7 @@ class CalcCarbonIsotopes:
 
         self.Delta13C = self.Delta13C_simple
 
-    def calc_c3_discrimination(self, pmodel: PModel) -> None:
+    def calc_c3_discrimination(self, pmodel: PModelNew) -> None:
         r"""Calculate C3 isotopic discrimination.
 
         This method calculates the isotopic discrimination for
@@ -200,7 +200,7 @@ class CalcCarbonIsotopes:
 
         Examples:
             >>> import numpy as np
-            >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> from pyrealm.pmodel import PModelEnvironment
             >>> from pyrealm.pmodel.new_pmodel import PModelNew
             >>> env = PModelEnvironment(
             ...              tc=np.array([20]), patm=np.array([101325]),

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -109,7 +109,8 @@ class CalcCarbonIsotopes:
 
         Examples:
             >>> import numpy as np
-            >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> from pyrealm.pmodel.new_pmodel import PModelNew
+            >>> from pyrealm.pmodel import PModelEnvironment
             >>> from pyrealm.constants import PModelConst
             >>> pmodel_const = PModelConst(beta_cost_ratio_c4=35)
             >>> env = PModelEnvironment(
@@ -121,7 +122,7 @@ class CalcCarbonIsotopes:
             ...     ppfd=np.array([800]),
             ...     pmodel_const=pmodel_const
             ... )
-            >>> mod_c4 = PModel(env, method_optchi='c4_no_gamma')
+            >>> mod_c4 = PModelNew(env, method_optchi='c4_no_gamma')
             >>> mod_c4_delta = CalcCarbonIsotopes(mod_c4, d13CO2= -8.4, D14CO2 = 19.2)
             >>> mod_c4_delta.Delta13C.round(4)
             array([5.6636])
@@ -149,6 +150,7 @@ class CalcCarbonIsotopes:
 
         Examples:
             >>> import numpy as np
+            >>> from pyrealm.pmodel.new_pmodel import PModelNew
             >>> from pyrealm.pmodel import PModel, PModelEnvironment
             >>> from pyrealm.constants import PModelConst
             >>> pmodel_const = PModelConst(beta_cost_ratio_c4=35)
@@ -161,7 +163,7 @@ class CalcCarbonIsotopes:
             ...     ppfd=np.array([800]),
             ...     pmodel_const=pmodel_const
             ... )
-            >>> mod_c4 = PModel(env, method_optchi='c4_no_gamma')
+            >>> mod_c4 = PModelNew(env, method_optchi='c4_no_gamma')
             >>> mod_c4_delta = CalcCarbonIsotopes(mod_c4, d13CO2= -8.4, D14CO2 = 19.2)
             >>> # mod_c4_delta.Delta13C.round(4)
             >>> # array([5.2753])
@@ -199,13 +201,14 @@ class CalcCarbonIsotopes:
         Examples:
             >>> import numpy as np
             >>> from pyrealm.pmodel import PModel, PModelEnvironment
+            >>> from pyrealm.pmodel.new_pmodel import PModelNew
             >>> env = PModelEnvironment(
             ...              tc=np.array([20]), patm=np.array([101325]),
             ...              co2=np.array([400]), vpd=np.array([1000]),
             ...              fapar=np.array([1]), ppfd=np.array([800]),
             ...              theta=np.array([0.4])
             ... )
-            >>> mod_c3 = PModel(env, method_optchi='lavergne20_c3')
+            >>> mod_c3 = PModelNew(env, method_optchi='lavergne20_c3')
             >>> mod_c3_delta = CalcCarbonIsotopes(mod_c3, d13CO2= -8.4, D14CO2 = 19.2)
             >>> mod_c3_delta.Delta13C.round(4)
             array([20.4056])

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -2,14 +2,14 @@
 the following  classes:
 
 * :class:`~pyrealm.pmodel.new_pmodel.PModelABC`: An abstract base class providing some
-     of the core functionality for initialising PModel subclasses.
+  of the core functionality for initialising PModel subclasses.
 
 * :class:`~pyrealm.pmodel.new_pmodel.PModelNew`: A subclass providing the standard
-     implementation of the P Model.
+  implementation of the P Model.
 
 * :class:`~pyrealm.pmodel.new_pmodel.SubdailyPModelNew`: A subclass providing the
-     subdaily implementation of the P Model, which accounts for slow acclimation of core
-     photosynthetic processes.
+  subdaily implementation of the P Model, which accounts for slow acclimation of core
+  photosynthetic processes.
 
 
 """  # noqa D210, D415
@@ -41,13 +41,13 @@ from pyrealm.pmodel.quantum_yield import QUANTUM_YIELD_CLASS_REGISTRY, QuantumYi
 class PModelABC(ABC):
     r"""Abstract base class for the PModel and SubdailyPModel.
 
-    The base class __init__ implements the core arguments to the PModel subclasses: the
-    forcing data to be used for the model and various methodological options for the
+    The base class ``__init__`` implements the core arguments to the PModel subclasses:
+    the forcing data to be used for the model and various methodological options for the
     calculation of the model parameters.
 
-    Subclasses should define an `__init__` method that first calls
-    `super().__init__(...)` to run the shared core functionality and then define any
-    model specific attributes. The abstract base method `_fit_model` should then be
+    Subclasses should define an ``__init__`` method that first calls
+    ``super().__init__(...)`` to run the shared core functionality and then define any
+    model specific attributes. The abstract base method ``_fit_model`` should then be
     defined and used to execute the model specific logic of the base class.
 
     Args:
@@ -62,6 +62,8 @@ class PModelABC(ABC):
             :class:`~pyrealm.pmodel.optimal_chi.OptimalChiABC`).
         method_jmaxlim: (Optional, default=`wang17`) Method to use for
             :math:`J_{max}` limitation.
+        method_arrhenius: (Optional, default=`simple`) Method to set the form of
+            Arrhenius scaling used for `vcmax` and `jmax`.
         reference_kphio: An optional alternative reference value for the quantum yield
             efficiency of photosynthesis (:math:`\phi_0`, -) to be passed to the kphio
             calculation method.
@@ -210,7 +212,7 @@ class PModelABC(ABC):
 
         .. math::
 
-            V_{cmax} &= \phi_{0} I_{abs} \frac{m}{m_c} f_{v} 
+            V_{cmax} = \phi_{0} I_{abs} \frac{m}{m_c} f_{v} 
 
         where  :math:`f_v` is a limitation term calculated via the method selected in
         `method_jmaxlim`."""
@@ -226,7 +228,7 @@ class PModelABC(ABC):
         
         .. math::
 
-            J_{max} &= 4 \phi_{0} I_{abs} f_{j}
+            J_{max} = 4 \phi_{0} I_{abs} f_{j}
 
         where  :math:`f_j` is a limitation term calculated via the method selected in
         `method_jmaxlim`."""
@@ -237,21 +239,26 @@ class PModelABC(ABC):
         """
 
         self.rd: NDArray[np.float64]
-        r"""Dark respiration (µmol m-2 s-1), , calculated as:
+        r"""Dark respiration (µmol m-2 s-1) calculated as:
 
         .. math::
 
             R_d = b_0 \frac{fr(t)}{fv(t)} V_{cmax},
 
-        following :cite:`Atkin:2015hk`, where :math:`fr(t)` is the instantaneous
+        following :cite:t:`Atkin:2015hk`, where :math:`fr(t)` is the instantaneous
         temperature response of dark respiration implemented in
         :func:`~pyrealm.pmodel.functions.calc_ftemp_inst_rd`, and :math:`b_0` is set in
         :attr:`~pyrealm.constants.pmodel_const.PModelConst.atkin_rd_to_vcmax`."""
 
         self.gpp: NDArray[np.float64]
-        r"""Gross primary productivity (µg C m-2 s-1) calculated as :math:`\text{GPP} =
-         \text{LUE} \cdot I_{abs}`, where :math:`I_{abs}` is the absorbed photosynthetic
-         radiation"""
+        r"""Gross primary productivity (µg C m-2 s-1) calculated as:
+        
+        .. math::
+
+            \text{GPP} = \text{LUE} \cdot I_{abs}
+            
+        where :math:`I_{abs}` is the absorbed photosynthetic radiation.
+        """
 
         self.gs: NDArray[np.float64]
         r"""Stomatal conductance (µmol m-2 s-1), calculated as:

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -330,7 +330,45 @@ class PModelABC(ABC):
 
 
 class PModelNew(PModelABC):
-    """New implementation of the PModel."""
+    r"""Fit a standard P Model.
+
+    This class fits the P Model to a given set of environmental and photosynthetic
+    parameters. An extended description with typical use cases is given in
+    :any:`pmodel_overview` but the basic flow of the model is:
+
+    1. Estimate :math:`\ce{CO2}` limitation factors and optimal internal to ambient
+       :math:`\ce{CO2}` partial pressure ratios (:math:`\chi`), using one of the
+       methods based on :class:`~pyrealm.pmodel.optimal_chi.OptimalChiABC`.
+    2. Estimate limitation factors to :math:`V_{cmax}` and :math:`J_{max}` using
+       one of the methods implemented using
+       :class:`~pyrealm.pmodel.jmax_limitation.JmaxLimitationABC`.
+
+    Soil moisture effects:
+        The `lavergne20_c3`, `lavergne20_c4`, ``prentice14_rootzonestress``,
+        ``c4_rootzonestress`` and ``c4_no_gamma_rootzonestress`` options to
+        ``method_optchi`` implement different approaches to soil moisture effects on
+        photosynthesis. See also the alternative GPP penalty factors that can be applied
+        after fitting the P Model
+        (:func:`pyrealm.pmodel.functions.calc_soilmstress_stocker` and
+        :func:`pyrealm.pmodel.functions.calc_soilmstress_mengoli`).
+
+    Args:
+        env: An instance of
+           :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
+        method_kphio: The method to use for calculating the quantum yield
+            efficiency of photosynthesis (:math:`\phi_0`, unitless). The method name
+            must be included in the
+            :data:`~pyrealm.pmodel.quantum_yield.QUANTUM_YIELD_CLASS_REGISTRY`.
+        method_optchi: (Optional, default=`prentice14`) Selects the method to be
+            used for calculating optimal :math:`chi`. The choice of method also sets the
+            choice of  C3 or C4 photosynthetic pathway (see
+            :class:`~pyrealm.pmodel.optimal_chi.OptimalChiABC`).
+        method_jmaxlim: (Optional, default=`wang17`) Method to use for
+            :math:`J_{max}` limitation.
+        reference_kphio: An optional alternative reference value for the quantum yield
+            efficiency of photosynthesis (:math:`\phi_0`, -) to be passed to the kphio
+            calculation method.
+    """
 
     _data_attributes = (
         ("lue", "g C mol-1"),
@@ -560,34 +598,37 @@ class SubdailyPModelNew(PModelABC):
         acclimation window for the day, or undefined values in P Model predictions. Some
         options include:
 
-        * The ``allow_partial_data`` argument is passed on to
-          :meth:`~pyrealm.pmodel.scaler.SubdailyScaler.get_daily_means` to
+        * The ``allow_partial_data`` argument is passed on to the
+          :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.get_daily_means` method to
           allow daily optimum conditions to be calculated when the data in the
           acclimation window is incomplete. This does not fix problems when no data is
           present in the window or when the P Model predictions for a day are undefined.
 
-        * The ``allow_holdover`` argument is passed on to
-          :meth:`~pyrealm.pmodel.subdaily.memory_effect` to set whether missing values
-          in the optimal predictions can be filled by holding over previous valid
-          values.
+        * The ``allow_holdover`` argument is passed on to the
+          :meth:`~pyrealm.pmodel.acclimation.AcclimationModel.apply_acclimation` method
+          to set whether missing values in the optimal predictions can be filled by
+          holding over previous valid values.
 
     Args:
         env: An instance of
-          :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
-        fs_scaler: An instance of
-          :class:`~pyrealm.pmodel.scaler.SubdailyScaler`.
-        alpha: The :math:`\alpha` weight.
-        allow_holdover: Should the :func:`~pyrealm.pmodel.subdaily.memory_effect`
-          function be allowed to hold over values to fill missing values.
-        allow_partial_data: Should estimates of daily optimal conditions be calculated
-          with missing values in the acclimation window.
+           :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
+        method_kphio: The method to use for calculating the quantum yield
+            efficiency of photosynthesis (:math:`\phi_0`, unitless). The method name
+            must be included in the
+            :data:`~pyrealm.pmodel.quantum_yield.QUANTUM_YIELD_CLASS_REGISTRY`.
+        method_optchi: (Optional, default=`prentice14`) Selects the method to be
+            used for calculating optimal :math:`chi`. The choice of method also sets the
+            choice of  C3 or C4 photosynthetic pathway (see
+            :class:`~pyrealm.pmodel.optimal_chi.OptimalChiABC`).
+        method_jmaxlim: (Optional, default=`wang17`) Method to use for
+            :math:`J_{max}` limitation.
         reference_kphio: An optional alternative reference value for the quantum yield
-          efficiency of photosynthesis (:math:`\phi_0`, -) to be passed to the kphio
-          calculation method.
-        fill_kind: The approach used to fill daily realised values to the subdaily
-          timescale, currently one of 'previous' or 'linear'.
+            efficiency of photosynthesis (:math:`\phi_0`, -) to be passed to the kphio
+            calculation method.
+        acclim_model: An instance of
+            :class:`~pyrealm.pmodel.acclimation.AcclimationModel`
         previous_realised: A tuple of previous realised values of three NumPy arrays
-          (xi_real, vcmax25_real, jmax25_real).
+            (xi_real, vcmax25_real, jmax25_real).
     """
 
     _data_attributes = (

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -899,7 +899,6 @@ class SubdailyPModelNew(PModelABC):
         self.vcmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.vcmax25_daily_realised,
             previous_values=self.previous_realised["vcmax25"],
-            return_interpolation_inputs=False,
         )
         self.jmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.jmax25_daily_realised,

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -103,7 +103,7 @@ class PModelABC(ABC):
         self._optchi_class: type[OptimalChiABC]
         """The OptimalChiABC subclass to be used in the model."""
         self.optchi: OptimalChiABC
-        """The optimal chi (:math:`\chi`) calculations for the fitted P Model."""
+        r"""The optimal chi (:math:`\chi`) calculations for the fitted P Model."""
 
         self._method_setter(
             method_value_attr="method_optchi",
@@ -126,7 +126,7 @@ class PModelABC(ABC):
         self._kphio_class: type[QuantumYieldABC]
         """The QuantumYieldABC subclass to be used in the model."""
         self.kphio: QuantumYieldABC
-        """The quantum yield (:math:`\phi_0`) calculations for the fitted P Model."""
+        r"""The quantum yield (:math:`\phi_0`) calculations for the fitted P Model."""
 
         self._method_setter(
             method_value_attr="method_kphio",
@@ -223,8 +223,8 @@ class PModelABC(ABC):
         """
 
         self.jmax: NDArray[np.float64]
-        """Maximum rate of electron transport at the growth temperature (µmol m-2
-        s-1), calculated as:
+        r"""Maximum rate of electron transport at the growth temperature (µmol m-2 s-1),
+        calculated as:
         
         .. math::
 
@@ -899,6 +899,7 @@ class SubdailyPModelNew(PModelABC):
         self.vcmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.vcmax25_daily_realised,
             previous_values=self.previous_realised["vcmax25"],
+            return_interpolation_inputs=False,
         )
         self.jmax25 = self.acclim_model.fill_daily_to_subdaily(
             self.jmax25_daily_realised,

--- a/pyrealm/pmodel/new_pmodel.py
+++ b/pyrealm/pmodel/new_pmodel.py
@@ -516,9 +516,9 @@ class PModelNew(PModelABC):
     ) -> SubdailyPModelNew:
         r"""Convert a standard PModel to a subdaily P Model.
 
-        This method converts a :class:`~pyrealm.pmodel.pmodel.PModel` instance to a
-        to a :class:`~pyrealm.pmodel.subdaily.SubdailyPModel` instance with the same
-        settings.
+        This method converts a :class:`~pyrealm.pmodel.new_pmodel.PModelNew` instance to
+        a to a :class:`~pyrealm.pmodel.new_pmodel.SubdailyPModelNew` instance with the
+        same settings.
 
         Args:
             acclim_model: An AcclimationModel instance for the subdaily model.
@@ -540,14 +540,14 @@ class PModelNew(PModelABC):
 class SubdailyPModelNew(PModelABC):
     r"""Fit a P Model incorporating acclimation in photosynthetic responses.
 
-    The :class:`~pyrealm.pmodel.pmodel.PModel` implementation of the P Model assumes
-    that plants instantaneously adopt optimal behaviour, which is reasonable where the
-    data represents average conditions over longer timescales and the plants can be
-    assumed to have acclimated to optimal behaviour. Over shorter timescales, this
-    assumption is unwarranted and photosynthetic slow responses need to be included.
-    This class implements the weighted-average approach of {cite:t}`mengoli:2022a`, but
-    is extended to include the slow response of :math:`\xi` in addition to
-    :math:`V_{cmax25}` and :math:`J_{max25}`.
+    The :class:`~pyrealm.pmodel.new_pmodel.PModelNew` implementation of the P Model
+    assumes that plants instantaneously adopt optimal behaviour, which is reasonable
+    where the data represents average conditions over longer timescales and the plants
+    can be assumed to have acclimated to optimal behaviour. Over shorter timescales,
+    this assumption is unwarranted and photosynthetic slow responses need to be
+    included. This class implements the weighted-average approach of
+    {cite:t}`mengoli:2022a`, but is extended to include the slow response of :math:`\xi`
+    in addition to :math:`V_{cmax25}` and :math:`J_{max25}`.
 
     The workflow of the model:
 
@@ -594,7 +594,7 @@ class SubdailyPModelNew(PModelABC):
       and vapour pressure deficit.
     * Predictions of GPP are then made as in the standard P Model.
 
-    As with the :class:`~pyrealm.pmodel.pmodel.PModel`, the values of the `kphio`
+    As with the :class:`~pyrealm.pmodel.new_pmodel.PModelNew`, the values of the `kphio`
     argument _can_ be provided as an array of values, potentially varying through time
     and space. The behaviour of the daily model that drives acclimation here is to take
     the daily mean `kphio` value for each time series within the acclimation window, as
@@ -687,12 +687,12 @@ class SubdailyPModelNew(PModelABC):
         self.pmodel_acclim: PModelNew
         r"""P Model predictions for the daily acclimation conditions.
 
-        A :class:`~pyrealm.pmodel.pmodel.PModel` instance providing the predictions of
-        the P Model for the daily acclimation conditions set for the SubdailyPModel. The
-        model is used to obtain predictions of the instantaneous optimal estimates of
-        :math:`V_{cmax}`, :math:`J_{max}` and :math:`\xi` during the acclimation window.
-        These are then used to estimate realised values of those parameters given slow
-        responses to acclimation.
+        A :class:`~pyrealm.pmodel.new_pmodel.PModelNew` instance providing the
+        predictions of the P Model for the daily acclimation conditions set for the
+        SubdailyPModel. The model is used to obtain predictions of the instantaneous
+        optimal estimates of :math:`V_{cmax}`, :math:`J_{max}` and :math:`\xi` during
+        the acclimation window. These are then used to estimate realised values of those
+        parameters given slow responses to acclimation.
         """
 
         # TODO - maybe encapsulate these in a dataclass?

--- a/pyrealm_build_data/two_leaf/two_leaf_python.md
+++ b/pyrealm_build_data/two_leaf/two_leaf_python.md
@@ -5,11 +5,21 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.13.8
+    jupytext_version: 1.16.4
 kernelspec:
-  display_name: pyrealm_python3
+  display_name: Python 3 (ipykernel)
   language: python
-  name: pyrealm_python3
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Two leaf radiative transfer model
@@ -25,7 +35,9 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from pvlib.location import Location
 
-from pyrealm.pmodel import PModelEnvironment, PModel, SubdailyPModel, SubdailyScaler
+from pyrealm.pmodel import PModelEnvironment
+from pyrealm.pmodel.new_pmodel import PModelNew, SubdailyPModelNew
+from pyrealm.pmodel.acclimation import AcclimationModel
 ```
 
 ## Test data
@@ -234,23 +246,21 @@ pmod_env = PModelEnvironment(
     patm=forcing_data["patm"].to_numpy(),
     co2=forcing_data["co2"].to_numpy(),
     vpd=forcing_data["vpd"].to_numpy(),
+    fapar=forcing_data["fapar"].to_numpy(), 
+    ppfd=forcing_data["ppfd"].to_numpy()
 )
 
 # Standard P Model
-standard_pmod = PModel(pmod_env, kphio=1 / 8)
-standard_pmod.estimate_productivity(
-    fapar=forcing_data["fapar"].to_numpy(), ppfd=forcing_data["ppfd"].to_numpy()
-)
+standard_pmod = PModelNew(pmod_env, reference_kphio=1 / 8)
+
 
 # Subdaily P Model
-sd_scaler = SubdailyScaler(forcing_data["time"].to_numpy().astype("datetime64"))
-sd_scaler.set_window(np.timedelta64("12", "h"), half_width=np.timedelta64("15", "m"))
+acclim_model = AcclimationModel(datetimes=forcing_data["time"].to_numpy().astype("datetime64"))
+acclim_model.set_window(np.timedelta64("12", "h"), half_width=np.timedelta64("15", "m"))
 
-subdaily_pmod = SubdailyPModel(
+subdaily_pmod = SubdailyPModelNew(
     env=pmod_env,
-    fs_scaler=sd_scaler,
-    fapar=forcing_data["fapar"].to_numpy(),
-    ppfd=forcing_data["ppfd"].to_numpy(),
+    acclim_model=acclim_model,
 )
 ```
 
@@ -261,33 +271,33 @@ The code below is a draft implementation of the Two Leaf conversion class.
 ```{code-cell} ipython3
 class TwoLeafAssimilation:
     def __init__(
-        self, pmodel: PModel | SubdailyPModel, irrad: TwoLeafIrradiance, LAI: np.array
+        self, pmodel: PModelNew | SubdailyPModelNew, irrad: TwoLeafIrradiance, LAI: np.array
     ):
 
         # A load of needless inconsistencies in the object attribute names - to be resolved!
-        vcmax_pmod = (
-            pmodel.vcmax if isinstance(pmodel, PModel) else pmodel.subdaily_vcmax
-        )
-        vcmax25_pmod = (
-            pmodel.vcmax25 if isinstance(pmodel, PModel) else pmodel.subdaily_vcmax25
-        )
-        optchi_obj = pmodel.optchi if isinstance(pmodel, PModel) else pmodel.optimal_chi
-        core_const = (
-            pmodel.core_const if isinstance(pmodel, PModel) else pmodel.env.core_const
-        )
+        # vcmax_pmod = (
+        #     pmodel.vcmax if isinstance(pmodel, PModelNew) else pmodel.subdaily_vcmax
+        # )
+        # vcmax25_pmod = (
+        #     pmodel.vcmax25 if isinstance(pmodel, PModel) else pmodel.subdaily_vcmax25
+        # )
+        # optchi_obj = pmodel.optchi if isinstance(pmodel, PModel) else pmodel.optimal_chi
+        # core_const = (
+        #     pmodel.core_const if isinstance(pmodel, PModel) else pmodel.env.core_const
+        # )
 
         # Generate extinction coefficients to express the vertical gradient in photosynthetic
         # capacity after the equation provided in Figure 10 of Lloyd et al. (2010):
 
         kv_Lloyd = np.exp(
-            0.00963 * vcmax_pmod - 2.43
+            0.00963 * pmodel.vcmax - 2.43
         )  # KB: Here I opt for vcmax rather than Vcmax25
 
         # Calculate carboxylation in the two partitions at standard conditions
-        self.Vmax25_canopy = LAI * vcmax25_pmod * ((1 - np.exp(-kv_Lloyd)) / kv_Lloyd)
+        self.Vmax25_canopy = LAI * pmodel.vcmax25 * ((1 - np.exp(-kv_Lloyd)) / kv_Lloyd)
         self.Vmax25_sun = (
             LAI
-            * vcmax25_pmod
+            * pmodel.vcmax25
             * ((1 - np.exp(-kv_Lloyd - irrad.kb * LAI)) / (kv_Lloyd + irrad.kb * LAI))
         )
         self.Vmax25_shade = self.Vmax25_canopy - self.Vmax25_sun
@@ -301,8 +311,8 @@ class TwoLeafAssimilation:
         )
 
         # Now the photosynthetic estimates as V_cmax * mc
-        self.Av_sun = self.Vmax_sun * optchi_obj.mc
-        self.Av_shade = self.Vmax_shade * optchi_obj.mc
+        self.Av_sun = self.Vmax_sun * pmodel.optchi.mc
+        self.Av_shade = self.Vmax_shade * pmodel.optchi.mc
 
         ## Jmax estimates for sun and shade;
         self.Jmax25_sun = 29.1 + 1.64 * self.Vmax25_sun  # Eqn 31, after Wullschleger
@@ -325,8 +335,8 @@ class TwoLeafAssimilation:
             / (irrad.I_cshade + 2.2 * self.Jmax_shade)
         )
 
-        self.Aj_sun = (self.J_sun / 4) * optchi_obj.mj
-        self.Aj_shade = (self.J_shade / 4) * optchi_obj.mj
+        self.Aj_sun = (self.J_sun / 4) * pmodel.optchi.mj
+        self.Aj_shade = (self.J_shade / 4) * pmodel.optchi.mj
 
         # Calculate the assimilation in each partition as the minimum of Aj and Av,
         # in both cases clipping when the sun is below the angle of obscurity
@@ -339,7 +349,7 @@ class TwoLeafAssimilation:
             irrad.beta_angle < irrad.solar_obscurity_angle, 0, Acanopy_shade
         )
 
-        self.gpp = core_const.k_c_molmass * self.Acanopy_sun + self.Acanopy_shade
+        self.gpp = pmodel.env.core_const.k_c_molmass * self.Acanopy_sun + self.Acanopy_shade
 
         # # and we account for canopy respiration
         # gpp_canopy = if_else(sEa > 0.02,
@@ -545,7 +555,7 @@ plt.tight_layout()
 ```{code-cell} ipython3
 plt.plot(
     forcing_data["time"][plot_slice],
-    subdaily_pmod.subdaily_vcmax[plot_slice],
+    subdaily_pmod.vcmax[plot_slice],
     label="Subdaily Vcmax",
 )
 plt.plot(
@@ -575,10 +585,10 @@ python_outputs = pd.DataFrame({
     ),
     "gammastar_pmod": subdaily_pmod.env.gammastar,
     "kmm_pmod": subdaily_pmod.env.kmm,
-    "ci_pmod": subdaily_pmod.optimal_chi.ci,
-    "vcmax_pmod": subdaily_pmod.subdaily_vcmax,
-    "jmax_pmod": subdaily_pmod.subdaily_jmax,
-    "vcmax25_pmod": subdaily_pmod.subdaily_vcmax25,
+    "ci_pmod": subdaily_pmod.optchi.ci,
+    "vcmax_pmod": subdaily_pmod.vcmax,
+    "jmax_pmod": subdaily_pmod.jmax,
+    "vcmax25_pmod": subdaily_pmod.vcmax25,
     # "rd_pmod": subdaily_pmod.rd,
     # "kv_Lloyd": ,
     "Icsun": two_leaf_irrad.I_csun,


### PR DESCRIPTION
# Description

This PR moves all of the documentation over to using the new `PModelNew` and `SubdailyPModelNew` API.

The idea here is to get everything working using the new functionality (under the `New` names) to then hopefully make it really easy to excise the old codebase in #419.

The changes in the code files (`pyrealm/pmodel`) are docstring fixes, _except_ for an update to `AcclimationModel` that separates out the generation of the interpolation inputs to `fill_daily_to_subdaily` into a private function `__get_subdaily_interpolation_xy`. That's mostly an aid to plotting the acclimation process by making those interpolation values accessible (albeit via a private method).

Fixes #425

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
