### PR TITLE
Prototype of @experimental

### DIFF
--- a/pyrealm/core/experimental.py
+++ b/pyrealm/core/experimental.py
@@ -1,0 +1,87 @@
+"""This module provides a simple decorator for use with experimental features of the
+pyrealm codebase. It automatically adds an experimental admonition to the docstring of
+decorated objects and causes those function to generate an experimental warning when
+called. The structure is largely taken from  the `deprecated` package, released under
+the Apache 2.0 licence.
+"""  # noqa: D205
+
+# Original licence of deprecation package:
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import functools
+import textwrap
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+
+class ExperimentalFeatureWarning2(Warning):
+    """Warn about experimental features.
+
+    This is just a simple wrapper on the base Warning to issue clearer warnings about
+    experimental features in the code.
+    """
+
+    def __init__(self, qualname: str) -> None:
+        self.message = (
+            f"Calling {qualname} is an experimental feature of pyrealm and "
+            f"the implementation and API may change within major versions."
+        )
+
+    def __str__(self) -> str:
+        return repr(self.message)
+
+
+def experimental() -> Callable:
+    """Decorate an experimental object.
+
+    This function wraps an experimental object.
+    """
+
+    def _object_wrapper(obj: Callable) -> Callable:
+        # Get the object docstring
+        existing_docstring = obj.__doc__ or ""
+
+        # Experimental note
+        experimental_notice = f"""
+
+.. admonition:: Experimental
+    :class: Important
+    
+    The {obj.__name__} method or class is an experimental feature and may
+    change between major releases.
+
+        """
+
+        # Split the docstring title from the rest of the body
+        string_list = existing_docstring.split("\n", 1)
+
+        if len(string_list) > 1:
+            # Need to handle indentation careully to avoid breaking docstring
+            # indentation
+            string_list[1] = textwrap.dedent(string_list[1])
+
+        # Insert the experimental notice below the title and close it all up.
+        string_list.insert(1, experimental_notice)
+
+        obj.__doc__ = "".join(string_list)
+
+        @functools.wraps(obj)
+        def _inner(*args: Any, **kwargs: Any) -> Callable:
+            warnings.warn(obj.__qualname__, ExperimentalFeatureWarning2)
+            return obj(*args, **kwargs)
+
+        return _inner
+
+    return _object_wrapper

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -17,6 +17,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm import ExperimentalFeatureWarning
+from pyrealm.core.experimental import experimental
 from pyrealm.core.utilities import (
     check_input_shapes,
     evaluate_horner_polynomial,
@@ -280,6 +281,7 @@ class QuantumYieldTemperature(
         self.kphio = ftemp * self.reference_kphio
 
 
+@experimental()
 class QuantumYieldSandoval(
     QuantumYieldABC,
     method="sandoval",

--- a/tests/unit/core/test_experimental.py
+++ b/tests/unit/core/test_experimental.py
@@ -1,0 +1,38 @@
+"""Tests the experimental decorator."""
+
+import pytest
+
+
+def test_experimental():
+    """Test the experimental decorator."""
+    from pyrealm.core.experimental import ExperimentalFeatureWarning2, experimental
+
+    @experimental()
+    def experimental_function():
+        """The experimental_function."""
+        return
+
+    @experimental()
+    class ExperimentalClass:
+        """The ExperimentalClass."""
+
+    class StandardClass:
+        """The StandardClass."""
+
+        @experimental()
+        def experimental_method(self):
+            """The experimental_method."""
+            return
+
+    with pytest.warns(ExperimentalFeatureWarning2):
+        _ = experimental_function()
+        assert ".. admonition:: Experimental" in experimental_function.__doc__
+
+    with pytest.warns(ExperimentalFeatureWarning2):
+        _ = ExperimentalClass()
+        assert ".. admonition:: Experimental" in ExperimentalClass.__doc__
+
+    inst = StandardClass()
+    with pytest.warns(ExperimentalFeatureWarning2):
+        inst.experimental_method()
+        assert ".. admonition:: Experimental" in inst.experimental_method.__doc__


### PR DESCRIPTION
# Description

This PR:

* Introduces the new `pyrealm.core.experimental` module, which  provides the `@experimental` decorator and `ExperimentalFeatureWarning2` (so called because we already have `pyrealm.ExperimentalFeatureWarning`, although this would be replaced if we get this working.

Tests show it works, but there is an issue with building the docs - somehow this interferes with `autodoc` in a way that breaks the links to experimental objects - if you ignore errors when building, the build succeeds and it looks good but the link in the side menu is broken and the links to the object fail:

See here:

https://pyrealm.readthedocs.io/en/429-experimental-decorator/api/pmodel_api.html#module-pyrealm.pmodel.quantum_yield

The `QuantumYieldSandoval()` appears differently in the menu and the attributes are not autogenerated.

Fixes #429

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
