### PR TITLE
Update default values for phi0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,9 +50,18 @@ worked through. The changes below are provisional.
   supports the previous fixed and temperature dependent $\phi_0$ approaches but also
   David Sandoval's extension for estimating the impact of water stress on $\phi_0$.
 
-  **Breaking change** The signatures of the `PModel` and `SubdailyPModel` classes have
-  changed: the arguments `kphio` and `do_ftemp_kphio` have been replaced by
-  `method_kphio` and `reference_kphio`.
+  **Breaking changes**:
+  
+  - The signatures of the `PModel` and `SubdailyPModel` classes have
+    changed: the arguments `kphio` and `do_ftemp_kphio` have been replaced by
+    `method_kphio` and `reference_kphio`.
+  - In addition to changing the implementation, the **default values** of $\phi_0$ have
+    changed. In `1.0.0`, the `PModel` followed {cite:t}`Stocker:2020dh` in using default
+    values of either 0.081785 or 0.049977, depending on whether the model applied
+    temperature correction to $\phi_0$. These values were tuned to the particular model
+    setup and the application of a water stress penalty. The `PModel` and
+    `SubdailyPModel` now both default to the theoretical maximum quantum yield of
+    photosynthesis ($\phi_0 = 1/8$).
 
 - The implementation of $J_{max}$ and $V_{cmax}$ limitation has been updated to provide
   a more flexible and expandable system. The changes are mostly internal, but there are

--- a/docs/source/users/pmodel/pmodel_details/quantum_yield.md
+++ b/docs/source/users/pmodel/pmodel_details/quantum_yield.md
@@ -76,17 +76,24 @@ variation in $\phi_0$ {cite}`Bernacchi:2003dc`.
 
 For these reasons, the {class}`~pyrealm.pmodel.pmodel.PModel` provides alternative
 approaches to estimating the value of $\phi{0}$, using the `method_kphio` argument. The
-currently implemented approaches are described below. Note that each approach has a
-specific **reference value for $\phi_{0}$**, which is used as the baseline for further
-calculations. This value can be altered via the `reference_kphio` argument.
+currently implemented approaches are described below.
+
+All of the approaches share the same baseline reference value of $\phi{0}= 1/8$ as the
+theoretical maximum quantum yield of photosynthesis. This can be overridden got all
+analsyes using a given {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironmen` by
+changing the value of
+{attr}`PModelConst.maximum_phi0<pyrealm.constants.pmodel_const.PModelConst.maximum_phi0`,
+but it can also be overriden for a single P Model using the `reference_kphio` argument.
+This can be needed when specific methods have been calibrated using a 'tuned' value for
+$\phi_0$: an example here is the soil moisture stress corrected GPP estimates of
+:cite:t:`Stocker:2020dh` which use different $\phi_0$ values (see
+{meth}`~pyrealm.pmodel.functions.calc_soilmstress_stocker`).
 
 ## Temperature dependent $\phi_0$
 
 The default approach (`method_kphio='temperature'`) applies a temperature dependent
 estimate of $\phi_0$, following {cite:t}`Bernacchi:2003dc` for C3 plants and
-{cite:t}`cai:2020a` for C4 plants. The default reference value for this approach is
-$\phi_0 = 0.081785$, following the BRC parameterisation in Table 1. of
-{cite:t}`Stocker:2020dh`.
+{cite:t}`cai:2020a` for C4 plants.
 
 ```{code-cell} ipython3
 :tags: [hide-input]
@@ -111,9 +118,7 @@ plt.show()
 ## Fixed $\phi_0$
 
 This approach (`method_kphio='fixed'`) applies a fixed value of $\phi_0$ in the
-calculation of light use efficiency. The default reference value used in this case is
-$\phi_0 = 0.049977$, following the ORG settings parameterisation in Table 1. of
-{cite:t}`Stocker:2020dh`.
+calculation of light use efficiency.
 
 However, the fixed method will also accept $\phi_0$ values for each observation being
 fitted in the PModel. This option is provided to allow users to experiment with
@@ -155,8 +160,7 @@ plt.show()
 
 The option `method_kphio='sandoval'` implements an experimental calculation
 {cite}`sandoval:in_prep` of $\phi_0$ as a function of a local aridity index (P/PET), the
-mean growth temperature and the air temperature {cite}`sandoval:in_prep`. This approach
-uses the theoretical maximum value of $\phi_0 = 1/9$ as the reference value. You will
+mean growth temperature and the air temperature {cite}`sandoval:in_prep`. You will
 need to provide the aridity index and mean growing temperature for observations when
 creating the `PModelEnvironment`.
 

--- a/docs/source/users/pmodel/pmodel_details/quantum_yield.md
+++ b/docs/source/users/pmodel/pmodel_details/quantum_yield.md
@@ -80,9 +80,9 @@ currently implemented approaches are described below.
 
 All of the approaches share the same baseline reference value of $\phi{0}= 1/8$ as the
 theoretical maximum quantum yield of photosynthesis. This can be overridden got all
-analsyes using a given {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironmen` by
+analsyes using a given {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` by
 changing the value of
-{attr}`PModelConst.maximum_phi0<pyrealm.constants.pmodel_const.PModelConst.maximum_phi0`,
+{attr}`PModelConst.maximum_phi0<pyrealm.constants.pmodel_const.PModelConst.maximum_phi0>`,
 but it can also be overriden for a single P Model using the `reference_kphio` argument.
 This can be needed when specific methods have been calibrated using a 'tuned' value for
 $\phi_0$: an example here is the soil moisture stress corrected GPP estimates of

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -23,32 +23,47 @@ language_info:
 
 # Soil moisture effects
 
-At present, there are four approaches for incorporating soil moisture effects on
-photosynthesis:
+Approaches to modelling the impact of soil moisture conditions on photosynthesis are a
+very open area and a number of different methods are implemented in ``pyrealm``. These
+different approaches reflect uncertainty about the most appropriate way to modulate
+predictions.
 
-* Two soil moisture stress functions, both of which estimate a penalty factor to
-  calculated GPP based on soil moisture conditions and aridity.
-  * {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` calculates
-    $\beta(\theta)$ {cite:p}`Stocker:2020dh`.
-  * {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` calculates
-  * $\beta(\theta)$ {cite:p}`mengoli:2023a`.
-* The experimental `rootzonestress` methods for
-  {class}`~pyrealm.pmodel.optimal_chi.OptimalChiABC`, which impose a direct stress
-  penalty on $\beta$.
-* The `lavergne20_c3` and `lavergne20_c4` methods for
-  {class}`~pyrealm.pmodel.optimal_chi.OptimalChiABC`, which use an empirical model
-  of the
-  change in the ratio of the photosynthetic costs of carboxilation and transpiration.
-  Altering this cost ratio - inconveniently also called $\beta$ - for soil moisture
-  stress provides a more complete picture of plant responses than GPP penalty factors.
+1. Effects on [optimal chi](./optimal_chi). The `pyrealm` package includes two separate
+   approaches that affect optimal chi:
 
-The GPP penalty functions are described here, but see the [optimal chi](./optimal_chi)
-documentation for details of the other methods.
+   * The `lavergne20_c3` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C3`)
+     and `lavergne20_c4` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4`)
+     methods , which use an empirical model of the change in the ratio of the
+     photosynthetic costs of carboxilation and transpiration.
+
+   * The experimental optimal chi methods that impose a direct rootzone stress penalty
+     on the $\beta$ term in calculating optimal chi: `prentice14_rootzonestress`
+     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14RootzoneStress`),
+     `c4_rootzonestress`
+     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4RootzoneStress`), and
+     `c4_no_gamma_rootzonestress`
+     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGammaRootzoneStress`)
+
+2. Effects on the [quantum yield of photosynthesis](./quantum_yield):
+
+   * The `sandoval` method ({class}`~pyrealm.pmodel.quantum_yield.QuantumYieldSandoval`)
+     implements an experimental calculation that modulates $\phi_0$ as a function of the
+     temperature and a local aridity index.
+
+3. Post-hoc penalties on gross primary productivity. These approaches both use empirical
+   functions of soil moisture and aridity  data that have been parameterised to align
+   raw predictions from a P Model with field observations of GPP. Two penalty function
+   are available that calculate the fraction of potential GPP that is realised given the
+   effects of soil moisture stress:
+   * {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` {cite:p}`Stocker:2020dh`.
+   * {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` {cite:p}`mengoli:2023a`.
+
+The GPP penalty functions are described in more detail below.
 
 ## The {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` penalty factor
 
 This is an empirically derived factor ($\beta(\theta) \in [0,1]$,
-{cite:p}`Stocker:2018be,Stocker:2020dh` that describes a penalty to gross primary
+{cite:p}`Stocker:2018be,Stocker:2020dh`) that describes a penalty to gross primary
 productivity (GPP)  resulting from soil moisture stress.
 
 The factor requires estimates of:
@@ -100,9 +115,15 @@ the examples below, the default $\theta_0 = 0$ has been changed to $\theta_0 =
 
 from matplotlib import pyplot as plt
 import numpy as np
-from pyrealm import pmodel
-from pyrealm.pmodel.pmodel import PModel
-from pyrealm.pmodel.pmodel_environment import PModelEnvironment
+
+from pyrealm.pmodel import (
+    PModelEnvironment,
+    PModel,
+    calc_soilmstress_stocker,
+    calc_soilmstress_mengoli,
+    SubdailyPModel,
+    AcclimationModel,
+)
 from pyrealm.constants import PModelConst
 
 # change default theta0 parameter
@@ -128,7 +149,7 @@ soilm = np.linspace(0, 0.7, 101)
 
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
 
-    soilmstress = pmodel.calc_soilmstress_stocker(
+    soilmstress = calc_soilmstress_stocker(
         soilm=soilm, meanalpha=mean_alpha, pmodel_const=const
     )
     ax2.plot(soilm, soilmstress, label=r"$\bar{{\alpha}}$ = {}".format(mean_alpha))
@@ -159,14 +180,53 @@ by the resulting factor. The example below shows how the predicted light use
 efficiency from the P Model changes across an aridity gradient both with and without the
 soil moisture factor.
 
+In the `rpmodel` implementation, the soil moisture factor is applied within the
+calculation of the P Model and the penalised GPP is used to modify $V_{cmax}$ and
+$J_{max}$, so that these values are congruent with the resulting penalised LUE and GPP.
+This is **not** implemented in the {mod}`~pyrealm.pmodel` module, where
+correction is only implemented as a post-hoc penalty to GPP.
+
+```{caution}
+* This soil moisture stress function was parameterised using the standard P Model
+  (:class:`~pyrealm.pmodel.pmodel.PModel`) and is unlikely to transfer well to GPP
+  predictions from the subdaily form of the model
+  (:class:`~pyrealm.pmodel.pmodel.SubdailyPModel`).
+
+* The parameterisation of this soil moisture stress function formed part of a wider
+  model tuning in {cite:t}`Stocker:2020dh` that also adjusted the value of the
+  quantum yield of photosynthesis to capture canopy scale efficiency. To match this
+  calibration process, the correction should be applied to outputs of a `PModel` with
+  matching settings: see {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker`
+  for details.
+```
+
 ```{code-cell} ipython3
 # Calculate the P Model in a constant environment
-tc = np.array([20] * 101)
-sm_gradient = np.linspace(0, 1.0, 101)
+n_obs = 48 * 5
+obs_minutes = 30
+time_offsets = np.arange(0, n_obs * obs_minutes, obs_minutes).astype("timedelta64[m]")
+datetimes = np.datetime64("2000-01-01 00:00") + time_offsets
 
-env = PModelEnvironment(tc=tc, patm=101325.0, vpd=820, co2=400, fapar=1, ppfd=1000)
-model = PModel(env)
+sm_gradient = np.linspace(0, 1.0, n_obs)
 
+env = PModelEnvironment(
+    tc=np.full(n_obs, fill_value=20),
+    patm=np.full(n_obs, fill_value=101325),
+    vpd=np.full(n_obs, fill_value=820),
+    co2=np.full(n_obs, fill_value=400),
+    fapar=np.full(n_obs, fill_value=1),
+    ppfd=np.full(n_obs, fill_value=1000),
+)
+
+# Configure the PModel to use the 'BRC' model setup of Stocker et al. (2020)
+model = PModel(
+    env=env,
+    method_kphio="temperature",
+    method_arrhenius="simple",
+    method_jmaxlim="wang17",
+    method_optchi="prentice14",
+    reference_kphio=0.081785,
+)
 
 # Calculate the soil moisture stress factor across a soil moisture gradient
 # at differing aridities
@@ -175,8 +235,8 @@ gpp_stressed = {}
 
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
     # Calculate the stress for this aridity
-    sm_stress = pmodel.calc_soilmstress_stocker(
-        soilm=soilm, meanalpha=mean_alpha, pmodel_const=const
+    sm_stress = calc_soilmstress_stocker(
+        soilm=sm_gradient, meanalpha=mean_alpha, pmodel_const=const
     )
     # Apply the penalty factor
     gpp_stressed[mean_alpha] = model.gpp * sm_stress
@@ -188,23 +248,12 @@ for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
 plt.plot(sm_gradient, model.gpp, label="No soil moisture penalty")
 
 for ky, val in gpp_stressed.items():
-    plt.plot(soilm, val, label=r"$\bar{{\alpha}}$ = {}".format(ky))
+    plt.plot(sm_gradient, val, label=r"$\bar{{\alpha}}$ = {}".format(ky))
 
 plt.xlabel(r"Relative soil moisture, $m_s$, -")
 plt.ylabel(r"GPP")
 plt.legend()
 plt.show()
-```
-
-```{warning}
-In the `rpmodel` implementation, the soil moisture factor is applied within the
-calculation of the P Model and the penalised GPP is used to modify $V_{cmax}$ and
-$J_{max}$, so that these values are congruent with the resulting penalised LUE and GPP.
-
-This is **not** implemented in the {mod}`~pyrealm.pmodel` module. The empirical
-correction is only as a post-hoc penalty to GPP, which facilitates the comparison of
-different penalty factors applied to the same P Model instance.
-
 ```
 
 ## The {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` penalty factor
@@ -243,8 +292,6 @@ y &= \min( a  \textrm{AI} ^ {b}, 1)\\
 $$
 
 ```{code-cell} ipython3
-from pyrealm.constants import PModelConst
-
 const = PModelConst()
 aridity_index = np.arange(0.35, 7, 0.1)
 
@@ -284,9 +331,7 @@ beta = {}
 ai_vals = [0.3, 1, 3, 6]
 
 for ai in ai_vals:
-    beta[ai] = pmodel.calc_soilmstress_mengoli(
-        soilm=sm_gradient, aridity_index=np.array(ai)
-    )
+    beta[ai] = calc_soilmstress_mengoli(soilm=sm_gradient, aridity_index=np.array(ai))
     plt.plot(sm_gradient, beta[ai], label=f"AI = {ai}")
 
 plt.xlabel(r"Relative soil moisture $\theta$")
@@ -306,13 +351,47 @@ calculated and then applied to the GPP calculated for a model
 ({attr}`~pyrealm.pmodel.pmodel.PModel.gpp`). In the example below, the result is
 obviously just $\beta(\theta)$ from above scaled to the constant GPP.
 
+```{caution}
+* This soil moisture stress function was parameterised using the subdaily P Model
+  (:class:`~pyrealm.pmodel.pmodel.SubdailyPModel`) and is unlikely to transfer well
+  to GPP predictions from the standard form of the model
+  (:class:`~pyrealm.pmodel.pmodel.PModel`).
+
+* The parameterisation of this soil moisture stress function was estimated using
+  predictions from a particular parameterisation of the subdaily PModel. To match
+  the parameterisation settings, the correction should be applied to outputs of a
+  `SubdailyPModel` with matching settings:
+  see {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` for details.
+```
+
 ```{code-cell} ipython3
+acclim_model = AcclimationModel(datetimes=datetimes)
+acclim_model.set_window(
+    window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(1, "h")
+)
+
+acclim_model.get_window_values(env.tc)
+
+subdaily_model = SubdailyPModel(
+    env=env,
+    acclim_model=acclim_model,
+    method_kphio="temperature",
+    method_arrhenius="simple",
+    method_jmaxlim="wang17",
+    method_optchi="prentice14",
+    reference_kphio=1 / 8,
+)
+
 for ai in ai_vals:
 
-    plt.plot(sm_gradient, model.gpp * beta[ai], label=f"AI = {ai}")
+    plt.plot(sm_gradient, subdaily_model.gpp * beta[ai], label=f"AI = {ai}")
 
 plt.xlabel(r"Relative soil moisture $\theta$")
 plt.ylabel("GPP")
 plt.legend()
 plt.show()
+```
+
+```{code-cell} ipython3
+
 ```

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -40,12 +40,16 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pandas
 
-from pyrealm.pmodel.pmodel import PModel, SubdailyPModel
-from pyrealm.pmodel.pmodel_environment import PModelEnvironment
-from pyrealm.pmodel.acclimation import AcclimationModel
+from pyrealm.pmodel import (
+    PModel,
+    SubdailyPModel,
+    PModelEnvironment,
+    AcclimationModel,
+    calculate_simple_arrhenius_factor,
+)
 from pyrealm.pmodel.optimal_chi import OptimalChiPrentice14
 from pyrealm.pmodel.quantum_yield import QuantumYieldTemperature
-from pyrealm.pmodel.functions import calculate_simple_arrhenius_factor
+from pyrealm.pmodel.arrhenius import SimpleArrhenius
 ```
 
 ## Example dataset
@@ -87,7 +91,7 @@ subdaily_env = PModelEnvironment(
 )
 
 # Fit the standard P Model
-pmodel_standard = PModel(subdaily_env, method_kphio="fixed", reference_kphio=1 / 8)
+pmodel_standard = PModel(subdaily_env)
 pmodel_standard.summarize()
 ```
 
@@ -116,7 +120,6 @@ acclim_model.set_window(
 pmodel_subdaily = SubdailyPModel(
     env=subdaily_env,
     acclim_model=acclim_model,
-    reference_kphio=1 / 8,
 )
 ```
 
@@ -163,7 +166,7 @@ daily_acclim_env = PModelEnvironment(
     ppfd=ppfd_acclim,
 )
 
-pmodel_acclim = PModel(daily_acclim_env, reference_kphio=1 / 8)
+pmodel_acclim = PModel(daily_acclim_env)
 ```
 
 ### Slow responses of $\xi$, $J_{max25}$ and $V_{cmax25}$
@@ -184,13 +187,15 @@ enzymes.
 pmodel_const = pmodel_subdaily.env.pmodel_const
 core_const = pmodel_subdaily.env.core_const
 
-tk_acclim = temp_acclim + core_const.k_CtoK
-tk_ref = pmodel_const.plant_T_ref + core_const.k_CtoK
-vcmax25_acclim = pmodel_acclim.vcmax / calculate_simple_arrhenius_factor(
-    tk=tk_acclim, tk_ref=tk_ref, ha=pmodel_const.arrhenius_vcmax["simple"]["ha"]
+arrh_daily = SimpleArrhenius(
+    env=daily_acclim_env, reference_temperature=25, core_const=core_const
 )
-jmax25_acclim = pmodel_acclim.jmax / calculate_simple_arrhenius_factor(
-    tk=tk_acclim, tk_ref=tk_ref, ha=pmodel_const.arrhenius_jmax["simple"]["ha"]
+
+vcmax25_acclim = pmodel_acclim.vcmax / arrh_daily.calculate_arrhenius_factor(
+    pmodel_const.arrhenius_vcmax
+)
+jmax25_acclim = pmodel_acclim.jmax / arrh_daily.calculate_arrhenius_factor(
+    pmodel_const.arrhenius_jmax
 )
 ```
 
@@ -248,18 +253,23 @@ temperature at fast scales:
   responses of $J_{max}$ and $V_{cmax}$.
 
 ```{code-cell} ipython3
-tk_subdaily = subdaily_env.tc + pmodel_subdaily.env.core_const.k_CtoK
-
 # Fill the realised jmax and vcmax from subdaily to daily
 vcmax25_subdaily = acclim_model.fill_daily_to_subdaily(vcmax25_real)
 jmax25_subdaily = acclim_model.fill_daily_to_subdaily(jmax25_real)
 
-# Adjust to actual temperature at subdaily timescale
-vcmax_subdaily = vcmax25_subdaily * calculate_simple_arrhenius_factor(
-    tk=tk_subdaily, tk_ref=tk_ref, ha=pmodel_const.arrhenius_vcmax["simple"]["ha"]
+# Get the Arrhenius scaler
+
+arrh_subdaily = SimpleArrhenius(
+    env=subdaily_env, reference_temperature=25, core_const=core_const
 )
-jmax_subdaily = jmax25_subdaily * calculate_simple_arrhenius_factor(
-    tk=tk_subdaily, tk_ref=tk_ref, ha=pmodel_const.arrhenius_jmax["simple"]["ha"]
+
+
+# Adjust to actual temperature at subdaily timescale
+vcmax_subdaily = vcmax25_subdaily * arrh_subdaily.calculate_arrhenius_factor(
+    coefficients=pmodel_const.arrhenius_vcmax
+)
+jmax_subdaily = jmax25_subdaily * arrh_subdaily.calculate_arrhenius_factor(
+    coefficients=pmodel_const.arrhenius_jmax
 )
 ```
 
@@ -299,7 +309,7 @@ Ac_subdaily = (
 )
 
 # Calculate J and Aj
-phi = QuantumYieldTemperature(env=subdaily_env, reference_kphio=1 / 8)
+phi = QuantumYieldTemperature(env=subdaily_env)
 iabs = fapar_subdaily * ppfd_subdaily
 
 J_subdaily = (4 * phi.kphio * iabs) / np.sqrt(

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -37,7 +37,6 @@ from importlib import resources
 from matplotlib import pyplot as plt
 import matplotlib.dates as mdates
 import numpy as np
-from numpy.testing import assert_allclose
 import pandas
 
 from pyrealm.pmodel import (
@@ -342,5 +341,7 @@ plt.tight_layout()
 # This cell is here to force a docs build failure if these values
 # are _not_ identical. The 'remove-cell' tag is applied to hide this
 # in built docs.
+from numpy.testing import assert_allclose
+
 assert_allclose(GPP_subdaily, pmodel_subdaily.gpp)
 ```

--- a/docs/source/users/pmodel/subdaily_details/worked_example.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example.md
@@ -119,14 +119,18 @@ instantaneously adopt optimal behaviour.
 ```{code-cell} ipython3
 # Standard PModels
 pmodC3 = PModel(
-    env=pm_env, method_kphio="fixed", reference_kphio=1 / 8, method_optchi="prentice14"
+    env=pm_env,
+    method_kphio="fixed",
+    method_optchi="prentice14",
 )
 pmodC3.summarize()
 ```
 
 ```{code-cell} ipython3
 pmodC4 = PModel(
-    env=pm_env, method_kphio="fixed", reference_kphio=1 / 8, method_optchi="c4_no_gamma"
+    env=pm_env,
+    method_kphio="fixed",
+    method_optchi="c4_no_gamma",
 )
 
 pmodC4.summarize()
@@ -148,20 +152,18 @@ acclim_model.set_window(
     half_width=np.timedelta64(1, "h"),
 )
 
-# Fit C3 and C4 with the new implementation
+# Fit C3 and C4 with the Subdaily P Model
 subdailyC3 = SubdailyPModel(
     env=pm_env,
+    acclim_model=acclim_model,
     method_optchi="prentice14",
     method_kphio="fixed",
-    reference_kphio=1 / 8,
-    acclim_model=acclim_model,
 )
 subdailyC4 = SubdailyPModel(
     env=pm_env,
+    acclim_model=acclim_model,
     method_optchi="c4_no_gamma",
     method_kphio="fixed",
-    reference_kphio=1 / 8,
-    acclim_model=acclim_model,
 )
 ```
 
@@ -240,11 +242,13 @@ This produces the same outputs as the `SubdailyPModel` class, but is convenient 
 compact when the two models are going to be compared.
 
 ```{code-cell} ipython3
-# Models have identical GPP - maximum absolute difference is zero.
-print(np.nanmax(abs(subdailyC3.gpp.flatten() - converted_C3.gpp.flatten())))
-print(np.nanmax(abs(subdailyC4.gpp.flatten() - converted_C4.gpp.flatten())))
-```
+:tags: [remove-cell]
 
-```{code-cell} ipython3
+# This cell is here to force a docs build failure if these values
+# are _not_ identical. The 'remove-cell' tag is applied to hide this
+# in built docs.
+from numpy.testing import assert_allclose
 
+assert_allclose(subdailyC3.gpp, converted_C3.gpp)
+assert_allclose(subdailyC4.gpp, converted_C4.gpp)
 ```

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -174,6 +174,12 @@ class PModelConst(ConstantsClass):
     bernacchi_gs25_0: float = 4.332  # Reported as 42.75 µmol mol-1
     """Bernacchi estimate of gs25_0"""
 
+    # Quantum yield efficiency of photosynthesis
+    maximum_phi0: float = 1.0 / 8.0
+    """The theoretical maximum intrinsic quantum yield efficiency of photosynthesis
+    (:math:`\phi_0`, unitless). This value defaults to 1/8 but could be set to 1/9 to
+    capture the absence of a Q cycle :cite:`long:1993a`."""
+
     # Boyd
     boyd_kp25_c4: float = 16  # Pa  from Boyd et al. (2015)
     boyd_dhac_c4: float = 36300  # J mol-1

--- a/pyrealm/pmodel/__init__.py
+++ b/pyrealm/pmodel/__init__.py
@@ -28,6 +28,7 @@ Constants
 # flatten the namespace for the main public components and setup.cfg applies
 # # to the whole file.
 
+from pyrealm.pmodel.acclimation import AcclimationModel
 from pyrealm.pmodel.competition import (
     C3C4Competition,
     calculate_tree_proportion,
@@ -50,17 +51,16 @@ from pyrealm.pmodel.pmodel import PModel, SubdailyPModel
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 
 __all__ = [
+    "AcclimationModel",
     "C3C4Competition",
     "CalcCarbonIsotopes",
     "JmaxLimitation",
     "PModel",
     "PModelEnvironment",
     "SubdailyPModel",
-    "SubdailyScaler",
     "calc_co2_to_ca",
     "calc_ftemp_inst_rd",
     "calc_ftemp_inst_vcmax",
-    "calc_ftemp_kphio",
     "calc_gammastar",
     "calc_kmm",
     "calc_ns_star",

--- a/pyrealm_build_data/two_leaf/two_leaf_python.md
+++ b/pyrealm_build_data/two_leaf/two_leaf_python.md
@@ -251,7 +251,7 @@ pmod_env = PModelEnvironment(
 )
 
 # Standard P Model
-standard_pmod = PModel(pmod_env, reference_kphio=1 / 8)
+standard_pmod = PModel(pmod_env)
 
 
 # Subdaily P Model

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -669,13 +669,17 @@ def pmodelenv(values):
 def test_pmodel_class_c3(
     request, values, pmodelenv, soilmstress, method_kphio, luevcmax_method, environ
 ):
-    """Test the PModel class for C3 plants."""
+    """Test the PModel class for C3 plants.
+
+    Note that the values generated here do not use the recommended settings from
+    :cite:t:`Stocker:2020dh` for the BRC and ORG approaches for the reference values of
+    phi0.
+    """
 
     from pyrealm.pmodel import calc_soilmstress_stocker
     from pyrealm.pmodel.pmodel import PModel
 
-    # TODO - this is a bit odd as rpmodel embeds stocker soilm in model where in pyrealm
-    #        it is only applied post-GPP calculation. Maybe disentangle these.
+    # Calculate the soil moisture factor to apply post hoc
     if soilmstress:
         soilmstress = calc_soilmstress_stocker(
             values["soilm_sc"], values["meanalpha_sc"]

--- a/tests/regression/pmodel/test_sandoval_quantum_yield.py
+++ b/tests/regression/pmodel/test_sandoval_quantum_yield.py
@@ -34,7 +34,7 @@ def test_QuantumYieldSandoval(values):
         co2=400,
         mean_growth_temperature=values["mean_gdd_temp"].to_numpy(),
         aridity_index=values["aridity_index"].to_numpy(),
-        pmodel_const=PModelConst(),
+        pmodel_const=PModelConst(maximum_phi0=1 / 9),
     )
 
     # Calculate kphio for that environment

--- a/tests/unit/pmodel/test_c3c4competition.py
+++ b/tests/unit/pmodel/test_c3c4competition.py
@@ -84,8 +84,9 @@ def test_c3c4competition(pmodel_c3_args, pmodel_c4_args, expected):
         ppfd=np.array([800]),
     )
 
-    pmodel_c3 = PModel(env, **pmodel_c3_args)
-    pmodel_c4 = PModel(env, **pmodel_c4_args)
+    # The test values were calculated when PModel still used the Stocker default phi0
+    pmodel_c3 = PModel(env, **pmodel_c3_args, reference_kphio=0.081785)
+    pmodel_c4 = PModel(env, **pmodel_c4_args, reference_kphio=0.081785)
 
     comp = C3C4Competition(
         pmodel_c3.gpp,

--- a/tests/unit/pmodel/test_quantum_yield.py
+++ b/tests/unit/pmodel/test_quantum_yield.py
@@ -26,7 +26,7 @@ def quantum_yield_env():
 @pytest.mark.parametrize(
     argnames="reference_kphio, expected_kphio",
     argvalues=(
-        pytest.param(None, 0.049977, id="default"),
+        pytest.param(None, 1 / 8, id="default"),
         pytest.param(0.1, 0.1, id="provided"),
     ),
 )
@@ -113,18 +113,18 @@ def test_QuantumYieldTemperature(
     argnames="reference_kphio, expected_kphio",
     argvalues=(
         pytest.param(
-            None,
+            1 / 9,
             np.array(
                 [0.02848466, 0.05510828, 0.06099888, 0.07537036, 0.02231382, 0.03026185]
             ),
-            id="default_kphio",
+            id="provided_kphio",
         ),
         pytest.param(
-            1 / 8,
+            None,
             np.array(
                 [0.03204524, 0.06199681, 0.06862374, 0.08479165, 0.02510305, 0.03404458]
             ),
-            id="provided_kphio",
+            id="default_kphio",
         ),
     ),
 )


### PR DESCRIPTION
# Description

The different `QuantumYieldABC` implementations had different default values for `phi_0` - but these choices reflected particular analysis decisions of the original implementations. There is now a single default.

This PR:

* removes the `default_reference_kphio` class attribute from `QuantumYieldABC` which provided class specific defaults and replaces it with a shared global default value set in the `PModelEnvironment.pmodel_consts`. 
* That constant value can be overridden globally through the constants settings, but also particular models can be run with a different setting by using `reference_kphio` with `PModel` or `SubdailyPModel` as before - this is passed into the `QuantumYieldABC` to override the global default.
* The soil moisture functions are most affected here.  The core `QuantumYield` classes  functions were explicitly parameterised with `phi_0` settings to match these soil moisture functions. That lead to confusing differences in predictions - which is the motivation for this change - and so the docs for these now need state explicitly that the models need to be set up correctly to duplicate those analyses.

Fixes #414

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
