### PR TITLE
Rework PModelConsts and usage in functions

### DIFF
--- a/docs/source/users/pmodel/pmodel_details/arrhenius.md
+++ b/docs/source/users/pmodel/pmodel_details/arrhenius.md
@@ -115,11 +115,12 @@ This leads to the curve labelled `rpmodel` in the plot, which does not have a pe
 pmodel_const = PModelConst()
 core_const = CoreConst()
 tc = np.arange(0, 40, 0.1)
+tk = tc + core_const.k_CtoK
 
 # Calculate the simple scaling factor
 simple = calculate_simple_arrhenius_factor(
-    tk=tc + core_const.k_CtoK,
-    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+    tk=tk,
+    tk_ref=pmodel_const.tk_ref,
     ha=pmodel_const.arrhenius_vcmax["simple"]["ha"],
 )
 
@@ -127,9 +128,9 @@ simple = calculate_simple_arrhenius_factor(
 # 1) t_g = 10°C
 coef = pmodel_const.arrhenius_vcmax["kattge_knorr"]
 kattge_knorr_10 = calculate_kattge_knorr_arrhenius_factor(
-    tk_leaf=tc + core_const.k_CtoK,
+    tk_leaf=tk,
     tc_growth=10,
-    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tk_ref,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],
@@ -138,9 +139,9 @@ kattge_knorr_10 = calculate_kattge_knorr_arrhenius_factor(
 
 # 2) t_g = 20°C
 kattge_knorr_20 = calculate_kattge_knorr_arrhenius_factor(
-    tk_leaf=tc + core_const.k_CtoK,
+    tk_leaf=tk,
     tc_growth=20,
-    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tk_ref,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],
@@ -149,9 +150,9 @@ kattge_knorr_20 = calculate_kattge_knorr_arrhenius_factor(
 
 # 3) rpmodel: t_g == T_leaf
 rpmodel = calculate_kattge_knorr_arrhenius_factor(
-    tk_leaf=tc + core_const.k_CtoK,
-    tc_growth=tc + core_const.k_CtoK,
-    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+    tk_leaf=tk,
+    tc_growth=tk,
+    tk_ref=pmodel_const.tk_ref,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],

--- a/docs/source/users/pmodel/pmodel_details/arrhenius.md
+++ b/docs/source/users/pmodel/pmodel_details/arrhenius.md
@@ -119,7 +119,7 @@ tc = np.arange(0, 40, 0.1)
 # Calculate the simple scaling factor
 simple = calculate_simple_arrhenius_factor(
     tk=tc + core_const.k_CtoK,
-    tk_ref=pmodel_const.plant_T_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
     ha=pmodel_const.arrhenius_vcmax["simple"]["ha"],
 )
 
@@ -129,7 +129,7 @@ coef = pmodel_const.arrhenius_vcmax["kattge_knorr"]
 kattge_knorr_10 = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tc + core_const.k_CtoK,
     tc_growth=10,
-    tk_ref=pmodel_const.plant_T_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],
@@ -140,7 +140,7 @@ kattge_knorr_10 = calculate_kattge_knorr_arrhenius_factor(
 kattge_knorr_20 = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tc + core_const.k_CtoK,
     tc_growth=20,
-    tk_ref=pmodel_const.plant_T_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],
@@ -151,7 +151,7 @@ kattge_knorr_20 = calculate_kattge_knorr_arrhenius_factor(
 rpmodel = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tc + core_const.k_CtoK,
     tc_growth=tc + core_const.k_CtoK,
-    tk_ref=pmodel_const.plant_T_ref + core_const.k_CtoK,
+    tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
     ha=coef["ha"],
     hd=coef["hd"],
     entropy_intercept=coef["entropy_intercept"],

--- a/docs/source/users/pmodel/pmodel_details/arrhenius.md
+++ b/docs/source/users/pmodel/pmodel_details/arrhenius.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  codemirror_mode:
-    name: ipython
-    version: 3
-  file_extension: .py
-  mimetype: text/x-python
-  name: python
-  nbconvert_exporter: python
-  pygments_lexer: ipython3
-  version: 3.11.9
 ---
 
 # Arrhenius scaling in the P Model
@@ -33,14 +23,13 @@ when fitting a P Model. The `kattge_knorr` method scaling is implemented for
 experimental purposes only.
 :::
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pyrealm.constants.core_const import CoreConst
-from pyrealm.constants.pmodel_const import PModelConst
+from pyrealm.constants import CoreConst, PModelConst
 from pyrealm.pmodel.functions import (
     calculate_simple_arrhenius_factor,
     calculate_kattge_knorr_arrhenius_factor,
@@ -108,7 +97,7 @@ present, the implementation of the standard P Model in `rpmodel` uses the form o
 `kattge_knorr` method but sets $t_g=T$, rather than having a fixed growth temperature.
 This leads to the curve labelled `rpmodel` in the plot, which does not have a peak.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 # Define constants and a temperature range
@@ -131,10 +120,7 @@ kattge_knorr_10 = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tk,
     tc_growth=10,
     tk_ref=pmodel_const.tk_ref,
-    ha=coef["ha"],
-    hd=coef["hd"],
-    entropy_intercept=coef["entropy_intercept"],
-    entropy_slope=coef["entropy_slope"],
+    coef=coef,
 )
 
 # 2) t_g = 20°C
@@ -142,10 +128,7 @@ kattge_knorr_20 = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tk,
     tc_growth=20,
     tk_ref=pmodel_const.tk_ref,
-    ha=coef["ha"],
-    hd=coef["hd"],
-    entropy_intercept=coef["entropy_intercept"],
-    entropy_slope=coef["entropy_slope"],
+    coef=coef,
 )
 
 # 3) rpmodel: t_g == T_leaf
@@ -153,16 +136,15 @@ rpmodel = calculate_kattge_knorr_arrhenius_factor(
     tk_leaf=tk,
     tc_growth=tk,
     tk_ref=pmodel_const.tk_ref,
-    ha=coef["ha"],
-    hd=coef["hd"],
-    entropy_intercept=coef["entropy_intercept"],
-    entropy_slope=coef["entropy_slope"],
+    coef=coef,
 )
 
 plt.plot(tc, simple, label="Simple")
 plt.plot(tc, kattge_knorr_10, label="Kattge Knorr ($t_g=10$°C)")
 plt.plot(tc, kattge_knorr_20, label="Kattge Knorr ($t_g=20$°C)")
-plt.plot(tc, rpmodel, linestyle="--", color="grey", label="rpmodel ($t_g=T$)")
+plt.plot(
+    tc, rpmodel, linestyle="--", color="grey", label="Kattge Knorr in rpmodel ($t_g=T$)"
+)
 plt.legend(frameon=False)
 plt.xlabel("Leaf temperature (°C)")
 plt.tight_layout()

--- a/docs/source/users/pmodel/pmodel_details/arrhenius.md
+++ b/docs/source/users/pmodel/pmodel_details/arrhenius.md
@@ -9,6 +9,16 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Arrhenius scaling in the P Model
@@ -23,7 +33,7 @@ when fitting a P Model. The `kattge_knorr` method scaling is implemented for
 experimental purposes only.
 :::
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 import matplotlib.pyplot as plt
@@ -97,7 +107,7 @@ present, the implementation of the standard P Model in `rpmodel` uses the form o
 `kattge_knorr` method but sets $t_g=T$, rather than having a fixed growth temperature.
 This leads to the curve labelled `rpmodel` in the plot, which does not have a peak.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 # Define constants and a temperature range

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -106,13 +106,14 @@ from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 from pyrealm.constants import PModelConst
 
 # change default theta0 parameter
-const = PModelConst(soilmstress_theta0=0.1)
+coef = PModelConst().soilmstress_stocker
+coef["theta0"] = 0.1
 
 # Calculate q
 mean_alpha_seq = np.linspace(0, 1, 101)
 
-q = (1 - (const.soilmstress_a + const.soilmstress_b * mean_alpha_seq)) / (
-    const.soilmstress_thetastar - const.soilmstress_theta0
+q = (1 - (coef["a"] + coef["b"] * mean_alpha_seq)) / (
+    coef["thetastar"] - coef["theta0"]
 ) ** 2
 
 # Create a 1x2 plot
@@ -129,16 +130,16 @@ soilm = np.linspace(0, 0.7, 101)
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
 
     soilmstress = pmodel.calc_soilmstress_stocker(
-        soilm=soilm, meanalpha=mean_alpha, pmodel_const=const
+        soilm=soilm, meanalpha=mean_alpha, coef=coef
     )
     ax2.plot(soilm, soilmstress, label=r"$\bar{{\alpha}}$ = {}".format(mean_alpha))
 
-ax2.axvline(x=const.soilmstress_thetastar, linestyle="--", color="black")
-ax2.axvline(x=const.soilmstress_theta0, linestyle="--", color="black")
+ax2.axvline(x=coef["thetastar"], linestyle="--", color="black")
+ax2.axvline(x=coef["theta0"], linestyle="--", color="black")
 
 secax = ax2.secondary_xaxis("top")
 secax.set_xticks(
-    ticks=[const.soilmstress_thetastar, const.soilmstress_theta0],
+    ticks=[coef["thetastar"], coef["theta0"]],
     labels=[r"$\theta^\ast$", r"$\theta_0$"],
 )
 
@@ -176,7 +177,7 @@ gpp_stressed = {}
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
     # Calculate the stress for this aridity
     sm_stress = pmodel.calc_soilmstress_stocker(
-        soilm=soilm, meanalpha=mean_alpha, pmodel_const=const
+        soilm=soilm, meanalpha=mean_alpha, coef=coef
     )
     # Apply the penalty factor
     gpp_stressed[mean_alpha] = model.gpp * sm_stress
@@ -245,16 +246,14 @@ $$
 ```{code-cell} ipython3
 from pyrealm.constants import PModelConst
 
-const = PModelConst()
+coef = PModelConst().soilmstress_mengoli
 aridity_index = np.arange(0.35, 7, 0.1)
 
-y = np.minimum(
-    const.soilm_mengoli_y_a * np.power(aridity_index, const.soilm_mengoli_y_b), 1
-)
+y = np.minimum(coef["y_a"] * np.power(aridity_index, coef["y_b"]), 1)
 
 
 psi = np.minimum(
-    const.soilm_mengoli_psi_a * np.power(aridity_index, const.soilm_mengoli_psi_b),
+    coef["psi_a"] * np.power(aridity_index, coef["psi_b"]),
     1,
 )
 

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -9,6 +9,16 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Soil moisture effects
@@ -61,7 +71,7 @@ set created below. The data set consists of 5 days of observations of a constant
 environment that can be used to show the effects of changing soil moisture input values
 on the resulting GPP.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 from matplotlib import pyplot as plt
@@ -149,7 +159,7 @@ varies with changing soil moisture for differing values of mean aridity. In
 the examples below, the default $\theta_0 = 0$ has been changed to $\theta_0 =
 0.1$ to make the lower bound more obvious.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 # change default theta0 parameter
@@ -226,7 +236,7 @@ correction is only implemented as a post-hoc penalty to GPP.
   for details.
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 # Configure the PModel to use the 'BRC' model setup of Stocker et al. (2020)
 model = PModel(
     env=env,
@@ -251,7 +261,7 @@ for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
     gpp_stressed[mean_alpha] = model.gpp * sm_stress
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 plt.plot(sm_gradient, model.gpp, label="No soil moisture penalty")
@@ -321,17 +331,17 @@ Given the default values, this critical level as around 0.3457: plants can only 
 the predicted GPP from the P Model in locations where the aridity index is less than
 this value.
 
-```{code-cell}
+```{code-cell} ipython3
 coef = PModelConst().soilmstress_mengoli
 print(coef)
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 AI_crit_y = np.exp(-np.log(coef["y_a"]) / coef["y_b"])
 round(AI_crit_y, 4)
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 aridity_index = np.sort(np.concatenate([[AI_crit_y], np.linspace(0.2, 7, n_obs)]))
 
 y = np.minimum(coef["y_a"] * np.power(aridity_index, coef["y_b"]), 1)
@@ -374,7 +384,7 @@ ax2.legend(frameon=False)
 plt.tight_layout()
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 np.exp(-np.log(0.62) / -0.45)
 ```
 
@@ -402,7 +412,7 @@ obviously just $\beta(\theta)$ from above scaled to the constant GPP.
   see {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` for details.
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 acclim_model = AcclimationModel(datetimes=datetimes)
 acclim_model.set_window(
     window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(1, "h")
@@ -428,6 +438,6 @@ plt.legend(frameon=False)
 plt.show()
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 
 ```

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -9,16 +9,6 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
-language_info:
-  codemirror_mode:
-    name: ipython
-    version: 3
-  file_extension: .py
-  mimetype: text/x-python
-  name: python
-  nbconvert_exporter: python
-  pygments_lexer: ipython3
-  version: 3.11.9
 ---
 
 # Soil moisture effects
@@ -28,37 +18,86 @@ very open area and a number of different methods are implemented in ``pyrealm``.
 different approaches reflect uncertainty about the most appropriate way to modulate
 predictions.
 
-1. Effects on [optimal chi](./optimal_chi). The `pyrealm` package includes two separate
-   approaches that affect optimal chi:
+## Alternative approaches
 
-   * The `lavergne20_c3` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C3`)
-     and `lavergne20_c4` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4`)
-     methods , which use an empirical model of the change in the ratio of the
-     photosynthetic costs of carboxilation and transpiration.
+### Effects on [optimal chi](./optimal_chi)
 
-   * The experimental optimal chi methods that impose a direct rootzone stress penalty
-     on the $\beta$ term in calculating optimal chi: `prentice14_rootzonestress`
-     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14RootzoneStress`),
-     `c4_rootzonestress`
-     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4RootzoneStress`), and
-     `c4_no_gamma_rootzonestress`
-     ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGammaRootzoneStress`)
+The `pyrealm` package includes two separate approaches that affect optimal chi:
 
-2. Effects on the [quantum yield of photosynthesis](./quantum_yield):
+* The `lavergne20_c3` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C3`)
+ and `lavergne20_c4` ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4`)
+ methods , which use an empirical model of the change in the ratio of the
+ photosynthetic costs of carboxilation and transpiration.
 
-   * The `sandoval` method ({class}`~pyrealm.pmodel.quantum_yield.QuantumYieldSandoval`)
-     implements an experimental calculation that modulates $\phi_0$ as a function of the
-     temperature and a local aridity index.
+* The experimental optimal chi methods that impose a direct rootzone stress penalty
+ on the $\beta$ term in calculating optimal chi: `prentice14_rootzonestress`
+ ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14RootzoneStress`),
+ `c4_rootzonestress`
+ ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4RootzoneStress`), and
+ `c4_no_gamma_rootzonestress`
+ ({class}`~pyrealm.pmodel.optimal_chi.OptimalChiC4NoGammaRootzoneStress`)
 
-3. Post-hoc penalties on gross primary productivity. These approaches both use empirical
-   functions of soil moisture and aridity  data that have been parameterised to align
-   raw predictions from a P Model with field observations of GPP. Two penalty function
-   are available that calculate the fraction of potential GPP that is realised given the
-   effects of soil moisture stress:
-   * {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` {cite:p}`Stocker:2020dh`.
-   * {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` {cite:p}`mengoli:2023a`.
+### Effects on the [quantum yield of photosynthesis](./quantum_yield)
 
-The GPP penalty functions are described in more detail below.
+* The `sandoval` method ({class}`~pyrealm.pmodel.quantum_yield.QuantumYieldSandoval`)
+ implements an experimental calculation that modulates $\phi_0$ as a function of the
+ temperature and a local aridity index.
+
+### Post-hoc penalties on gross primary productivity
+
+These approaches both use empirical
+functions of soil moisture and aridity  data that have been parameterised to align
+raw predictions from a P Model with field observations of GPP. Two penalty function
+are available that calculate the fraction of potential GPP that is realised given the
+effects of soil moisture stress:
+
+* The {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` function implements the
+  {cite:t}`Stocker:2020dh` GPP penalty for use with the standard P Model.
+* {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` function implements the
+  {cite:t}`mengoli:2023a` GPP penalty for use with the subdaily P Model..
+
+The GPP penalty functions are described in more detail below, using the artificial data
+set created below. The data set consists of 5 days of observations of a constant
+environment that can be used to show the effects of changing soil moisture input values
+on the resulting GPP.
+
+```{code-cell}
+:tags: [hide-input]
+
+from matplotlib import pyplot as plt
+import numpy as np
+
+from pyrealm.pmodel import (
+    PModelEnvironment,
+    PModel,
+    calc_soilmstress_stocker,
+    calc_soilmstress_mengoli,
+    SubdailyPModel,
+    AcclimationModel,
+)
+from pyrealm.constants import PModelConst
+
+# Create a test data set consisting of 5 days of observations of a constant environment
+# that can be used to show the effects of changing soil moisture input values on the
+# resulting GPP
+n_obs = 48 * 5
+obs_minutes = 30
+time_offsets = np.arange(0, n_obs * obs_minutes, obs_minutes).astype("timedelta64[m]")
+datetimes = np.datetime64("2000-01-01 00:00") + time_offsets
+
+# Constant P Model enviroment
+env = PModelEnvironment(
+    tc=np.full(n_obs, fill_value=20),
+    patm=np.full(n_obs, fill_value=101325),
+    vpd=np.full(n_obs, fill_value=820),
+    co2=np.full(n_obs, fill_value=400),
+    fapar=np.full(n_obs, fill_value=1),
+    ppfd=np.full(n_obs, fill_value=1000),
+)
+
+# Soil moisture gradient across the observations
+sm_gradient = np.linspace(0, 1.0, n_obs)
+```
 
 ## The {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` penalty factor
 
@@ -106,32 +145,19 @@ $$
 
 The figures below shows how the aridity sensitivity parameter ($q$) changes with
 differing aridity measures and then how the soil moisture factor $\beta(\theta)$
-varies with changing soil moisture for some different values of mean aridity. In
+varies with changing soil moisture for differing values of mean aridity. In
 the examples below, the default $\theta_0 = 0$ has been changed to $\theta_0 =
 0.1$ to make the lower bound more obvious.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
-
-from matplotlib import pyplot as plt
-import numpy as np
-
-from pyrealm.pmodel import (
-    PModelEnvironment,
-    PModel,
-    calc_soilmstress_stocker,
-    calc_soilmstress_mengoli,
-    SubdailyPModel,
-    AcclimationModel,
-)
-from pyrealm.constants import PModelConst
 
 # change default theta0 parameter
 coef = PModelConst().soilmstress_stocker
 coef["theta0"] = 0.1
 
 # Calculate q
-mean_alpha_seq = np.linspace(0, 1, 101)
+mean_alpha_seq = np.linspace(0, 1, n_obs)
 
 q = (1 - (coef["a"] + coef["b"] * mean_alpha_seq)) / (
     coef["thetastar"] - coef["theta0"]
@@ -145,13 +171,15 @@ ax1.plot(mean_alpha_seq, q)
 ax1.set_xlabel(r"Mean aridity, $\bar{\alpha}$")
 ax1.set_ylabel(r"Aridity sensitivity parameter, $q$")
 
-# Plot beta(theta) ~ m_s for 5 values of mean alpha
-soilm = np.linspace(0, 0.7, 101)
 
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
 
-    soilmstress = calc_soilmstress_stocker(soilm=soilm, meanalpha=mean_alpha, coef=coef)
-    ax2.plot(soilm, soilmstress, label=r"$\bar{{\alpha}}$ = {}".format(mean_alpha))
+    soilmstress = calc_soilmstress_stocker(
+        soilm=sm_gradient, meanalpha=mean_alpha, coef=coef
+    )
+    ax2.plot(
+        sm_gradient, soilmstress, label=r"$\bar{{\alpha}}$ = {}".format(mean_alpha)
+    )
 
 ax2.axvline(x=coef["thetastar"], linestyle="--", color="black")
 ax2.axvline(x=coef["theta0"], linestyle="--", color="black")
@@ -162,12 +190,11 @@ secax.set_xticks(
     labels=[r"$\theta^\ast$", r"$\theta_0$"],
 )
 
-ax2.legend()
+ax2.legend(frameon=False)
 ax2.set_xlabel(r"Relative soil moisture, $m_s$")
 ax2.set_ylabel(r"Empirical soil moisture factor, $\beta(\theta)$")
 
-
-plt.show()
+plt.tight_layout()
 ```
 
 ### Application of the {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` factor
@@ -199,24 +226,7 @@ correction is only implemented as a post-hoc penalty to GPP.
   for details.
 ```
 
-```{code-cell} ipython3
-# Calculate the P Model in a constant environment
-n_obs = 48 * 5
-obs_minutes = 30
-time_offsets = np.arange(0, n_obs * obs_minutes, obs_minutes).astype("timedelta64[m]")
-datetimes = np.datetime64("2000-01-01 00:00") + time_offsets
-
-sm_gradient = np.linspace(0, 1.0, n_obs)
-
-env = PModelEnvironment(
-    tc=np.full(n_obs, fill_value=20),
-    patm=np.full(n_obs, fill_value=101325),
-    vpd=np.full(n_obs, fill_value=820),
-    co2=np.full(n_obs, fill_value=400),
-    fapar=np.full(n_obs, fill_value=1),
-    ppfd=np.full(n_obs, fill_value=1000),
-)
-
+```{code-cell}
 # Configure the PModel to use the 'BRC' model setup of Stocker et al. (2020)
 model = PModel(
     env=env,
@@ -234,12 +244,14 @@ gpp_stressed = {}
 
 for mean_alpha in [0.9, 0.5, 0.3, 0.1, 0.0]:
     # Calculate the stress for this aridity
-    sm_stress = calc_soilmstress_stocker(soilm=soilm, meanalpha=mean_alpha, coef=coef)
+    sm_stress = calc_soilmstress_stocker(
+        soilm=sm_gradient, meanalpha=mean_alpha, coef=coef
+    )
     # Apply the penalty factor
     gpp_stressed[mean_alpha] = model.gpp * sm_stress
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 plt.plot(sm_gradient, model.gpp, label="No soil moisture penalty")
@@ -274,11 +286,11 @@ the total soil capacity. The soil water estimated using CRU data in SPLASH v1 mo
 soil moisture calculated in the same way should be used with this approach.
 ```
 
-The calculation of $\beta(\theta)$ is based on two functions of the aridity index: both
-power laws, constrained to take a maximum of 1 (no soil moisture stress penalty). The
-first function describes the maximal attainable level ($y$) and the second function
-describes a threshold ($\psi$) at which that level is reached. The parameters of these
-power laws are derived from experimental data and set in
+The calculation of $\beta(\theta)$ is based on two functions of the aridity index. Both
+functions are power laws, constrained to take a maximum of 1 (no soil moisture stress
+penalty). The first function describes the maximal attainable level ($y$) and the second
+function describes a threshold ($\psi$) at which that level is reached. The parameters
+of these power laws are derived from experimental data and set in
 {class}`~pyrealm.constants.pmodel_const.PModelConst`.
 
 $$
@@ -287,28 +299,6 @@ y &= \min( a  \textrm{AI} ^ {b}, 1)\\
 \psi &= \min( a  \textrm{AI} ^ {b}, 1)\\
 \end{align*}
 $$
-
-```{code-cell} ipython3
-from pyrealm.constants import PModelConst
-
-coef = PModelConst().soilmstress_mengoli
-aridity_index = np.arange(0.35, 7, 0.1)
-
-y = np.minimum(coef["y_a"] * np.power(aridity_index, coef["y_b"]), 1)
-
-
-psi = np.minimum(
-    coef["psi_a"] * np.power(aridity_index, coef["psi_b"]),
-    1,
-)
-
-plt.plot(aridity_index, y, label="Maximum level ($y$)")
-plt.plot(aridity_index, psi, label="Critical threshold ($\psi$)")
-plt.xlabel(r"Aridity Index (AI)")
-plt.ylabel(r"$\beta(\theta)$")
-plt.legend()
-plt.show()
-```
 
 The penalty factor $\beta(\theta)$ is then calculated given the relative soil moisture
 $\theta$, the threshold $\psi$ and the maximum level:
@@ -321,23 +311,74 @@ $$
     \end{cases}
 $$
 
-```{code-cell} ipython3
+The function for the maximum attainable level $y$ reaches the maximum value of 1 at:
+
+$$
+\textrm{AI} = e^{-log(a)/b}
+$$
+
+Given the default values, this critical level as around 0.3457: plants can only realise
+the predicted GPP from the P Model in locations where the aridity index is less than
+this value.
+
+```{code-cell}
+coef = PModelConst().soilmstress_mengoli
+print(coef)
+```
+
+```{code-cell}
+AI_crit_y = np.exp(-np.log(coef["y_a"]) / coef["y_b"])
+round(AI_crit_y, 4)
+```
+
+```{code-cell}
+aridity_index = np.sort(np.concatenate([[AI_crit_y], np.linspace(0.2, 7, n_obs)]))
+
+y = np.minimum(coef["y_a"] * np.power(aridity_index, coef["y_b"]), 1)
+
+psi = np.minimum(
+    coef["psi_a"] * np.power(aridity_index, coef["psi_b"]),
+    1,
+)
+
+# Create a 1x2 plot
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+
+ax1.plot(aridity_index, y, label="Maximum level ($y$)")
+ax1.plot(aridity_index, psi, label="Critical threshold ($\psi$)")
+ax1.plot(
+    [AI_crit_y, AI_crit_y],
+    [0, 1],
+    linestyle=":",
+    color="0.7",
+    label="Upper limit to attain 100% of predicted GPP",
+)
+ax1.set_xlabel(r"Aridity Index (AI)")
+ax1.set_ylabel(r"Function value ($y$ or $\psi$)")
+ax1.legend(frameon=False)
+
+
 # Calculate the soil moisture stress factor across a soil moisture
 # gradient for different aridity index values
 beta = {}
-ai_vals = [0.3, 1, 3, 6]
+ai_vals = [AI_crit_y.round(4), 1, 3, 6]
 
 for ai in ai_vals:
     beta[ai] = calc_soilmstress_mengoli(soilm=sm_gradient, aridity_index=np.array(ai))
     plt.plot(sm_gradient, beta[ai], label=f"AI = {ai}")
 
-plt.xlabel(r"Relative soil moisture $\theta$")
-plt.ylabel(r"$\beta(\theta)$")
-plt.legend()
-plt.show()
+ax2.set_xlabel(r"Relative soil moisture ($\theta$)")
+ax2.set_ylabel(r"$\beta(\theta)$")
+ax2.legend(frameon=False)
+
+plt.tight_layout()
 ```
 
-As the plot above shows, plants in arid conditions have severely constrained maximum
+```{code-cell}
+np.exp(-np.log(0.62) / -0.45)
+```
+
+As the plots above show, plants in arid conditions have severely constrained maximum
 levels, but have lower critical thresholds, allowing them to maintain the maximum level
 under drier conditions.
 
@@ -361,13 +402,11 @@ obviously just $\beta(\theta)$ from above scaled to the constant GPP.
   see {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` for details.
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 acclim_model = AcclimationModel(datetimes=datetimes)
 acclim_model.set_window(
     window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(1, "h")
 )
-
-acclim_model.get_window_values(env.tc)
 
 subdaily_model = SubdailyPModel(
     env=env,
@@ -383,12 +422,12 @@ for ai in ai_vals:
 
     plt.plot(sm_gradient, subdaily_model.gpp * beta[ai], label=f"AI = {ai}")
 
-plt.xlabel(r"Relative soil moisture $\theta$")
+plt.xlabel(r"Relative soil moisture ($\theta$)")
 plt.ylabel("GPP")
-plt.legend()
+plt.legend(frameon=False)
 plt.show()
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 
 ```

--- a/docs/source/users/pmodel/pmodel_details/soil_moisture.md
+++ b/docs/source/users/pmodel/pmodel_details/soil_moisture.md
@@ -56,7 +56,7 @@ The `pyrealm` package includes two separate approaches that affect optimal chi:
 ### Post-hoc penalties on gross primary productivity
 
 These approaches both use empirical
-functions of soil moisture and aridity  data that have been parameterised to align
+functions of soil moisture and aridity data that have been parameterised to align
 raw predictions from a P Model with field observations of GPP. Two penalty function
 are available that calculate the fraction of potential GPP that is realised given the
 effects of soil moisture stress:
@@ -64,7 +64,7 @@ effects of soil moisture stress:
 * The {func}`~pyrealm.pmodel.functions.calc_soilmstress_stocker` function implements the
   {cite:t}`Stocker:2020dh` GPP penalty for use with the standard P Model.
 * {func}`~pyrealm.pmodel.functions.calc_soilmstress_mengoli` function implements the
-  {cite:t}`mengoli:2023a` GPP penalty for use with the subdaily P Model..
+  {cite:t}`mengoli:2023a` GPP penalty for use with the subdaily P Model.
 
 The GPP penalty functions are described in more detail below, using the artificial data
 set created below. The data set consists of 5 days of observations of a constant
@@ -327,7 +327,7 @@ $$
 \textrm{AI} = e^{-log(a)/b}
 $$
 
-Given the default values, this critical level as around 0.3457: plants can only realise
+Given the default values, this critical level is around 0.3457: plants can only realise
 the predicted GPP from the P Model in locations where the aridity index is less than
 this value.
 

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -185,7 +185,7 @@ pmodel_const = pmodel_subdaily.env.pmodel_const
 core_const = pmodel_subdaily.env.core_const
 
 tk_acclim = temp_acclim + core_const.k_CtoK
-tk_ref = pmodel_const.plant_T_ref + core_const.k_CtoK
+tk_ref = pmodel_const.tc_ref + core_const.k_CtoK
 vcmax25_acclim = pmodel_acclim.vcmax / calculate_simple_arrhenius_factor(
     tk=tk_acclim, tk_ref=tk_ref, ha=pmodel_const.arrhenius_vcmax["simple"]["ha"]
 )

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -9,6 +9,16 @@ kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
   name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
 ---
 
 # Subdaily P Model calculations
@@ -19,7 +29,7 @@ steps used in the estimation process in order to show intermediates results but 
 practice, as shown in the [worked example](worked_example), most of these calculations
 are handled internally by the model fitting in `pyrealm`.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 from importlib import resources
@@ -47,7 +57,7 @@ The code below uses half hourly data from 2014 for the [BE-Vie FluxNET
 site](https://fluxnet.org/doi/FLUXNET2015/BE-Vie), which was also used as a
 demonstration in {cite:t}`mengoli:2022a`.
 
-```{code-cell}
+```{code-cell} ipython3
 data_path = resources.files("pyrealm_build_data.subdaily") / "subdaily_BE_Vie_2014.csv"
 
 data = pandas.read_csv(str(data_path))
@@ -68,7 +78,7 @@ This dataset can then be used to calculate the photosynthetic environment at the
 subdaily timescale. The code below also estimates GPP under the standard P Model with no
 slow responses for comparison.
 
-```{code-cell}
+```{code-cell} ipython3
 # Calculate the photosynthetic environment
 subdaily_env = PModelEnvironment(
     tc=temp_subdaily,
@@ -95,7 +105,7 @@ best to sample those conditions. Typically those might be the observed environme
 conditions at the observation closest to noon, or the mean environmental conditions in a
 window around noon.
 
-```{code-cell}
+```{code-cell} ipython3
 # Create the acclimation model
 acclim_model = AcclimationModel(datetime_subdaily, allow_holdover=True, alpha=1 / 15)
 
@@ -112,7 +122,7 @@ pmodel_subdaily = SubdailyPModel(
 )
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 idx = np.arange(48 * 120, 48 * 130)
@@ -136,7 +146,7 @@ The daily average conditions during the acclimation window can be sampled and us
 inputs to the standard P Model to calculate the optimal behaviour of plants under those
 conditions.
 
-```{code-cell}
+```{code-cell} ipython3
 # Get the daily acclimation conditions for the forcing variables
 temp_acclim = acclim_model.get_daily_means(temp_subdaily)
 co2_acclim = acclim_model.get_daily_means(co2_subdaily)
@@ -172,7 +182,7 @@ at 25°C. This is achieved calculating an Arrhenius scaling factor for the tempe
 the observation relative to the standard temperature, given the activation energy of the
 enzymes.
 
-```{code-cell}
+```{code-cell} ipython3
 pmodel_const = pmodel_subdaily.env.pmodel_const
 core_const = pmodel_subdaily.env.core_const
 
@@ -194,7 +204,7 @@ jmax25_acclim = pmodel_acclim.jmax / arrh_daily.calculate_arrhenius_factor(
 The memory effect can now be applied to the three parameters with slow
 responses to calculate realised values, here using the default 15 day window.
 
-```{code-cell}
+```{code-cell} ipython3
 # Calculation of memory effect in xi, vcmax25 and jmax25
 xi_real = acclim_model.apply_acclimation(pmodel_acclim.optchi.xi)
 vcmax25_real = acclim_model.apply_acclimation(vcmax25_acclim)
@@ -205,7 +215,7 @@ The plots below show the instantaneously acclimated values for  $J_{max25}$,
 $V_{cmax25}$ and $\xi$ in grey along with the realised slow reponses, after
 application of the memory effect.
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [hide-input]
 
 fig, axes = plt.subplots(1, 3, figsize=(12, 4))
@@ -242,7 +252,7 @@ temperature at fast scales:
 * These values are adjusted to the actual half hourly temperatures to give the fast
   responses of $J_{max}$ and $V_{cmax}$.
 
-```{code-cell}
+```{code-cell} ipython3
 # Fill the realised jmax and vcmax from subdaily to daily
 vcmax25_subdaily = acclim_model.fill_daily_to_subdaily(vcmax25_real)
 jmax25_subdaily = acclim_model.fill_daily_to_subdaily(jmax25_real)
@@ -267,7 +277,7 @@ passing the realised values of $\xi$ as a fixed constraint to the calculation of
 optimal $\chi$, rather than calculating the instantaneously optimal values of $\xi$
 as is the case in the standard P Model.
 
-```{code-cell}
+```{code-cell} ipython3
 # Interpolate xi to subdaily scale
 xi_subdaily = acclim_model.fill_daily_to_subdaily(xi_real)
 
@@ -286,7 +296,7 @@ Model, where $c_i$ includes the slow responses of $\xi$ and $V_{cmax}$ and $J_{m
 include the slow responses of $V_{cmax25}$ and $J_{max25}$ and fast responses to
 temperature.
 
-```{code-cell}
+```{code-cell} ipython3
 # Calculate Ac
 Ac_subdaily = (
     vcmax_subdaily
@@ -322,7 +332,7 @@ ax.set_aspect("equal")
 plt.tight_layout()
 ```
 
-```{code-cell}
+```{code-cell} ipython3
 :tags: [remove-cell]
 
 # This cell is here to force a docs build failure if these values

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -187,7 +187,8 @@ pmodel_const = pmodel_subdaily.env.pmodel_const
 core_const = pmodel_subdaily.env.core_const
 
 tk_acclim = temp_acclim + core_const.k_CtoK
-tk_ref = pmodel_const.tc_ref + core_const.k_CtoK
+tk_ref = pmodel_const.tk_ref
+
 vcmax25_acclim = pmodel_acclim.vcmax / calculate_simple_arrhenius_factor(
     tk=tk_acclim, tk_ref=tk_ref, ha=pmodel_const.arrhenius_vcmax["simple"]["ha"]
 )

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -44,15 +44,7 @@ class PModelConst(ConstantsClass):
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_prentice14`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_c4`)
 
-    * **Unit cost ratios (beta) response to soil moisture**. These constants set the
-      response of beta to soil moisture for the
-      :meth:`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C3`
-      method and for
-      :meth:`~pyrealm.pmodel.optimal_chi.OptimalChiLavergne20C4`.
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c3`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c3`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c4`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c4`)
+
 
     * **Electron transport capacity maintenance cost** Value taken from
       :cite:t:`Wang:2017go`
@@ -175,7 +167,6 @@ class PModelConst(ConstantsClass):
     * Upper bound in relative soil moisture (``b``).
     """
 
-    # Mengoli 2023 soil moisture stress
     soilmstress_mengoli: dict[str, float] = field(
         default_factory=lambda: dict(psi_a=0.34, psi_b=-0.6, y_a=0.62, y_b=-0.45)
     )
@@ -197,14 +188,14 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: np.array([146.0 / 9])
     )
     r"""Unit cost ratio for C4 plants (:math:`\beta`, 16.222)."""
-    lavergne_2020_b_c3: float = 1.73
-    """Slope of soil moisture effects on beta for C3 plants"""
-    lavergne_2020_a_c3: float = 4.55
-    """Intercept of soil moisture effects on beta for C3 plants"""
-    lavergne_2020_b_c4: float = 1.73
-    """Slope of soil moisture effects on beta for C4 plants"""
-    lavergne_2020_a_c4: float = 4.55 - np.log(9)
-    """Slope of soil moisture effects on beta for C4 plants"""
+
+    lavergne_2020_c3: tuple[float, float] = (4.55, 1.73)
+    """Intercept and slope coefficients for the effects of soil moisture on optimal chi
+    estimates for C3 plants, following :cite:`lavergne:2020a`."""
+
+    lavergne_2020_c4: tuple[float, float] = (4.55 - np.log(9), 1.73)
+    """Intercept and slope coefficients for the effects of soil moisture on optimal chi
+    estimates for C4 plants, following :cite:`lavergne:2020a`."""
 
     # Wang17
     wang17_c: float = 0.41

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -10,51 +10,10 @@ from pyrealm.constants import ConstantsClass
 
 @dataclass(frozen=True)
 class PModelConst(ConstantsClass):
-    r"""Constants for the P Model.
+    r"""Constants for the P Model module.
 
-    This dataclass provides the following underlying constants used in calculating the
-    predictions of the P Model.
-
-
-
-    * **Enzyme kinetics for VCMax**. Values taken from Table 3 of
-      :cite:t:`Kattge:2007db`.
-
-
-
-    * **Temperature responses of photosynthetic enzymes**. Values taken from Table 1 of
-      :cite:t:`Bernacchi:2001kg`. `kc_25` and `ko_25` are converted from µmol mol-1 and
-      mmol mol-1, assuming a measurement at an elevation of 227.076 metres and standard
-      atmospheric pressure for that elevation (98716.403 Pa).
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_dhac`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_dhao`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_dha`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_kc25`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_ko25`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs25_0`)
-
-
-
-    * **Unit cost ratios (beta)**. The value for C3 plants is taken from
-      :cite:t:`Stocker:2020dh`. For C4 plants, we follow the estimates of the
-      :math:`g_1` parameter for C3 and C4 plants in :cite:t:`Lin:2015wh`  and
-      :cite:t:`DeKauwe:2015im`, which have a C3/C4 ratio of around 3. Given that
-      :math:`g_1 \equiv \xi \propto \surd\beta`, a reasonable default for C4 plants is
-      that :math:`\beta_{C4} \approx \beta_{C3} / 9 \approx 146 /  9 \approx 16.222`.
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_prentice14`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_c4`)
-
-
-
-    * **Electron transport capacity maintenance cost** Value taken from
-      :cite:t:`Wang:2017go`
-
-    * **Calculation of omega**. Values for estimating the scaling factor in J max
-      limitation method of :cite:t:`Smith:2019dv`.
-
-    * **Dark respiration**. Value taken from :cite:t:`Atkin:2015hk` for C3 herbaceous
-      plants
-
+    This dataclass provides constants used in calculating the predictions of the P Model
+    and associated methods.
     """
 
     sandoval_peak_phio: tuple[float, float] = (6.8681, 0.07956432)
@@ -73,11 +32,18 @@ class PModelConst(ConstantsClass):
     of the mean growth temperature (J/mol/K), the deactivation energy constant (J/mol)
     and the activation energy (J/mol). """
 
-    plant_T_ref: float = 25.0
-    """Standard baseline reference temperature of photosynthetic processes (Prentice,
-    unpublished)  (:math:`T_o` , 25.0, °C)"""
+    tc_ref: float = 25.0
+    """Standard baseline reference temperature of photosynthetic processes in °C 
+    (:math:`T_o` , 25.0, °C)"""
 
-    # Heskel
+    # NOTE that tk_ref might be a considered a duplication of CoreConst.k_To but that
+    # refers explicitly to the physical standard temperature and this is a reference
+    # temperature for photosynthesis. It is _vanishingly_ unlikely that this will
+    # change but they could _in theory_ be different.
+    tk_ref: float = 298.15
+    """Standard baseline reference temperature of photosynthetic processes in Kelvin 
+    (298.15, K)"""
+
     heskel_rd: tuple[float, float] = (0.1012, 0.0005)
     """Linear (:math:`b`, 0.1012) and quadratic  (:math:`c`, 0.0005) coefficients of the
     temperature scaling of dark respiration. Values taken from
@@ -101,6 +67,7 @@ class PModelConst(ConstantsClass):
     providing the intercept and slope of activation entropy as a function of the mean
     growth temperature (J/mol/K), the deactivation energy constant (:math:`H_d`, J/mol) 
     and the activation energy (J/mol). (:math:`H_a`, J/mol)."""
+
     arrhenius_jmax: dict = field(
         default_factory=lambda: dict(
             simple=dict(ha=43900),
@@ -132,18 +99,53 @@ class PModelConst(ConstantsClass):
     :cite:t:`Bernacchi:2003dc`"""
 
     # Bernachhi
-    bernacchi_dhac: float = 79430
-    """Bernacchi estimate of activation energy Kc for CO2 (J/mol)"""
-    bernacchi_dhao: float = 36380
-    """Bernacchi estimate of activation energy Ko for O2 (J/mol)"""
-    bernacchi_dha: float = 37830
-    """Bernacchi estimate of activation energy for gammastar (J/mol)"""
-    bernacchi_kc25: float = 39.97  # Reported as 404.9 µmol mol-1
-    """Bernacchi estimate of kc25"""
-    bernacchi_ko25: float = 27480  # Reported as 278.4 mmol mol-1
-    """Bernacchi estimate of ko25"""
-    bernacchi_gs25_0: float = 4.332  # Reported as 42.75 µmol mol-1
-    """Bernacchi estimate of gs25_0"""
+    bernacchi_kmm: dict[str, float] = field(
+        default_factory=lambda: dict(
+            dhac=79430.0,
+            dhao=36380.0,
+            kc25=39.97,  # Reported as 404.9 µmol mol-1
+            ko25=27480.0,  # Reported as 278.4 mmol mol-1
+        )
+    )
+    """Coefficients for the estimation of the Michaelis Menten coefficient of
+    Rubisco-limited assimilation. Values are taken from Table 1 of
+    :cite:t:`Bernacchi:2001kg` and provide a dictionary of:
+    
+    * The activation energy for :math:`\ce{CO2}` (:math:`\Delta H_{kc}`, ``dhac``,
+      J/mol) 
+    * The activation energy for :math:`\ce{O2}` (:math:`\Delta H_{ko}`, `dhao``, J/mol))
+    * The Michelis constant for :math:`\ce{CO2}` at standard temperature
+      (:math:`K_{c25}`, ``kc25``, Pa) 
+    * The Michelis constant for :math:`\ce{O2}` at standard temperature
+      (:math:`K_{o25}`, ``ko25``, Pa)
+
+    The values for  `kc_25` and `ko_25` are converted from the original tabulated values
+    of 404.9 µmol mol-1 and 278.4 mmol mol-1 respectively to Pa, assuming a measurement
+    at an elevation of 227.076 metres and standard  atmospheric pressure for that
+    elevation (98716.403 Pa).
+    """
+
+    bernacchi_gs: dict[str, float] = field(
+        default_factory=lambda: dict(
+            dha=37830.0,
+            gs25_0=4.332,
+        )
+    )
+    """Coefficients for the estimation of the photorespiratory CO2 compensation point.
+    Values are taken from Table 1 of :cite:t:`Bernacchi:2001kg` and provide a dictionary
+    of: 
+    
+    * The reference value of :math:`\Gamma^{*}` at standard temperature and pressure
+      (:math:`\Gamma^{*}_{0}`, ``gs25_0``, Pa), converted from the tabulated value of
+      42.75 µmol mol-1, , assuming a measurement at an elevation of 227.076 metres and
+      standard  atmospheric pressure for that elevation (98716.403 Pa).
+    * The activation energy (:math:`\Delta H_a`, ``dha``, J/mol)
+
+    The values for  `kc_25` and `ko_25` are converted from the original tabulated values
+    of 404.9 µmol mol-1 and 278.4 mmol mol-1 respectively to Pa, assuming a measurement
+    at an elevation of 227.076 metres and standard  atmospheric pressure for that
+    elevation (98716.403 Pa).
+    """
 
     # Boyd
     boyd_kp25_c4: float = 16  # Pa  from Boyd et al. (2015)
@@ -161,10 +163,10 @@ class PModelConst(ConstantsClass):
     """Parameterisation of the soil moisture stress function of
     :cite:t:`Stocker:2020dh` as a dictionary providing values for the:
     
-    * Intercept of the aridity sensitivity function (``theta0``),
-    * Slope of the aridity sensitivity function (``thetastar``),
-    * Lower bound in relative soil moisture  (``a``), and
-    * Upper bound in relative soil moisture (``b``).
+    * intercept of the aridity sensitivity function (``theta0``),
+    * slope of the aridity sensitivity function (``thetastar``),
+    * lower bound in relative soil moisture  (``a``), and
+    * upper bound in relative soil moisture (``b``).
     """
 
     soilmstress_mengoli: dict[str, float] = field(
@@ -184,10 +186,20 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: np.array([146.0])
     )
     r"""Unit cost ratio for C3 plants (:math:`\beta`, 146.0)."""
+
     beta_cost_ratio_c4: NDArray[np.float64] = field(
         default_factory=lambda: np.array([146.0 / 9])
     )
     r"""Unit cost ratio for C4 plants (:math:`\beta`, 16.222)."""
+
+    # * **Unit cost ratios (beta)**. The value for C3 plants is taken from
+    #   :cite:t:`Stocker:2020dh`. For C4 plants, we follow the estimates of the
+    #   :math:`g_1` parameter for C3 and C4 plants in :cite:t:`Lin:2015wh`  and
+    #   :cite:t:`DeKauwe:2015im`, which have a C3/C4 ratio of around 3. Given that
+    #   :math:`g_1 \equiv \xi \propto \surd\beta`, a reasonable default for C4 plants is
+    #   that :math:`\beta_{C4} \approx \beta_{C3} / 9 \approx 146 /  9 \approx 16.222`.
+    #   (:attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_prentice14`,
+    #   :attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_c4`)
 
     lavergne_2020_c3: tuple[float, float] = (4.55, 1.73)
     """Intercept and slope coefficients for the effects of soil moisture on optimal chi
@@ -197,10 +209,9 @@ class PModelConst(ConstantsClass):
     """Intercept and slope coefficients for the effects of soil moisture on optimal chi
     estimates for C4 plants, following :cite:`lavergne:2020a`."""
 
-    # Wang17
     wang17_c: float = 0.41
-    """Unit carbon cost for the maintenance of electron transport capacity (:math:`c`,
-    0.41, )"""
+    """Unit carbon cost for the maintenance of electron transport capacity, value taken
+    from  :cite:t:`Wang:2017go` (:math:`c`, 0.41, )."""
 
     # Smith19
     smith19_theta: float = 0.85
@@ -208,6 +219,10 @@ class PModelConst(ConstantsClass):
     smith19_c_cost: float = 0.05336251
     r"""Scaling factor c for Jmax limitation (:math:`c`, 0.05336251)"""
 
+    # * **Calculation of omega**. Values for estimating the scaling factor in J max
+    #   limitation method of :cite:t:`Smith:2019dv`.
+
     # Atkin
     atkin_rd_to_vcmax: float = 0.015
-    """Ratio of Rdark to Vcmax25 (0.015)"""
+    """Ratio of Dark respiration to Vcmax25. Value taken from :cite:t:`Atkin:2015hk` for
+    C3 herbaceous plants."""

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -64,12 +64,12 @@ class PModelConst(ConstantsClass):
             ),
         )
     )
-    """Coefficients of Arrhenius factor scaling for :math:`V_{cmax}`. The `simple`
+    """Coefficients of Arrhenius factor scaling for :math:`V_{cmax}`. The ``simple``
     method provides an estimate of the activation energy (:math:`H_a`, J/mol). The
-    `kattge_knorr` method provides the parameterisation from :cite:t:`Kattge:2007db`, 
+    ``kattge_knorr`` method provides the parameterisation from :cite:t:`Kattge:2007db`, 
     providing the intercept and slope of activation entropy as a function of the mean
     growth temperature (J/mol/K), the deactivation energy constant (:math:`H_d`, J/mol) 
-    and the activation energy (J/mol). (:math:`H_a`, J/mol)."""
+    and the activation energy (:math:`H_a`, J/mol)."""
 
     arrhenius_jmax: dict = field(
         default_factory=lambda: dict(
@@ -82,12 +82,12 @@ class PModelConst(ConstantsClass):
             ),
         )
     )
-    """Coefficients of Arrhenius factor scaling for :math:`J_{max}`. The `simple`
+    """Coefficients of Arrhenius factor scaling for :math:`J_{max}`. The ``simple``
     method provides an estimate of the activation energy (:math:`H_a`, J/mol). The
-    `kattge_knorr` method provides the parameterisation from :cite:t:`Kattge:2007db`, 
+    ``kattge_knorr`` method provides the parameterisation from :cite:t:`Kattge:2007db`, 
     providing the intercept and slope of activation entropy as a function of the mean
     growth temperature (J/mol/K), the deactivation energy constant (:math:`H_d`, J/mol) 
-    and the activation energy (J/mol). (:math:`H_a`, J/mol)."""
+    and the activation energy (:math:`H_a`, J/mol)."""
 
     kphio_C4: tuple[float, float, float] = (-0.064, 0.03, -0.000464)
     """Coefficients of the quadratic scaling of the quantum yield of photosynthesis

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -204,7 +204,7 @@ class PModelConst(ConstantsClass):
     # Smith19
     smith19_coef: tuple[float, float] = (0.85, 0.05336251)
     r"""Scaling factors ``theta`` (:math:`\theta`, 0.85) and ``c`` (:math:`c`,
-     0.05336251) used in the calculation of J_max limitation using the method of 
+    0.05336251) used in the calculation of J_max limitation using the method of 
     :cite:t:`Smith:2019dv`."""
 
     # Atkin

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -104,8 +104,8 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: dict(
             dhac=79430.0,
             dhao=36380.0,
-            kc25=39.97,  # Reported as 404.9 µmol mol-1
-            ko25=27480.0,  # Reported as 278.4 mmol mol-1
+            kc25=39.97,
+            ko25=27480.0,
         )
     )
     """Coefficients for the estimation of the Michaelis Menten coefficient of
@@ -152,7 +152,7 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: dict(theta0=0, thetastar=0.6, a=0.0, b=0.733)
     )
     """Parameterisation of the soil moisture stress function of
-    :cite:t:`Stocker:2020dh` as a dictionary providing values for the:
+    :cite:t:`Stocker:2020dh` as a dictionary providing values for the: 
     
     * intercept of the aridity sensitivity function (``theta0``),
     * slope of the aridity sensitivity function (``thetastar``),
@@ -172,25 +172,22 @@ class PModelConst(ConstantsClass):
     * exponent of the threshold function (``psi_b``).
     """
 
-    # Unit cost ratio (beta) values for different CalcOptimalChi methods
-    beta_cost_ratio_prentice14: NDArray[np.float64] = field(
+    beta_cost_ratio_c3: NDArray[np.float64] = field(
         default_factory=lambda: np.array([146.0])
     )
-    r"""Unit cost ratio for C3 plants (:math:`\beta`, 146.0)."""
+    r"""Unit cost ratio for C3 plants (:math:`\beta`, 146.0) taken from
+     :cite:t:`Stocker:2020dh`."""
 
     beta_cost_ratio_c4: NDArray[np.float64] = field(
         default_factory=lambda: np.array([146.0 / 9])
     )
-    r"""Unit cost ratio for C4 plants (:math:`\beta`, 16.222)."""
-
-    # * **Unit cost ratios (beta)**. The value for C3 plants is taken from
-    #   :cite:t:`Stocker:2020dh`. For C4 plants, we follow the estimates of the
-    #   :math:`g_1` parameter for C3 and C4 plants in :cite:t:`Lin:2015wh`  and
-    #   :cite:t:`DeKauwe:2015im`, which have a C3/C4 ratio of around 3. Given that
-    #   :math:`g_1 \equiv \xi \propto \surd\beta`, a reasonable default for C4 plants is
-    #   that :math:`\beta_{C4} \approx \beta_{C3} / 9 \approx 146 /  9 \approx 16.222`.
-    #   (:attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_prentice14`,
-    #   :attr:`~pyrealm.constants.pmodel_const.PModelConst.beta_cost_ratio_c4`)
+    r"""Unit cost ratio for C4 plants (:math:`\beta`, 16.222).
+    
+    For C4 plants, we follow the estimates of the   :math:`g_1` parameter for C3 and C4
+    plants in :cite:t:`Lin:2015wh`  and :cite:t:`DeKauwe:2015im`, which have a C3/C4
+    ratio of around 3. Given that :math:`g_1 \equiv \xi \propto \surd\beta`, a
+    reasonable default for C4 plants is that :math:`\beta_{C4} \approx \beta_{C3} / 9
+    \approx 146 /  9 \approx 16.222`."""
 
     lavergne_2020_c3: tuple[float, float] = (4.55, 1.73)
     """Intercept and slope coefficients for the effects of soil moisture on optimal chi

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -20,11 +20,13 @@ class PModelConst(ConstantsClass):
     """Curvature parameters for calculation of peak phio in the Sandoval method for
     estimation of quantum yield efficiency."""
 
-    sandoval_kinetics: tuple[float, float, float, float] = (
-        1558.853,
-        -50.223,
-        294.804,
-        75000.0,
+    sandoval_kinetics: dict[str, float] = field(
+        default_factory=lambda: dict(
+            entropy_intercept=1558.853,
+            entropy_slope=-50.223,
+            hd=75000.0,
+            ha=294.804,
+        )
     )
     """Enzyme kinetics parameters for estimation of kphio from mean growth temperature
     in the Sandoval method :cite:t:`sandoval:in_prep` for estimation of quantum yield

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -33,11 +33,6 @@ class PModelConst(ConstantsClass):
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_ko25`,
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs25_0`)
 
-    * **Soil moisture stress**. Parameterisation from :cite:t:`Stocker:2020dh`
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_theta0`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_thetastar`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_a`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_b`)
 
     * **Soil moisture stress**. Parameterisation from :cite:t:`mengoli:2023a`
       (:attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_y_a`,
@@ -173,15 +168,12 @@ class PModelConst(ConstantsClass):
     # boyd_ko25_c4: float = 28210
     # boyd_gs25_0_c4: float = 2.6
 
-    # Stocker 2020 soil moisture stress
-    soilmstress_theta0: float = 0.0
-    """Lower bound in relative soil moisture"""
-    soilmstress_thetastar: float = 0.6
-    """Upper bound in relative soil moisture"""
-    soilmstress_a: float = 0.0
-    """Intercept of aridity sensitivity function for soil moisture"""
-    soilmstress_b: float = 0.733
-    """Slope of aridity sensitivity function for soil moisture"""
+    soilmstress_stocker: dict[str, float] = field(
+        default_factory=lambda: dict(theta0=0, thetastar=0.6, a=0.0, b=0.733)
+    )
+    """Parameterisation of the soil moisture stress function of
+    :cite:t:`Stocker:2020dh`. A dictionary providing values for ``theta0``,
+    ``thetastar``, ``a`` and ``b``."""
 
     # Mengoli 2023 soil moisture stress
     soilm_mengoli_y_a: float = 0.62

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -36,13 +36,14 @@ class PModelConst(ConstantsClass):
     """Standard baseline reference temperature of photosynthetic processes in °C 
     (:math:`T_o` , 25.0, °C)"""
 
+    tk_ref: float = 298.15
+    """Standard baseline reference temperature of photosynthetic processes in Kelvin 
+    (298.15, K)"""
+
     # NOTE that tk_ref might be a considered a duplication of CoreConst.k_To but that
     # refers explicitly to the physical standard temperature and this is a reference
     # temperature for photosynthesis. It is _vanishingly_ unlikely that this will
     # change but they could _in theory_ be different.
-    tk_ref: float = 298.15
-    """Standard baseline reference temperature of photosynthetic processes in Kelvin 
-    (298.15, K)"""
 
     heskel_rd: tuple[float, float] = (0.1012, 0.0005)
     """Linear (:math:`b`, 0.1012) and quadratic  (:math:`c`, 0.0005) coefficients of the
@@ -146,16 +147,6 @@ class PModelConst(ConstantsClass):
     at an elevation of 227.076 metres and standard  atmospheric pressure for that
     elevation (98716.403 Pa).
     """
-
-    # Boyd
-    boyd_kp25_c4: float = 16  # Pa  from Boyd et al. (2015)
-    boyd_dhac_c4: float = 36300  # J mol-1
-    # boyd_dhac_c4: float = 79430
-    # boyd_dhao_c4: float = 36380
-    # boyd_dha_c4: float = 37830
-    # boyd_kc25_c4: float = 41.03
-    # boyd_ko25_c4: float = 28210
-    # boyd_gs25_0_c4: float = 2.6
 
     soilmstress_stocker: dict[str, float] = field(
         default_factory=lambda: dict(theta0=0, thetastar=0.6, a=0.0, b=0.733)

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -34,11 +34,6 @@ class PModelConst(ConstantsClass):
       :attr:`~pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs25_0`)
 
 
-    * **Soil moisture stress**. Parameterisation from :cite:t:`mengoli:2023a`
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_y_a`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_y_b`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_psi_a`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_psi_b`)
 
     * **Unit cost ratios (beta)**. The value for C3 plants is taken from
       :cite:t:`Stocker:2020dh`. For C4 plants, we follow the estimates of the
@@ -172,18 +167,26 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: dict(theta0=0, thetastar=0.6, a=0.0, b=0.733)
     )
     """Parameterisation of the soil moisture stress function of
-    :cite:t:`Stocker:2020dh`. A dictionary providing values for ``theta0``,
-    ``thetastar``, ``a`` and ``b``."""
+    :cite:t:`Stocker:2020dh` as a dictionary providing values for the:
+    
+    * Intercept of the aridity sensitivity function (``theta0``),
+    * Slope of the aridity sensitivity function (``thetastar``),
+    * Lower bound in relative soil moisture  (``a``), and
+    * Upper bound in relative soil moisture (``b``).
+    """
 
     # Mengoli 2023 soil moisture stress
-    soilm_mengoli_y_a: float = 0.62
-    """Coefficient of the maximal level function for Mengoli soil moisture"""
-    soilm_mengoli_y_b: float = -0.45
-    """Exponent of the maximal level function for Mengoli soil moisture"""
-    soilm_mengoli_psi_a: float = 0.34
-    """Coefficient of the threshold function for Mengoli soil moisture"""
-    soilm_mengoli_psi_b: float = -0.60
-    """Exponent of the threshold function for Mengoli soil moisture"""
+    soilmstress_mengoli: dict[str, float] = field(
+        default_factory=lambda: dict(psi_a=0.34, psi_b=-0.6, y_a=0.62, y_b=-0.45)
+    )
+    """Parameterisation of the soil moisture stress function of
+    :cite:t:`mengoli:2023a` as a dictionary providing values for the:
+
+    * coefficient of the maximal level function  (``y_a``),
+    * exponent of the maximal level function  (``y_b``),
+    * coefficient of the threshold function  (``psi_a``), and
+    * exponent of the threshold function (``psi_b``).
+    """
 
     # Unit cost ratio (beta) values for different CalcOptimalChi methods
     beta_cost_ratio_prentice14: NDArray[np.float64] = field(

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -96,7 +96,7 @@ class PModelConst(ConstantsClass):
     unpublished)  (:math:`T_o` , 25.0, °C)"""
 
     # Heskel
-    heskel_rd: tuple[float, float] = (0.1012, 0.005)
+    heskel_rd: tuple[float, float] = (0.1012, 0.0005)
     """Linear (:math:`b`, 0.1012) and quadratic  (:math:`c`, 0.0005) coefficients of the
     temperature scaling of dark respiration. Values taken from
     :cite:t:`Heskel:2016fg`:."""

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -205,13 +205,10 @@ class PModelConst(ConstantsClass):
     from  :cite:t:`Wang:2017go` (:math:`c`, 0.41, )."""
 
     # Smith19
-    smith19_theta: float = 0.85
-    r"""Scaling factor theta for Jmax limitation (:math:`\theta`, 0.85)"""
-    smith19_c_cost: float = 0.05336251
-    r"""Scaling factor c for Jmax limitation (:math:`c`, 0.05336251)"""
-
-    # * **Calculation of omega**. Values for estimating the scaling factor in J max
-    #   limitation method of :cite:t:`Smith:2019dv`.
+    smith19_coef: tuple[float, float] = (0.85, 0.05336251)
+    r"""Scaling factors ``theta`` (:math:`\theta`, 0.85) and ``c`` (:math:`c`,
+     0.05336251) used in the calculation of J_max limitation using the method of 
+    :cite:t:`Smith:2019dv`."""
 
     # Atkin
     atkin_rd_to_vcmax: float = 0.015

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -13,24 +13,14 @@ class PModelConst(ConstantsClass):
     r"""Constants for the P Model.
 
     This dataclass provides the following underlying constants used in calculating the
-    predictions of the P Model. Values are shown with mathematical notation, default
-    value and units shown in brackets and the sources for default parameterisations are
-    given below:
+    predictions of the P Model.
 
-    * **Temperature scaling of dark respiration**. Values taken from
-      :cite:t:`Heskel:2016fg`:
-      (:attr:`~pyrealm.constants.pmodel_const.PModelConst.heskel_b`,
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.heskel_c`)
+
 
     * **Enzyme kinetics for VCMax**. Values taken from Table 3 of
       :cite:t:`Kattge:2007db`.
 
-    * **Scaling of Kphio with temperature**. The parameters of quadratic functions for
-      the temperature dependence of Kphio are:
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.kphio_C4`, C4 plants, Eqn 5 of
-      :cite:t:`cai:2020a`; and
-      :attr:`~pyrealm.constants.pmodel_const.PModelConst.kphio_C3`, C3 plants, Table 2
-      of :cite:t:`Bernacchi:2003dc`.
+
 
     * **Temperature responses of photosynthetic enzymes**. Values taken from Table 1 of
       :cite:t:`Bernacchi:2001kg`. `kc_25` and `ko_25` are converted from µmol mol-1 and
@@ -106,10 +96,10 @@ class PModelConst(ConstantsClass):
     unpublished)  (:math:`T_o` , 25.0, °C)"""
 
     # Heskel
-    heskel_b: float = 0.1012
-    """Linear coefficient of scaling of dark respiration (:math:`b`, 0.1012)"""
-    heskel_c: float = 0.0005
-    """Quadratic coefficient of scaling of dark respiration (:math:`c`, 0.0005)"""
+    heskel_rd: tuple[float, float] = (0.1012, 0.005)
+    """Linear (:math:`b`, 0.1012) and quadratic  (:math:`c`, 0.0005) coefficients of the
+    temperature scaling of dark respiration. Values taken from
+    :cite:t:`Heskel:2016fg`:."""
 
     # Arrhenius values
     arrhenius_vcmax: dict = field(
@@ -147,18 +137,17 @@ class PModelConst(ConstantsClass):
     growth temperature (J/mol/K), the deactivation energy constant (:math:`H_d`, J/mol) 
     and the activation energy (J/mol). (:math:`H_a`, J/mol)."""
 
-    # Kphio:
-    # - note that kphio_C4 has been updated to account for an unintended double
-    #   8 fold downscaling to account for the fraction of light reaching PS2.
-    #   from original values of [-0.008, 0.00375, -0.58e-4]
-    kphio_C4: NDArray[np.float64] = field(
-        default_factory=lambda: np.array((-0.064, 0.03, -0.000464))
-    )
-    """Quadratic scaling of Kphio with temperature for C4 plants"""
-    kphio_C3: NDArray[np.float64] = field(
-        default_factory=lambda: np.array((0.352, 0.022, -0.00034))
-    )
-    """Quadratic scaling of Kphio with temperature for C3 plants"""
+    kphio_C4: tuple[float, float, float] = (-0.064, 0.03, -0.000464)
+    """Coefficients of the quadratic scaling of the quantum yield of photosynthesis
+    (``phi_0``, :math:`\phi_0`) with temperature for C4 plants, taken from Eqn 5 of
+    :cite:t:`cai:2020a`, and adjusted from the original values (-0.008, 0.00375,
+    -0.58e-4) to account for an unintentional double scaling to account for the fraction
+    of light reaching PS2."""
+
+    kphio_C3: tuple[float, float, float] = (0.352, 0.022, -0.00034)
+    """Coefficients of the quadratic scaling of the quantum yield of photosynthesis
+    (``phi_0``, :math:`\phi_0`) with temperature for C3 plants, taken from Table 2 of
+    :cite:t:`Bernacchi:2003dc`"""
 
     # Bernachhi
     bernacchi_dhac: float = 79430

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -24,8 +24,8 @@ class PModelConst(ConstantsClass):
         default_factory=lambda: dict(
             entropy_intercept=1558.853,
             entropy_slope=-50.223,
-            hd=75000.0,
-            ha=294.804,
+            ha=75000.0,
+            hd=294.804,
         )
     )
     """Enzyme kinetics parameters for estimation of kphio from mean growth temperature

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -7,6 +7,8 @@ used to:
   calculation.
 """  # noqa: D205, D415
 
+from collections.abc import Sequence
+
 import numpy as np
 import tabulate
 from numpy.typing import NDArray
@@ -130,7 +132,7 @@ def summarize_attrs(
 
 
 def evaluate_horner_polynomial(
-    x: NDArray[np.float64], cf: list | NDArray
+    x: NDArray[np.float64], cf: Sequence | NDArray
 ) -> NDArray[np.float64]:
     r"""Evaluates a polynomial with coefficients `cf` at `x` using Horner's method.
 

--- a/pyrealm/pmodel/arrhenius.py
+++ b/pyrealm/pmodel/arrhenius.py
@@ -175,7 +175,7 @@ class SimpleArrhenius(
             tk=self.tk,
             tk_ref=self.tk_ref,
             ha=coefficients["ha"],
-            core_const=self.core_const,
+            k_R=self.core_const.k_R,
         )
 
 
@@ -196,9 +196,6 @@ class KattgeKnorrArrhenius(
             tk_leaf=self.tk,
             tk_ref=self.tk_ref,
             tc_growth=getattr(self.env, "mean_growth_temperature"),
-            ha=coefficients["ha"],
-            hd=coefficients["hd"],
-            entropy_intercept=coefficients["entropy_intercept"],
-            entropy_slope=coefficients["entropy_slope"],
-            core_const=self.core_const,
+            coef=coefficients,
+            k_R=self.core_const.k_R,
         )

--- a/pyrealm/pmodel/arrhenius.py
+++ b/pyrealm/pmodel/arrhenius.py
@@ -79,9 +79,6 @@ class ArrheniusFactorABC(ABC):
         """The PModelEnvironment containing the photosynthetic environment for the
         model."""
 
-        self.tk_ref = self.env.pmodel_const.tc_ref + self.env.core_const.k_CtoK
-        """The reference temperature in Kelvins, calculated internally."""
-
         # Run the calculation methods after checking for any required variables
         self._check_required_env_variables()
 
@@ -182,7 +179,7 @@ class SimpleArrhenius(
     def _calculation_method(self, coefficients: dict) -> NDArray:
         return calculate_simple_arrhenius_factor(
             tk=self.env.tk,
-            tk_ref=self.tk_ref,
+            tk_ref=self.env.pmodel_const.tk_ref,
             ha=coefficients["ha"],
             k_R=self.env.core_const.k_R,
         )
@@ -233,7 +230,7 @@ class KattgeKnorrArrhenius(
     def _calculation_method(self, coefficients: dict) -> NDArray:
         return calculate_kattge_knorr_arrhenius_factor(
             tk_leaf=self.env.tk,
-            tk_ref=self.tk_ref,
+            tk_ref=self.env.pmodel_const.tk_ref,
             tc_growth=getattr(self.env, "mean_growth_temperature"),
             coef=coefficients,
             k_R=self.env.core_const.k_R,

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -362,53 +362,6 @@ def calc_kmm(
     return kc * (1.0 + po / ko)
 
 
-def calc_kp_c4(
-    tk: NDArray[np.float64],
-    patm: NDArray[np.float64],
-    pmodel_const: PModelConst = PModelConst(),
-    core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
-    r"""Calculate the Michaelis Menten coefficient of PEPc.
-
-    Calculates the Michaelis Menten coefficient of phosphoenolpyruvate carboxylase
-    (PEPc) (:math:`K`, :cite:alp:`boyd:2015a`) as a function of temperature (:math:`T`)
-    and atmospheric pressure (:math:`p`), following Arrhenius scaling (see
-    :meth:`~pyrealm.pmodel.functions.calculate_simple_arrhenius_factor`) as:
-
-    Args:
-        tk: Temperature, relevant for photosynthesis (:math:`T`, K)
-        patm: Atmospheric pressure (:math:`p`, Pa)
-        pmodel_const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-        core_const: Instance of :class:`~pyrealm.constants.core_const.CoreConst`.
-
-    PModel Parameters:
-        hac: activation energy for :math:`\ce{CO2}` (:math:`H_{kc}`,
-             ``boyd_dhac_c4``)
-        kc25: Michelis constant for :math:`\ce{CO2}` at standard temperature
-            (:math:`K_{c25}`, ``boyd_kp25_c4``)
-
-    Returns:
-        A numeric value for :math:`K` (in Pa)
-
-    Examples:
-        >>> # Michaelis-Menten coefficient at 20°C (293.15K) and standard pressure (Pa)
-        >>> import numpy as np
-        >>> calc_kp_c4(np.array([293.15]), np.array([101325])).round(5)
-        array([12.46385])
-    """
-
-    # Check inputs, return shape not used
-    _ = check_input_shapes(tk, patm)
-
-    # Calculate rate relative to standard rate using an Arrhenius factor, converting
-    # temperatures to Kelvin
-    return pmodel_const.boyd_kp25_c4 * calculate_simple_arrhenius_factor(
-        tk=tk,
-        tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
-        ha=pmodel_const.boyd_dhac_c4,
-    )
-
-
 def calc_soilmstress_stocker(
     soilm: NDArray[np.float64],
     meanalpha: NDArray[np.float64] = np.array(1.0),

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -164,7 +164,8 @@ def calculate_kattge_knorr_arrhenius_factor(
 
 def calc_ftemp_inst_rd(
     tc: NDArray[np.float64],
-    pmodel_const: PModelConst = PModelConst(),
+    t_ref: float,
+    coef: tuple[float, float],
 ) -> NDArray[np.float64]:
     r"""Calculate temperature scaling of dark respiration.
 
@@ -177,31 +178,19 @@ def calc_ftemp_inst_rd(
             fr = \exp( b (T_o - T) -  c ( T_o^2 - T^2 ))
 
     Args:
-        tc: Temperature (°C)
-        pmodel_const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-
-    PModel Parameters:
-        To: standard reference temperature for photosynthetic processes (:math:`T_o`,
-            ``k_To``)
-        b: empirically derived global mean coefficient
-            (:math:`b`, ``heskel_b``)
-        c: empirically derived global mean coefficient
-            (:math:`c`, ``heskel_c``)
-
-    Returns:
-        Values for :math:`fr`
+        tc: Temperature (:math:`T`, °C)
+        t_ref: standard reference temperature for photosynthetic processes (:math:`T_o`,
+            °C)
+        coef: A two tuple of floats providing the linear and quadratic coefficients
+            (:math:`b` and :math:`c`)
 
     Examples:
-        >>> # Relative percentage instantaneous change in Rd going from 10 to 25 degrees
-        >>> val = (calc_ftemp_inst_rd(25) / calc_ftemp_inst_rd(10) - 1) * 100
-        >>> np.round(val, 4)
-        np.float64(250.9593)
+        >>> # Relative instantaneous change in Rd going from 10 to 25 degrees
+        >>> ((calc_ftemp_inst_rd(25) / calc_ftemp_inst_rd(10) - 1)).round(4)
+        np.float64(2.5096)
     """
 
-    return np.exp(
-        pmodel_const.heskel_b * (tc - pmodel_const.plant_T_ref)
-        - pmodel_const.heskel_c * (tc**2 - pmodel_const.plant_T_ref**2)
-    )
+    return np.exp(coef[0] * (t_ref - tc) - coef[1] * (t_ref**2 - tc**2))
 
 
 def calc_gammastar(

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -164,7 +164,7 @@ def calculate_kattge_knorr_arrhenius_factor(
 
 def calc_ftemp_inst_rd(
     tc: NDArray[np.float64],
-    t_ref: float,
+    tc_ref: float,
     coef: tuple[float, float],
 ) -> NDArray[np.float64]:
     r"""Calculate temperature scaling of dark respiration.
@@ -179,18 +179,27 @@ def calc_ftemp_inst_rd(
 
     Args:
         tc: Temperature (:math:`T`, °C)
-        t_ref: standard reference temperature for photosynthetic processes (:math:`T_o`,
-            °C)
+        tc_ref: standard reference temperature for photosynthetic processes
+            (:math:`T_o`,°C)
         coef: A two tuple of floats providing the linear and quadratic coefficients
             (:math:`b` and :math:`c`)
 
     Examples:
         >>> # Relative instantaneous change in Rd going from 10 to 25 degrees
-        >>> ((calc_ftemp_inst_rd(25) / calc_ftemp_inst_rd(10) - 1)).round(4)
+        >>> pmod_consts = PModelConst()
+        >>> (
+        ...     calc_ftemp_inst_rd(
+        ...         tc=25, tc_ref=pmod_consts.plant_T_ref, coef=pmod_consts.heskel_rd
+        ...     )
+        ...     / calc_ftemp_inst_rd(
+        ...         tc=10, tc_ref=pmod_consts.plant_T_ref, coef=pmod_consts.heskel_rd
+        ...     )
+        ...     - 1
+        ... ).round(4)
         np.float64(2.5096)
     """
 
-    return np.exp(coef[0] * (t_ref - tc) - coef[1] * (t_ref**2 - tc**2))
+    return np.exp(coef[0] * (tc - tc_ref) - coef[1] * (tc**2 - tc_ref**2))
 
 
 def calc_gammastar(

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -218,18 +218,18 @@ def calc_gammastar(
     :meth:`~pyrealm.pmodel.functions.calculate_simple_arrhenius_factor`). By default,
     estimates of  :math:`\Gamma^{*}_{0}` and :math:`H_a` are taken from
     :cite:t:`Bernacchi:2001kg` (see
-    attr:`PModelConst.bernacchi_gs<pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs>`)
+    :attr:`PModelConst.bernacchi_gs<pyrealm.constants.pmodel_const.PModelConst.bernacchi_gs>`)
 
     Args:
         tk: Temperature relevant for photosynthesis in Kelvin(:math:`T`, K)
         patm: Atmospheric pressure (:math:`p`, Pascals)
         tk_ref: The reference temperature of the coefficients in Kelvin.
         k_Po: The standard atmospheric pressure, defaulting to the value
-            from attr:`~pyrealm.constants.core_const.CoreConst.k_Po`.
+            from :attr:`~pyrealm.constants.core_const.CoreConst.k_Po`.
         k_R: The universal gas constant, defaulting to the value from
-            attr:`~pyrealm.constants.core_const.CoreConst.k_R`.
+            :attr:`~pyrealm.constants.core_const.CoreConst.k_R`.
         coef: A dictionary providing the enzyme kinetic coefficients for the reaction
-        (``dha`` and ``gs25_0``).
+            (``dha`` and ``gs25_0``).
 
     Returns:
         A float value or values for :math:`\Gamma^{*}` (in Pa)

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -476,7 +476,9 @@ def calc_soilmstress_stocker(
             (unitless). Defaults to 1.0 (no soil moisture stress).
         meanalpha: Local annual mean ratio of actual over potential
             evapotranspiration, measure for average aridity. Defaults to 1.0.
-        coef: A dictionary providing values of the coefficients 
+        coef: A dictionary providing values of the coefficients ``theta0``,
+            ``thetastar``, ``a`` and ``b``, , with default values from 
+            attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_stocker`.
 
     Returns:
         A numeric value or values for :math:`\beta`
@@ -510,7 +512,7 @@ def calc_soilmstress_stocker(
 def calc_soilmstress_mengoli(
     soilm: NDArray[np.float64] = np.array(1.0),
     aridity_index: NDArray[np.float64] = np.array(1.0),
-    pmodel_const: PModelConst = PModelConst(),
+    coef: dict[str, float] = PModelConst.soilmstress_mengoli,
 ) -> NDArray[np.float64]:
     r"""Calculate the Mengoli et al. empirical soil moisture stress factor.
 
@@ -543,18 +545,9 @@ def calc_soilmstress_mengoli(
     Args:
         soilm: Relative soil moisture (unitless).
         aridity_index: The climatological aridity index.
-        pmodel_const: Instance of :class:`~pyrealm.constants.pmodel_const.PModelConst`.
-
-    PModel Parameters:
-
-        y_a: Coefficient of the maximal level (:math:`y`,
-            :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_y_a`)
-        y_b: Exponent of the maximal level (:math:`y`,
-            :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_y_b`)
-        psi_a: Coefficient of the threshold (:math:`\psi`,
-            :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_psi_a`)
-        psi_b: Exponent of the threshold (:math:`\psi`,
-            :attr:`~pyrealm.constants.pmodel_const.PModelConst.soilm_mengoli_psi_b`)
+        coef: A dictionary providing values of the coefficients ``y_a``, ``y_b``,
+            ``psi_a`` and ``psi_b``, with default values from 
+            attr:`~pyrealm.constants.pmodel_const.PModelConst.soilmstress_mengoli`.
 
     Returns:
         A numeric value or values for :math:`f(\theta)`
@@ -575,14 +568,12 @@ def calc_soilmstress_mengoli(
 
     # Calculate maximal level and threshold
     y = np.minimum(
-        pmodel_const.soilm_mengoli_y_a
-        * np.power(aridity_index, pmodel_const.soilm_mengoli_y_b),
+        coef["y_a"] * np.power(aridity_index, coef["y_b"]),
         1,
     )
 
     psi = np.minimum(
-        pmodel_const.soilm_mengoli_psi_a
-        * np.power(aridity_index, pmodel_const.soilm_mengoli_psi_b),
+        coef["psi_a"] * np.power(aridity_index, coef["psi_b"]),
         1,
     )
 

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -432,7 +432,7 @@ def calc_kp_c4(
 def calc_soilmstress_stocker(
     soilm: NDArray[np.float64],
     meanalpha: NDArray[np.float64] = np.array(1.0),
-    coef: dict[str, float] = PModelConst.soilmstress_stocker,
+    coef: dict[str, float] = PModelConst().soilmstress_stocker,
 ) -> NDArray[np.float64]:
     r"""Calculate Stocker's empirical soil moisture stress factor.
 
@@ -512,7 +512,7 @@ def calc_soilmstress_stocker(
 def calc_soilmstress_mengoli(
     soilm: NDArray[np.float64] = np.array(1.0),
     aridity_index: NDArray[np.float64] = np.array(1.0),
-    coef: dict[str, float] = PModelConst.soilmstress_mengoli,
+    coef: dict[str, float] = PModelConst().soilmstress_mengoli,
 ) -> NDArray[np.float64]:
     r"""Calculate the Mengoli et al. empirical soil moisture stress factor.
 

--- a/pyrealm/pmodel/jmax_limitation.py
+++ b/pyrealm/pmodel/jmax_limitation.py
@@ -237,14 +237,12 @@ class JmaxLimitationSmith19(
     def _calculate_limitation_terms(self) -> None:
         """Limitation calculations for the ``smith19`` method."""
 
-        # Adopted from Nick Smith's code:
         # Calculate omega, see Smith et al., 2019 Ecology Letters  # Eq. S4
-        theta = self.pmodel_const.smith19_theta
-        c_cost = self.pmodel_const.smith19_c_cost
+        theta, c_cost = self.pmodel_const.smith19_coef
 
         # simplification terms for omega calculation
         cm = 4 * c_cost / self.optchi.mj
-        v = 1 / (cm * (1 - self.pmodel_const.smith19_theta * cm)) - 4 * theta
+        v = 1 / (cm * (1 - theta * cm)) - 4 * theta
 
         # account for non-linearities at low m values. This code finds
         # the roots of a quadratic function that is defined purely from

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -532,8 +532,8 @@ class OptimalChiLavergne20C3(
 
         # Calculate beta as a function of theta
         self.beta = np.exp(
-            self.pmodel_const.lavergne_2020_b_c3 * getattr(self.env, "theta")
-            + self.pmodel_const.lavergne_2020_a_c3
+            self.pmodel_const.lavergne_2020_c3[1] * getattr(self.env, "theta")
+            + self.pmodel_const.lavergne_2020_c3[0]
         )
 
     def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
@@ -587,7 +587,8 @@ class OptimalChiLavergne20C4(
     because photorespiration is negligible, but :math:`m_c` and hence
     :math:`m_{joc}` are calculated.
 
-    Note:
+    .. NOTE::
+
         This is an **experimental approach**. The research underlying
         :cite:`lavergne:2020a`, found **no relationship** between C4 :math:`\beta`
         values and soil moisture in leaf gas exchange measurements.
@@ -624,8 +625,8 @@ class OptimalChiLavergne20C4(
 
         # Calculate beta as a function of theta
         self.beta = np.exp(
-            self.pmodel_const.lavergne_2020_b_c4 * getattr(self.env, "theta")
-            + self.pmodel_const.lavergne_2020_a_c4
+            self.pmodel_const.lavergne_2020_c4[1] * getattr(self.env, "theta")
+            + self.pmodel_const.lavergne_2020_c4[0]
         )
 
     def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -246,7 +246,7 @@ class OptimalChiPrentice14(
     def set_beta(self) -> None:
         """Set ``beta`` to a constant C3 specific value."""
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_prentice14
+        self.beta = self.pmodel_const.beta_cost_ratio_c3
 
     def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
         """Estimate ``chi`` for C3 plants."""
@@ -316,7 +316,7 @@ class OptimalChiPrentice14RootzoneStress(
         )
 
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
-        self.beta = self.pmodel_const.beta_cost_ratio_prentice14
+        self.beta = self.pmodel_const.beta_cost_ratio_c3
 
     def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
         """Estimate ``chi`` for C3 plants."""

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -498,9 +498,9 @@ class OptimalChiLavergne20C3(
 
     The coefficients are experimentally derived values with defaults taken from
     Figure 6a of :cite:`lavergne:2020a` (:math:`a`,
-    :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c3`;
+    :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_c3`;
     :math:`b`,
-    :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c3`).
+    :attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_c3`).
 
     Values of :math:`\chi` and other predictions are then calculated as in
     :meth:`~pyrealm.pmodel.optimal_chi.OptimalChiPrentice14`. This method
@@ -575,10 +575,10 @@ class OptimalChiLavergne20C4(
     C3 plants are adjusted to match the theoretical expectation that :math:`\beta`
     for C4 plants is nine times smaller than :math:`\beta` for C3 plants (see
     :meth:`~pyrealm.pmodel.optimal_chi.OptimalChiC4`): :math:`b`
-    (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_b_c4`) is
+    (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_c4`) is
     unchanged but
     :math:`a_{C4} = a_{C3} - log(9)`
-    (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_a_c4`) .
+    (:attr:`~pyrealm.constants.pmodel_const.PModelConst.lavergne_2020_c4`) .
 
     Following the calculation of :math:`\beta`, this method then follows the
     calculations described in

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -482,7 +482,7 @@ class PModel(PModelABC):
         # Dark respiration at growth temperature
         ftemp_inst_rd = calc_ftemp_inst_rd(
             tc=self.env.tc,
-            t_ref=self.pmodel_const.plant_T_ref,
+            tc_ref=self.pmodel_const.plant_T_ref,
             coef=self.pmodel_const.heskel_rd,
         )
         self.rd = (

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -480,7 +480,11 @@ class PModel(PModelABC):
         )
 
         # Dark respiration at growth temperature
-        ftemp_inst_rd = calc_ftemp_inst_rd(self.env.tc, pmodel_const=self.pmodel_const)
+        ftemp_inst_rd = calc_ftemp_inst_rd(
+            tc=self.env.tc,
+            t_ref=self.pmodel_const.plant_T_ref,
+            coef=self.pmodel_const.heskel_rd,
+        )
         self.rd = (
             self.pmodel_const.atkin_rd_to_vcmax
             * (ftemp_inst_rd / ftemp25_inst_vcmax)

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -443,7 +443,7 @@ class PModel(PModelABC):
         # Get an Arrhenius instance for use in scaling rates
         arrhenius_factors = self._arrhenius_class(
             env=self.env,
-            reference_temperature=self.env.pmodel_const.plant_T_ref,
+            reference_temperature=self.env.pmodel_const.tc_ref,
             core_const=self.env.core_const,
         )
 
@@ -482,7 +482,7 @@ class PModel(PModelABC):
         # Dark respiration at growth temperature
         ftemp_inst_rd = calc_ftemp_inst_rd(
             tc=self.env.tc,
-            tc_ref=self.pmodel_const.plant_T_ref,
+            tc_ref=self.pmodel_const.tc_ref,
             coef=self.pmodel_const.heskel_rd,
         )
         self.rd = (
@@ -860,7 +860,7 @@ class SubdailyPModel(PModelABC):
 
         arrhenius_daily = self._arrhenius_class(
             env=self.pmodel_acclim.env,
-            reference_temperature=self.pmodel_acclim.env.pmodel_const.plant_T_ref,
+            reference_temperature=self.pmodel_acclim.env.pmodel_const.tc_ref,
             core_const=self.env.core_const,
         )
 
@@ -913,7 +913,7 @@ class SubdailyPModel(PModelABC):
         #    actual subdaily temperatures.
         arrhenius_subdaily = self._arrhenius_class(
             env=self.env,
-            reference_temperature=self.pmodel_acclim.env.pmodel_const.plant_T_ref,
+            reference_temperature=self.pmodel_acclim.env.pmodel_const.tc_ref,
             core_const=self.env.core_const,
         )
 

--- a/pyrealm/pmodel/pmodel_environment.py
+++ b/pyrealm/pmodel/pmodel_environment.py
@@ -137,9 +137,9 @@ class PModelEnvironment:
         """The photosynthetic photon flux density (PPFD, µmol m-2 s-1)"""
 
         # Store constant settings and bounds checker
-        self.pmodel_const = pmodel_const
+        self.pmodel_const: PModelConst = pmodel_const
         """PModel constants used to calculate environment"""
-        self.core_const = core_const
+        self.core_const: CoreConst = core_const
         """Core constants used to calculate environment"""
         self._bounds_checker: BoundsChecker = bounds_checker
         """The BoundsChecker applied to the environment data."""
@@ -159,19 +159,27 @@ class PModelEnvironment:
             )
 
         # Internal calculations
-        self.tk = self.tc + self.core_const.k_CtoK
+        self.tk: NDArray[np.float64] = self.tc + self.core_const.k_CtoK
         """The temperature at which to estimate photosynthesis in Kelvin (K)"""
 
         self.ca: NDArray[np.float64] = calc_co2_to_ca(co2=self.co2, patm=self.patm)
         """Ambient CO2 partial pressure, Pa"""
 
-        self.gammastar = calc_gammastar(
-            tk=self.tk, patm=patm, pmodel_const=pmodel_const, core_const=core_const
+        self.gammastar: NDArray[np.float64] = calc_gammastar(
+            tk=self.tk,
+            patm=patm,
+            tk_ref=self.pmodel_const.tk_ref,
+            k_Po=self.core_const.k_Po,
+            coef=self.pmodel_const.bernacchi_gs,
         )
         r"""Photorespiratory compensation point (:math:`\Gamma^\ast`, Pa)"""
 
-        self.kmm = calc_kmm(
-            tk=self.tk, patm=patm, pmodel_const=pmodel_const, core_const=core_const
+        self.kmm: NDArray[np.float64] = calc_kmm(
+            tk=self.tk,
+            patm=patm,
+            tk_ref=self.pmodel_const.tk_ref,
+            k_co=self.core_const.k_co,
+            coef=self.pmodel_const.bernacchi_kmm,
         )
         """Michaelis Menten coefficient, Pa"""
 

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -327,16 +327,21 @@ class QuantumYieldSandoval(
         mean_growth_temperature = getattr(self.env, "mean_growth_temperature")
 
         # Calculate enzyme kinetics
-        a_ent, b_ent, Hd_base, Ha = self.env.pmodel_const.sandoval_kinetics
+        coef = self.env.pmodel_const.sandoval_kinetics
         # Calculate change in activation entropy as a linear function of
         # mean growth temperature, J/mol/K
-        delta_entropy = a_ent + b_ent * mean_growth_temperature
-        # Calculate deaactivation energy J/mol
-        Hd = Hd_base * delta_entropy
+        delta_entropy = (
+            coef["entropy_intercept"] + coef["entropy_slope"] * mean_growth_temperature
+        )
+        # Calculate de-activation energy J/mol
+        Hd = coef["hd"] * delta_entropy
 
         # Calculate the optimal temperature to be used as the reference temperature in
         # the modified Arrhenius calculation
-        Topt = Hd / (delta_entropy - self.env.core_const.k_R * np.log(Ha / (Hd - Ha)))
+        Topt = Hd / (
+            delta_entropy
+            - self.env.core_const.k_R * np.log(coef["ha"] / (Hd - coef["ha"]))
+        )
         tk_leaf = self.env.tk
         # Calculate peak kphio given the aridity index
         kphio_peak = self.peak_quantum_yield(aridity_index=aridity_index)
@@ -346,11 +351,8 @@ class QuantumYieldSandoval(
             tk_leaf=tk_leaf,
             tk_ref=Topt,
             tc_growth=mean_growth_temperature,
-            ha=Ha,
-            hd=Hd,  # type: ignore[arg-type]  # Not an array in this function
-            entropy_intercept=a_ent,
-            entropy_slope=b_ent,
-            core_const=self.env.core_const,
+            coef=self.env.pmodel_const.sandoval_kinetics,
+            k_R=self.env.core_const.k_R,
         )
 
         # Apply the factor and store it.

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -307,8 +307,10 @@ class QuantumYieldSandoval(
         aridity_index = getattr(self.env, "aridity_index")
         mean_growth_temperature = getattr(self.env, "mean_growth_temperature")
 
-        # Calculate enzyme kinetics
-        coef = self.env.pmodel_const.sandoval_kinetics
+        # Calculate enzyme kinetic. This needs to use a copy because the Hd value is
+        # modified below.
+        coef = self.env.pmodel_const.sandoval_kinetics.copy()
+
         # Calculate change in activation entropy as a linear function of
         # mean growth temperature, J/mol/K
         delta_entropy = (
@@ -327,12 +329,15 @@ class QuantumYieldSandoval(
         # Calculate peak kphio given the aridity index
         kphio_peak = self.peak_quantum_yield(aridity_index=aridity_index)
 
+        # Pass the modified Hd back into the calculation of the Arrhenius factor
+        coef["hd"] = Hd
+
         # Calculate the modified Arrhenius factor using the
         f_kphio = calculate_kattge_knorr_arrhenius_factor(
             tk_leaf=tk_leaf,
             tk_ref=Topt,
             tc_growth=mean_growth_temperature,
-            coef=self.env.pmodel_const.sandoval_kinetics,
+            coef=coef,
             k_R=self.env.core_const.k_R,
         )
 

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -140,18 +140,13 @@ def test_calc_ftemp_inst_vcmax(values, tc, expvars):
     pmodel_const = PModelConst()
     core_const = CoreConst()
 
-    cf = pmodel_const.arrhenius_vcmax["kattge_knorr"]
-
     # Calculate the arrhenius factor
     ret = calculate_kattge_knorr_arrhenius_factor(
         tk_leaf=values[tc] + core_const.k_CtoK,
         tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
         tc_growth=values[tc],  # This is an odd thing for rpmodel to do
-        ha=cf["ha"],
-        hd=cf["hd"],
-        entropy_intercept=cf["entropy_intercept"],
-        entropy_slope=cf["entropy_slope"],
-        core_const=core_const,
+        coef=pmodel_const.arrhenius_vcmax["kattge_knorr"],
+        k_R=core_const.k_R,
     )
 
     assert np.allclose(ret, values[expvars])

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -913,7 +913,7 @@ def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
     if is_C4:
         const = PModelConst(beta_cost_ratio_c4=mod_theta.optchi.beta)
     else:
-        const = PModelConst(beta_cost_ratio_prentice14=mod_theta.optchi.beta)
+        const = PModelConst(beta_cost_ratio_c3=mod_theta.optchi.beta)
 
     env = PModelEnvironment(
         tc=tc,

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -143,7 +143,7 @@ def test_calc_ftemp_inst_vcmax(values, tc, expvars):
     # Calculate the arrhenius factor
     ret = calculate_kattge_knorr_arrhenius_factor(
         tk_leaf=values[tc] + core_const.k_CtoK,
-        tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+        tk_ref=pmodel_const.tk_ref,
         tc_growth=values[tc],  # This is an odd thing for rpmodel to do
         coef=pmodel_const.arrhenius_vcmax["kattge_knorr"],
         k_R=core_const.k_R,

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -145,7 +145,7 @@ def test_calc_ftemp_inst_vcmax(values, tc, expvars):
     # Calculate the arrhenius factor
     ret = calculate_kattge_knorr_arrhenius_factor(
         tk_leaf=values[tc] + core_const.k_CtoK,
-        tk_ref=pmodel_const.plant_T_ref + core_const.k_CtoK,
+        tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
         tc_growth=values[tc],  # This is an odd thing for rpmodel to do
         ha=cf["ha"],
         hd=cf["hd"],

--- a/tests/unit/pmodel/test_arrhenius.py
+++ b/tests/unit/pmodel/test_arrhenius.py
@@ -176,17 +176,13 @@ class TestKattgeKnorrArrhenius:
 
         tk = args["tc_leaf"] + 273.15
         tk_ref = args["tc_ref"] + 273.15
-        cf = args["coef"]["kattge_knorr"]
 
         assert_allclose(
             calculate_kattge_knorr_arrhenius_factor(
                 tk_leaf=tk,
                 tk_ref=tk_ref,
                 tc_growth=args["tc_growth"],
-                ha=cf["ha"],
-                hd=cf["hd"],
-                entropy_intercept=cf["entropy_intercept"],
-                entropy_slope=cf["entropy_slope"],
+                coef=args["coef"]["kattge_knorr"],
             ),
             expected,
         )

--- a/tests/unit/pmodel/test_functions_new.py
+++ b/tests/unit/pmodel/test_functions_new.py
@@ -16,9 +16,17 @@ PATM = np.array([123456])
 
 def test_calc_ftemp_inst_rd(tc=TC):
     """Test calc_ftemp_inst_rd."""
+    from pyrealm.constants.pmodel_const import PModelConst
     from pyrealm.pmodel.functions import calc_ftemp_inst_rd
 
-    assert np.allclose(calc_ftemp_inst_rd(tc), 1.4455646406287255)
+    pmodel_const = PModelConst()
+
+    assert np.allclose(
+        calc_ftemp_inst_rd(
+            tc, t_ref=pmodel_const.plant_T_ref, coef=pmodel_const.heskel_rd
+        ),
+        1.4455646406287255,
+    )
 
 
 def test_calc_gammastar(tk=TK, patm=PATM):

--- a/tests/unit/pmodel/test_functions_new.py
+++ b/tests/unit/pmodel/test_functions_new.py
@@ -23,7 +23,7 @@ def test_calc_ftemp_inst_rd(tc=TC):
 
     assert np.allclose(
         calc_ftemp_inst_rd(
-            tc=tc, tc_ref=pmodel_const.plant_T_ref, coef=pmodel_const.heskel_rd
+            tc=tc, tc_ref=pmodel_const.tc_ref, coef=pmodel_const.heskel_rd
         ),
         1.4455646406287255,
     )
@@ -31,9 +31,17 @@ def test_calc_ftemp_inst_rd(tc=TC):
 
 def test_calc_gammastar(tk=TK, patm=PATM):
     """Test calc_ftemp_inst_rd."""
+    from pyrealm.constants.core_const import CoreConst
+    from pyrealm.constants.pmodel_const import PModelConst
     from pyrealm.pmodel.functions import calc_gammastar
 
-    assert np.allclose(calc_gammastar(tk, patm), 6.7888247955597)
+    pmodel_const = PModelConst()
+    core_const = CoreConst()
+
+    assert np.allclose(
+        calc_gammastar(tk, patm, tk_ref=pmodel_const.tc_ref + core_const.k_CtoK),
+        6.7888247955597,
+    )
 
 
 def test_calc_ns_star(tc=TC, patm=PATM):

--- a/tests/unit/pmodel/test_functions_new.py
+++ b/tests/unit/pmodel/test_functions_new.py
@@ -31,15 +31,14 @@ def test_calc_ftemp_inst_rd(tc=TC):
 
 def test_calc_gammastar(tk=TK, patm=PATM):
     """Test calc_ftemp_inst_rd."""
-    from pyrealm.constants.core_const import CoreConst
+
     from pyrealm.constants.pmodel_const import PModelConst
     from pyrealm.pmodel.functions import calc_gammastar
 
     pmodel_const = PModelConst()
-    core_const = CoreConst()
 
     assert np.allclose(
-        calc_gammastar(tk, patm, tk_ref=pmodel_const.tc_ref + core_const.k_CtoK),
+        calc_gammastar(tk, patm, tk_ref=pmodel_const.tk_ref),
         6.7888247955597,
     )
 

--- a/tests/unit/pmodel/test_functions_new.py
+++ b/tests/unit/pmodel/test_functions_new.py
@@ -23,7 +23,7 @@ def test_calc_ftemp_inst_rd(tc=TC):
 
     assert np.allclose(
         calc_ftemp_inst_rd(
-            tc, t_ref=pmodel_const.plant_T_ref, coef=pmodel_const.heskel_rd
+            tc=tc, tc_ref=pmodel_const.plant_T_ref, coef=pmodel_const.heskel_rd
         ),
         1.4455646406287255,
     )

--- a/tests/unit/pmodel/test_pmodel_environment.py
+++ b/tests/unit/pmodel/test_pmodel_environment.py
@@ -198,7 +198,7 @@ def test_out_of_bound_output_gammastar(function_test_data):
         result = calc_gammastar(
             tk=tc + core_const.k_CtoK,
             patm=patm,
-            tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
+            tk_ref=pmodel_const.tk_ref,
         )
 
         assert np.all(result >= gammastar_lower_bound), (

--- a/tests/unit/pmodel/test_pmodel_environment.py
+++ b/tests/unit/pmodel/test_pmodel_environment.py
@@ -134,20 +134,17 @@ def function_test_data():
 
 def test_out_of_bound_output(function_test_data):
     """Function to calculate kmm."""
-    from pyrealm.constants import CoreConst, PModelConst
+    from pyrealm.constants import CoreConst
     from pyrealm.pmodel.functions import calc_kmm
 
     tc_ar_values, patm_ar_values, co2_ar_values = function_test_data
 
-    pmodel_const = PModelConst()
     core_const = CoreConst()
     kmm_lower_bound = 0
     kmm_upper_bound = 1000
 
     for tc, patm, co2 in zip(tc_ar_values, patm_ar_values, co2_ar_values):
-        result = calc_kmm(
-            tk=tc + core_const.k_CtoK, patm=patm, pmodel_const=pmodel_const
-        )
+        result = calc_kmm(tk=tc + core_const.k_CtoK, patm=patm)
 
         assert np.all(result >= kmm_lower_bound), (
             f"Result for (tc={tc}, patm={patm}, co2={co2}) is out of lower bound"
@@ -192,8 +189,8 @@ def test_out_of_bound_output_gammastar(function_test_data):
 
     tc_ar_values, patm_ar_values, _ = function_test_data
 
-    core_const = CoreConst(k_To=298.15, k_Po=101325)
-    pmodel_const = PModelConst(bernacchi_gs25_0=4.332, bernacchi_dha=37830)
+    core_const = CoreConst()
+    pmodel_const = PModelConst()
     gammastar_lower_bound = 0
     gammastar_upper_bound = 30
 
@@ -201,8 +198,7 @@ def test_out_of_bound_output_gammastar(function_test_data):
         result = calc_gammastar(
             tk=tc + core_const.k_CtoK,
             patm=patm,
-            pmodel_const=pmodel_const,
-            core_const=core_const,
+            tk_ref=pmodel_const.tc_ref + core_const.k_CtoK,
         )
 
         assert np.all(result >= gammastar_lower_bound), (

--- a/tests/unit/pmodel/test_quantum_yield.py
+++ b/tests/unit/pmodel/test_quantum_yield.py
@@ -113,18 +113,18 @@ def test_QuantumYieldTemperature(
     argnames="reference_kphio, expected_kphio",
     argvalues=(
         pytest.param(
-            1 / 9,
+            None,
             np.array(
                 [0.02848466, 0.05510828, 0.06099888, 0.07537036, 0.02231382, 0.03026185]
             ),
-            id="provided_kphio",
+            id="default_kphio",
         ),
         pytest.param(
-            None,
+            1 / 9,
             np.array(
                 [0.03204524, 0.06199681, 0.06862374, 0.08479165, 0.02510305, 0.03404458]
             ),
-            id="default_kphio",
+            id="provided_kphio",
         ),
     ),
 )

--- a/tests/unit/pmodel/test_quantum_yield.py
+++ b/tests/unit/pmodel/test_quantum_yield.py
@@ -113,18 +113,18 @@ def test_QuantumYieldTemperature(
     argnames="reference_kphio, expected_kphio",
     argvalues=(
         pytest.param(
-            None,
+            1 / 9,
             np.array(
                 [0.02848466, 0.05510828, 0.06099888, 0.07537036, 0.02231382, 0.03026185]
             ),
-            id="default_kphio",
+            id="provided_kphio",
         ),
         pytest.param(
-            1 / 9,
+            None,
             np.array(
                 [0.03204524, 0.06199681, 0.06862374, 0.08479165, 0.02510305, 0.03404458]
             ),
-            id="provided_kphio",
+            id="default_kphio",
         ),
     ),
 )

--- a/tests/unit/splash/conftest.py
+++ b/tests/unit/splash/conftest.py
@@ -10,7 +10,7 @@ import xarray
 def splash_core_constants():
     """Provide constants using SPLASH original defaults.
 
-    SPLASH v1 uses 15°C / 288.1 5 K in the standard atmosphere definition and uses the
+    SPLASH v1 uses 15°C / 288.15 K in the standard atmosphere definition and uses the
     Chen method for calculating water density.
     """
 


### PR DESCRIPTION
# Description

The `PModelConsts` object has a very disorganised namespace with a mix of bundled and individual parameters, and poor use of attribute docstrings to pair information with data. 

> [!TIP]
> This is a slightly sprawling PR because it restructures PModelConst - so lots of changes - but also updates the signatures of the `pmodel` functions. Most of the actual changes are in `pmodel_const.py` and `pmodel/functions.py` - everything else is just updates to match

* Reviews the `PModelConsts` contents to group closely related parameters into single attributes with better documentation.
* Adds `tk_ref` to avoid the omnipresent recalculation of this value through the code base, and renames `plant_T_ref` to `tc_ref` for consistency.
* Updates the signatures of the `pyrealm.pmodel.functions` to take more specific parameterisation, rather than simply chucking all of `PModelConst` and `CoreConst` into each one. This makes the implementation and docs clearer.
* Updates usage to match and updates tests.

Fixes #391

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
