### PR TITLE
Marking experimental classes

### DIFF
--- a/docs/source/users/pmodel/shared_components/two_leaf_model.md
+++ b/docs/source/users/pmodel/shared_components/two_leaf_model.md
@@ -37,16 +37,16 @@ from pyrealm.core.solar import SolarPositions
 from pyrealm.pmodel.pmodel import PModel, SubdailyPModel
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 from pyrealm.pmodel.acclimation import AcclimationModel
-from pyrealm.pmodel.two_leaf import TwoLeafIrradience, TwoLeafAssimilation
+from pyrealm.pmodel.two_leaf import TwoLeafIrradiance, TwoLeafAssimilation
 
 from pyrealm.core.hygro import convert_sh_to_vpd
 ```
 
 This page shows how to use the two leaf, two stream model of assimilation
-:cite:`depury:1997a` in `pyrealm`. The standard and subdaily P Model use the big leaf
+{cite}`depury:1997a` in `pyrealm`. The standard and subdaily P Model use the big leaf
 approximation of the canopy structure: assimilation is estimated as if all the available
 light falls directly as a beam onto a single large leaf. In the two leaf, two stream
-model, :cite:t:`depury:1997a` differentiate the absorbance of light into sunlit and
+model, {cite:t}`depury:1997a` differentiate the absorbance of light into sunlit and
 shaded leaves ('two leaf') and also into direct and scattered radiation ('two streams').
 Within the canopy, the model separates out beam, scattered and diffuse irradiation and
 estimates how much of each stream is absorbed by the sunlit and shaded leaves.
@@ -212,7 +212,7 @@ multiple P Models. The irradiance calculation requires:
 * the atmospheric pressure.
 
 ```{code-cell} ipython3
-irradiances = TwoLeafIrradience(
+irradiances = TwoLeafIrradiance(
     solar_elevation=solar_pos.solar_elevation,
     ppfd=ppfd,
     leaf_area_index=2,

--- a/pyrealm/demography/__init__.py
+++ b/pyrealm/demography/__init__.py
@@ -1,0 +1,5 @@
+"""The demography module contains functions and classes for modelling the demography of
+tree communities, including the definition of plant functional types, size structured
+plant cohorts, community canopy models and the allocation of gross primary productivity
+into respiration, turnover and growth.
+"""  # noqa: D205

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.optimize import root_scalar  # type: ignore [import-untyped]
 
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.demography.community import Community
 from pyrealm.demography.core import PandasExporter, _validate_demography_array_arguments
 from pyrealm.demography.crown import (
@@ -253,6 +254,8 @@ class CohortCanopyData(PandasExporter):
     # Community wide attributes in their own class
     community_data: CommunityCanopyData = field(init=False)
 
+    __experimental__ = True
+
     def __post_init__(
         self,
         projected_leaf_area: NDArray[np.float64],
@@ -262,6 +265,9 @@ class CohortCanopyData(PandasExporter):
         cell_area: float,
     ) -> None:
         """Calculates cohort canopy attributes from the input data."""
+
+        warn_experimental("CohortCanopyData")
+
         # Partition the projected leaf area into the leaf area in each layer for each
         # stem and then scale up to the cohort leaf area in each layer.
         self.stem_leaf_area = np.diff(projected_leaf_area, axis=0, prepend=0)
@@ -343,8 +349,12 @@ class CommunityCanopyData(PandasExporter):
     fapar: NDArray[np.float64] = field(init=False)
     """The fraction of absorbed radiation for the whole community across layers."""
 
+    __experimental__ = True
+
     def __post_init__(self, cohort_transmissivity: NDArray[np.float64]) -> None:
         """Calculates community-wide canopy attributes from the input data."""
+
+        warn_experimental("CommunityCanopyData")
 
         # Aggregate across cohorts into a layer wide transmissivity
         self.f_trans = cohort_transmissivity.prod(axis=1)
@@ -384,6 +394,8 @@ class Canopy:
             closure heights (default: 0.001 metres)
     """
 
+    __experimental__ = True
+
     def __init__(
         self,
         community: Community,
@@ -392,6 +404,9 @@ class Canopy:
         canopy_gap_fraction: float = 0,
         solver_tolerance: float = 0.001,
     ) -> None:
+        # Warn that this is an experimental feature
+        warn_experimental("Canopy")
+
         # Store required init vars
         self.canopy_gap_fraction: float = canopy_gap_fraction
         """Canopy gap fraction."""

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -136,6 +136,7 @@ from marshmallow import Schema, fields, post_load, validate, validates_schema
 from marshmallow.exceptions import ValidationError
 from numpy.typing import NDArray
 
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.utilities import check_input_shapes
 from pyrealm.demography.core import CohortMethods, PandasExporter
 from pyrealm.demography.flora import Flora, StemTraits
@@ -168,11 +169,15 @@ class Cohorts(PandasExporter, CohortMethods):
     pft_names: NDArray[np.str_]
     n_cohorts: int = field(init=False)
 
+    __experimental__ = True
+
     def __post_init__(self) -> None:
         """Validation of cohorts data."""
 
         # TODO - validation - maybe make this optional to reduce workload within
         # simulations
+
+        warn_experimental("Cohorts")
 
         # Check cohort data types
         if not (
@@ -421,6 +426,8 @@ class Community:
     stem_traits: StemTraits = field(init=False)
     stem_allometry: StemAllometry = field(init=False)
 
+    __experimental__ = True
+
     def __post_init__(
         self,
     ) -> None:
@@ -429,6 +436,8 @@ class Community:
         The ``__post_init__`` builds a pandas dataframe of PFT values and T model
         predictions across the validated initial cohort data.
         """
+
+        warn_experimental("Community")
 
         # Check cell area and cell id
         if not (isinstance(self.cell_area, float | int) and self.cell_area > 0):

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -1,16 +1,15 @@
-"""Core shared functionality for the {mod}`~pyrealm.demography` module.
+"""This module provides shared functionality for the :mod:`~pyrealm.demography` module,
+implementing two abstract base classes that are used to share core methods across
+demography classes:
 
-This module implements two abstract base classes that are used to share core methods
-across demography classes:
-
-* {class}`~pyrealm.demography.core.PandasExporter` provides the utility
-  {meth}`~pyrealm.demography.core.PandasExporter.to_pandas` method for extracting data
+* :class:`~pyrealm.demography.core.PandasExporter` provides the utility
+  :meth:`~pyrealm.demography.core.PandasExporter.to_pandas` method for extracting data
   from demography classes for plotting and exploring data.
-* {class}`~pyrealm.demography.core.CohortMethods` provides the utility
-  {meth}`~pyrealm.demography.core.CohortMethods.add_cohort_data` and
-  {meth}`~pyrealm.demography.core.CohortMethods.drop_cohort_data` methods that are used
+* :class:`~pyrealm.demography.core.CohortMethods` provides the utility
+  :meth:`~pyrealm.demography.core.CohortMethods.add_cohort_data` and
+  :meth:`~pyrealm.demography.core.CohortMethods.drop_cohort_data` methods that are used
   to append new cohort data across some demography dataclasses.
-"""
+"""  # noqa: D205, D415
 
 from __future__ import annotations
 

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 import numpy as np
 from numpy.typing import NDArray
 
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.demography.core import (
     PandasExporter,
     _validate_demography_array_arguments,
@@ -283,6 +284,8 @@ class CrownProfile(PandasExporter):
     _n_stems: int = field(init=False)
     """The number of stems."""
 
+    __experimental__ = True
+
     def __post_init__(
         self,
         stem_traits: StemTraits | Flora,
@@ -290,6 +293,8 @@ class CrownProfile(PandasExporter):
         validate: bool,
     ) -> None:
         """Populate crown profile attributes from the traits, allometry and height."""
+
+        warn_experimental("CrownProfile")
 
         # If validation is required, only need to perform validation once to check that
         # the at_dbh values are congruent with the stem_traits inputs. If they are, then

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -11,6 +11,7 @@ from typing import ClassVar
 import numpy as np
 from numpy.typing import NDArray
 
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.demography.core import (
     CohortMethods,
     PandasExporter,
@@ -764,6 +765,8 @@ class StemAllometry(PandasExporter, CohortMethods):
     _n_stems: int = field(init=False)
     """The number of stems."""
 
+    __experimental__ = True
+
     def __post_init__(
         self,
         stem_traits: Flora | StemTraits,
@@ -771,6 +774,8 @@ class StemAllometry(PandasExporter, CohortMethods):
         validate: bool,
     ) -> None:
         """Populate the stem allometry attributes from the traits and size data."""
+
+        warn_experimental("StemAllometry")
 
         # If validation is required, only need to perform validation once to check that
         # the at_dbh values are congruent with the stem_traits inputs. If they are, then
@@ -921,6 +926,8 @@ class StemAllocation(PandasExporter):
     _n_stems: int = field(init=False)
     """The number of stems."""
 
+    __experimental__ = True
+
     def __post_init__(
         self,
         stem_traits: Flora | StemTraits,
@@ -929,6 +936,8 @@ class StemAllocation(PandasExporter):
         validate: bool,
     ) -> None:
         """Populate stem allocation attributes from the traits, allometry and GPP."""
+
+        warn_experimental("StemAllocation")
 
         if validate:
             _validate_demography_array_arguments(

--- a/pyrealm/pmodel/arrhenius.py
+++ b/pyrealm/pmodel/arrhenius.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 
 from numpy.typing import NDArray
 
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.pmodel.functions import (
     calculate_kattge_knorr_arrhenius_factor,
     calculate_simple_arrhenius_factor,
@@ -227,7 +228,11 @@ class KattgeKnorrArrhenius(
         array([0.70109])
     """
 
+    __experimental__ = True
+
     def _calculation_method(self, coefficients: dict) -> NDArray:
+        warn_experimental("KattgeKnorrArrhenius")
+
         return calculate_kattge_knorr_arrhenius_factor(
             tk_leaf=self.env.tk,
             tk_ref=self.env.pmodel_const.tk_ref,

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.constants import C3C4Const
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.utilities import check_input_shapes, summarize_attrs
 
 
@@ -181,6 +182,8 @@ class C3C4Competition:
     #      - Axis argument to aggregate values along a time axis?
     #        nansum for gpp  and nanmean for  DeltaC13/4_alone.
 
+    __experimental__ = True
+
     def __init__(
         self,
         gpp_c3: NDArray[np.float64],
@@ -190,6 +193,8 @@ class C3C4Competition:
         cropland: NDArray[np.float64],
         c3c4_const: C3C4Const = C3C4Const(),
     ):
+        warn_experimental("C3C4Competition")
+
         # Check inputs are congruent
         self.shape: tuple = check_input_shapes(
             gpp_c3, gpp_c4, treecover, cropland, below_t_min

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -6,13 +6,12 @@ which is used to support different implementations of the calculation of optimal
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from warnings import warn
 
 import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.constants import PModelConst
-from pyrealm.core.experimental import ExperimentalFeatureWarning
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.utilities import check_input_shapes, summarize_attrs
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
 
@@ -305,15 +304,13 @@ class OptimalChiPrentice14RootzoneStress(
         array([0.62016])
     """  # noqa D210, D415 - long but sane title line.
 
+    __experimental__ = True
+
     def set_beta(self) -> None:
         """Set ``beta`` to a constant C3 specific value."""
 
         # Warn that this is an experimental feature.
-        warn(
-            "The prentice14_rootzonestress method is experimental, "
-            "see the class documentation",
-            ExperimentalFeatureWarning,
-        )
+        warn_experimental("OptimalChiPrentice14RootzoneStress")
 
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
         self.beta = self.pmodel_const.beta_cost_ratio_c3
@@ -589,9 +586,10 @@ class OptimalChiLavergne20C4(
 
     .. NOTE::
 
-        This is an **experimental approach**. The research underlying
-        :cite:`lavergne:2020a`, found **no relationship** between C4 :math:`\beta`
-        values and soil moisture in leaf gas exchange measurements.
+        The research underlying :cite:`lavergne:2020a`, found **no relationship**
+        between C4 :math:`\beta` values and soil moisture in leaf gas exchange
+        measurements. This implementation asserts that there is a relationship and that
+        the relationship is consistent with the patterns found for C3 plants.
 
     Examples:
         >>> import numpy as np
@@ -614,14 +612,12 @@ class OptimalChiLavergne20C4(
         array([3.55989])
     """
 
+    __experimental__ = True
+
     def set_beta(self) -> None:
         """Set ``beta`` with soil moisture corrections."""
 
-        # Warn that this is an experimental feature.
-        warn(
-            "The lavergne20_c4 method is experimental, see the method documentation",
-            ExperimentalFeatureWarning,
-        )
+        warn_experimental("OptimalChiLavergne20C4")
 
         # Calculate beta as a function of theta
         self.beta = np.exp(
@@ -767,8 +763,12 @@ class OptimalChiC4NoGammaRootzoneStress(
         array([0.21583])
     """  # noqa D210, D415 - long but sane title line.
 
+    __experimental__ = True
+
     def set_beta(self) -> None:
         """Set constant ``beta`` for C4 plants."""
+
+        warn_experimental("OptimalChiC4NoGammaRootzoneStress")
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
         self.beta = self.pmodel_const.beta_cost_ratio_c4

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -299,7 +299,7 @@ class QuantumYieldSandoval(
         """Calculate kphio."""
 
         # Warn that this is an experimental feature.
-        warn_experimental("QuantumYieldSandoval._calculate_kphio")
+        warn_experimental("QuantumYieldSandoval")
 
         aridity_index = getattr(self.env, "aridity_index")
         mean_growth_temperature = getattr(self.env, "mean_growth_temperature")

--- a/pyrealm/pmodel/two_leaf.py
+++ b/pyrealm/pmodel/two_leaf.py
@@ -4,7 +4,7 @@ implementation in the BESS model.
 
 The module provides two core classes:
 
-* The :class:`~pyrealm.pmodel.two_leaf.TwoLeafIrradience` class can be used to estimate
+* The :class:`~pyrealm.pmodel.two_leaf.TwoLeafIrradiance` class can be used to estimate
   the irradiance absorbed by sunlit and shaded leaves, given the solar elevation angle,
   the atmospheric pressure, the leaf area index and the photosynthetic photon flux
   density.
@@ -28,6 +28,7 @@ from numpy.typing import NDArray
 from pyrealm.constants.core_const import CoreConst
 from pyrealm.constants.two_leaf import TwoLeafConst
 from pyrealm.core.bounds import BoundsChecker
+from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.utilities import check_input_shapes
 from pyrealm.pmodel.pmodel import PModel, SubdailyPModel
 
@@ -36,7 +37,7 @@ from pyrealm.pmodel.pmodel import PModel, SubdailyPModel
 # ------------------------------
 
 
-class TwoLeafIrradience:
+class TwoLeafIrradiance:
     r"""Calculate the irradiance absorbed by sunlit and shaded leaves.
 
     The two leaf, two stream model of :cite:t:`depury:1997a` partitions the irradiance
@@ -83,6 +84,8 @@ class TwoLeafIrradience:
         bounds_checker: A bounds checker instance used to validate the input data.
     """
 
+    __experimental__ = True
+
     def __init__(
         self,
         solar_elevation: NDArray[np.float64],
@@ -93,6 +96,8 @@ class TwoLeafIrradience:
         two_leaf_constants: TwoLeafConst = TwoLeafConst(),
         bounds_checker: BoundsChecker = BoundsChecker(),
     ):
+        warn_experimental("TwoLeafIrradiance")
+
         # Check shapes are consistent
         check_input_shapes(solar_elevation, ppfd, leaf_area_index, patm)
 
@@ -533,7 +538,7 @@ class TwoLeafAssimilation:
     separately estimates the assimilation by sunlit and shaded leaves.
 
     The class requires an estimate of the irradiances absorbed by the sunlit and shaded
-    leaves, calculated using the :class:`~pyrealm.pmodel.two_leaf.TwoLeafIrradience`
+    leaves, calculated using the :class:`~pyrealm.pmodel.two_leaf.TwoLeafIrradiance`
     class. It also requires a :class:`~pyrealm.pmodel.pmodel.PModel` or
     :class:`~pyrealm.pmodel.pmodel.SubdailyPModel` instance, which is used to provide
     estimates of four parameters:
@@ -590,12 +595,16 @@ class TwoLeafAssimilation:
         irrad: An instance of TwoLeafIrradiance.
     """
 
+    __experimental__ = True
+
     def __init__(
         self,
         pmodel: PModel | SubdailyPModel,
-        irradiance: TwoLeafIrradience,
+        irradiance: TwoLeafIrradiance,
     ):
         """Initialize the TwoLeafAssimilation class."""
+
+        warn_experimental("TwoLeafAssimilation")
 
         self.pmodel = pmodel
         """A PModel or SubdailyPModel instance."""

--- a/tests/regression/two_leaf_canopy/test_two_leaf_model.py
+++ b/tests/regression/two_leaf_canopy/test_two_leaf_model.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 
 from pyrealm.pmodel import PModel
 from pyrealm.pmodel.pmodel_environment import PModelEnvironment
-from pyrealm.pmodel.two_leaf import TwoLeafAssimilation, TwoLeafIrradience
+from pyrealm.pmodel.two_leaf import TwoLeafAssimilation, TwoLeafIrradiance
 
 
 @pytest.fixture
@@ -27,14 +27,14 @@ def solar_elevation():
 
 @pytest.fixture
 def solar_irradiance(solar_elevation, get_data):
-    """Creates instace of TwoLeafIrradience class."""
+    """Creates instace of TwoLeafIrradiance class."""
 
     data = get_data.loc[(get_data["time"] == "2014-08-01 12:30:00")]
 
     PPFD = data["ppfd"].to_numpy()
     LAI = data["LAI"].to_numpy()
     PATM = data["patm"].to_numpy()
-    result = TwoLeafIrradience(solar_elevation, PPFD, LAI, PATM)
+    result = TwoLeafIrradiance(solar_elevation, PPFD, LAI, PATM)
 
     return result
 

--- a/tests/unit/pmodel/two_leaf/test_two_leaf_classes.py
+++ b/tests/unit/pmodel/two_leaf/test_two_leaf_classes.py
@@ -55,12 +55,12 @@ import pytest
         ),
     ),
 )
-def test_TwoLeafIrradience(args, outcome, msg):
-    """Tests initialisation conditions of TwoLeafIrradience."""
-    from pyrealm.pmodel.two_leaf import TwoLeafIrradience
+def test_TwoLeafIrradiance(args, outcome, msg):
+    """Tests initialisation conditions of TwoLeafIrradiance."""
+    from pyrealm.pmodel.two_leaf import TwoLeafIrradiance
 
     with outcome as outc:
-        two_leaf = TwoLeafIrradience(**args)
+        two_leaf = TwoLeafIrradiance(**args)
 
         # Check the calculated attributes have been populated and have the right shape
         assert hasattr(two_leaf, "sunlit_absorbed_irradiance")
@@ -76,7 +76,7 @@ def test_TwoLeafAssimilation():
     """Test the creation of a TwoLeafAssimilation instance."""
 
     from pyrealm.pmodel import PModel, PModelEnvironment
-    from pyrealm.pmodel.two_leaf import TwoLeafAssimilation, TwoLeafIrradience
+    from pyrealm.pmodel.two_leaf import TwoLeafAssimilation, TwoLeafIrradiance
 
     model = PModel(
         env=PModelEnvironment(
@@ -89,7 +89,7 @@ def test_TwoLeafAssimilation():
         )
     )
 
-    irrad = TwoLeafIrradience(
+    irrad = TwoLeafIrradiance(
         solar_elevation=np.array([0.7]),
         patm=np.array([100000]),
         ppfd=np.array([1500]),


### PR DESCRIPTION
# Description

Following on from #453, this PR is to apply the experimental warnings to the main experimental classes. I haven't marked up all of the functions.

It also fixes a typo in a class name (`TwoLeafIrradience` to `TwoLeafIrradiance`) and does some other snagging.

Fixes #467 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
