### PR TITLE
Revise P Model attributes

### DIFF
--- a/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
+++ b/docs/source/users/pmodel/pmodel_details/envt_variation_outputs.md
@@ -230,7 +230,6 @@ resulting absorbed irradiance ($I_{abs}$).
 The productivity variables and their units are:
 
 * Gross primary productivity (``gpp``, $\mu\text{gC}\,\mathrm{m}^{-2}\,\text{s}^{-1}$)
-* Dark respiration (``rd``, $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$)
 * Maximum rate of carboxylation
     (``vcmax``, $\mu\text{mol}\,\mathrm{m}^{-2}\,\text{s}^{-1}$)
 * Maximum rate of carboxylation at standard temperature
@@ -245,14 +244,6 @@ The productivity variables and their units are:
 :tags: [hide-input]
 
 plot_fun("gpp", r"GPP   ($\mu\mathrm{g\,C}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)")
-```
-
-### Dark respiration (``rd``)
-
-```{code-cell} ipython3
-:tags: [hide-input]
-
-plot_fun("rd", r"$r_d$   ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)")
 ```
 
 ### Maximum rate of carboxylation (``vcmax``)
@@ -342,26 +333,24 @@ fig, axs = plt.subplots(2, 3, figsize=(12, 8), sharex=True)
 plot_iabs(
     axs[0, 0], "gpp", r"GPP ($\mu\mathrm{g\,C}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
 )
+
 plot_iabs(
-    axs[0, 1], "rd", r"$r_d$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
-)
-plot_iabs(
-    axs[0, 2],
+    axs[0, 1],
     "vcmax",
     r"$v_{cmax}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
 plot_iabs(
-    axs[1, 0],
+    axs[0, 2],
     "vcmax25",
     r"$v_{cmax25}$   ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
 plot_iabs(
-    axs[1, 1],
+    axs[1, 0],
     "jmax",
     r"$J_{max}$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)",
 )
 plot_iabs(
-    axs[1, 2], "gs", r"$g_s$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
+    axs[1, 1], "gs", r"$g_s$ ($\mu\mathrm{mol}\,\mathrm{m}^{-2}\,\mathrm{s}^{-1}$)"
 )
 
 axs[0, 0].legend(

--- a/docs/source/users/pmodel/subdaily_details/worked_example.md
+++ b/docs/source/users/pmodel/subdaily_details/worked_example.md
@@ -136,6 +136,14 @@ pmodC4 = PModel(
 pmodC4.summarize()
 ```
 
+```{code-cell} ipython3
+np.nanmean(pmodC3.iwue)
+```
+
+```{code-cell} ipython3
+np.nanmean((pmodC3.gpp / pmodC3.env.core_const.k_c_molmass) / pmodC3.gs)
+```
+
 ## Subdaily P Models
 
 The code below then refits these models, with slow responses in $\xi$, $V_{cmax25}$ and

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -213,8 +213,3 @@ class PModelConst(ConstantsClass):
     r"""Scaling factors ``theta`` (:math:`\theta`, 0.85) and ``c`` (:math:`c`,
     0.05336251) used in the calculation of J_max limitation using the method of 
     :cite:t:`Smith:2019dv`."""
-
-    # Atkin
-    atkin_rd_to_vcmax: float = 0.015
-    """Ratio of Dark respiration to Vcmax25. Value taken from :cite:t:`Atkin:2015hk` for
-    C3 herbaceous plants."""

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -92,11 +92,6 @@ def test_calc_density_h2o(values, tc, patm, context_manager, expvals):
             assert_allclose(ret, values[expvals])
 
 
-# ------------------------------------------
-# Testing calc_ftemp_inst_rd - temp only but in Kelvin!
-# ------------------------------------------
-
-
 @pytest.mark.parametrize(
     "tk, expvars",
     [
@@ -730,7 +725,7 @@ def test_pmodel_class_c3(
 
     if "sm-on" in name:
         warnings.warn(
-            "Skipping jmax, vcmax,rd and gs testing when using soil moisture stress"
+            "Skipping jmax, vcmax and gs testing when using soil moisture stress"
         )
         return
 
@@ -750,10 +745,7 @@ def test_pmodel_class_c3(
     assert_allclose(ret.vcmax, sc * expected["vcmax"], equal_nan=True, rtol=1e-06)
     assert_allclose(ret.vcmax25, sc * expected["vcmax25"], equal_nan=True, rtol=1e-06)
 
-    # rd and g_s are calcualted using vcmax
-    # TODO - tolerance turned up here to pass one of the Smith tests - remove later?
-
-    assert_allclose(ret.rd, sc * expected["rd"], equal_nan=True, atol=1e07)
+    # g_s  calculated using vcmax
     # Some algo issues with getting 0 and na in g_s
     # Fill na values with 0 in both inputs
     assert_allclose(
@@ -826,16 +818,16 @@ def test_pmodel_class_c4(
 
     # Test exclusions:
     # - rpmodel adjusts vcmax and jmax when Stocker empirical soil moisture
-    #   stress β(θ) is used and hence the predictions of g_s and rd.
+    #   stress β(θ) is used and hence the predictions of g_s.
     #   pyrealm.PModel _only_ adjusts the resulting LUE so skip tests of
-    #   jmax, vcmax, rd and gs when sm is used.
+    #   jmax, vcmax and gs when sm is used.
     # - Also skip tests of jmax when no Jmax limitation is applied (none-) as the
     #   calculation in rpmodel leads to numerical instablity
     # - Also skip tests of Jmax for Smith et al - unresolved coding differences.
 
     if "sm-on" in name:
         warnings.warn(
-            "Skipping jmax, vcmax,rd and gs testing when using soil moisture stress"
+            "Skipping jmax, vcmax and gs testing when using soil moisture stress"
         )
         return
 
@@ -848,9 +840,6 @@ def test_pmodel_class_c4(
     # pyrealm and pmodel do different things with jmax and vcmax
     assert_allclose(ret.vcmax, expected["vcmax"], equal_nan=True, rtol=1e-06)
     assert_allclose(ret.vcmax25, expected["vcmax25"], equal_nan=True, rtol=1e-06)
-
-    # rd and g_s are calcualted using vcmax
-    assert_allclose(ret.rd, expected["rd"], equal_nan=True, rtol=3e-05)
 
     # Some algo issues with getting 0 and na in g_s
     # Fill na values with 0 in both inputs
@@ -873,7 +862,7 @@ def test_pmodel_summarise(capsys, values, pmodelenv):
     assert all(
         [
             "\n" + var in out
-            for var in ("lue", "iwue", "gpp", "vcmax", "vcmax25", "rd", "gs", "jmax")
+            for var in ("lue", "iwue", "gpp", "vcmax", "vcmax25", "gs", "jmax")
         ]
     )
 


### PR DESCRIPTION
# Description

This PR:

* Removes estimation of dark respiration (`rd`) from the PModel and then from the `summarize` method and tests.
* Adds an `lue` property to `SubdailyPModel` that has the sole job of saying "LUE isn't calculated for this model". This does involve overriding an attribute of the base class, which is kinda ugly, but seemed the easiest way to do this that didn't involve a complex mess of getters and setters.
* Adds stomatal conductance (gs) and intrinsic water use efficiency (iwue) to the subdaily P Model

Fixes #451 

And also, I think this polishes off all of the final issues and fixes #386 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
