### PR TITLE
Updating CohortMethods to handle a count attribute in subclasses

### DIFF
--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -438,7 +438,7 @@ class Canopy:
 
         # Set simple attributes
         self.max_stem_height = community.stem_allometry.stem_height.max()
-        self.n_cohorts = community.number_of_cohorts
+        self.n_cohorts = community.n_cohorts
         self.filled_community_area = community.cell_area * (
             1 - self.canopy_gap_fraction
         )

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -162,6 +162,7 @@ class Cohorts(PandasExporter, CohortMethods):
     array_attrs: ClassVar[tuple[str, ...]] = tuple(
         ["dbh_values", "n_individuals", "pft_names"]
     )
+    count_attr: ClassVar[str] = "n_cohorts"
 
     # Instance attributes
     dbh_values: NDArray[np.float64]
@@ -422,7 +423,7 @@ class Community:
     cohorts: Cohorts
 
     # Post init properties
-    number_of_cohorts: int = field(init=False)
+    n_cohorts: int = field(init=False)
     stem_traits: StemTraits = field(init=False)
     stem_allometry: StemAllometry = field(init=False)
 
@@ -447,7 +448,7 @@ class Community:
             raise ValueError("Community cell id must be a integer >= 0.")
 
         # How many cohorts
-        self.number_of_cohorts = len(self.cohorts.dbh_values)
+        self.n_cohorts = self.cohorts.n_cohorts
 
         # Get the stem traits for the cohorts
         self.stem_traits = self.flora.get_stem_traits(self.cohorts.pft_names)
@@ -560,6 +561,8 @@ class Community:
         self.stem_traits.drop_cohort_data(drop_indices=drop_indices)
         self.stem_allometry.drop_cohort_data(drop_indices=drop_indices)
 
+        self.n_cohorts = self.cohorts.n_cohorts
+
     def add_cohorts(self, new_data: Cohorts) -> None:
         """Add a new set of cohorts to the community.
 
@@ -580,6 +583,8 @@ class Community:
             stem_traits=new_stem_traits, at_dbh=new_data.dbh_values
         )
         self.stem_allometry.add_cohort_data(new_data=new_stem_allometry)
+
+        self.n_cohorts = self.cohorts.n_cohorts
 
     # @classmethod
     # def load_communities_from_csv(

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -491,6 +491,7 @@ class StemTraits(PandasExporter, CohortMethods):
     array_attrs: ClassVar[tuple[str, ...]] = tuple(
         f.name for f in fields(PlantFunctionalTypeStrict)
     )
+    count_attr: ClassVar[str] = "_n_stems"
 
     # Instance trait attributes
     name: NDArray[np.str_]

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -892,6 +892,7 @@ class StemAllometry(PandasExporter, CohortMethods):
         "crown_r0",
         "crown_z_max",
     )
+    count_attr: ClassVar[str] = "_n_stems"
 
     # Init vars
     stem_traits: InitVar[Flora | StemTraits]

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -134,8 +134,11 @@ def test_Cohorts_CohortMethods():
     # Check success of adding and dropping data
     cohorts.add_cohort_data(new_data=cohorts)
     assert_allclose(cohorts.dbh_values, np.array([0.2, 0.5, 0.2, 0.5]))
+    assert cohorts.n_cohorts == 4
+
     cohorts.drop_cohort_data(drop_indices=np.array([0, 2]))
     assert_allclose(cohorts.dbh_values, np.array([0.5, 0.5]))
+    assert cohorts.n_cohorts == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/demography/test_flora.py
+++ b/tests/unit/demography/test_flora.py
@@ -434,6 +434,7 @@ def test_StemTraits_CohortMethods(fixture_flora):
     args = {ky: np.concatenate([val, val]) for ky, val in flora_df.items()}
 
     stem_traits = StemTraits(**args)
+    assert stem_traits._n_stems == 2 * fixture_flora.n_pfts
 
     # Check failure mode
     with pytest.raises(ValueError) as excep:
@@ -448,8 +449,10 @@ def test_StemTraits_CohortMethods(fixture_flora):
     stem_traits.add_cohort_data(new_data=stem_traits)
     assert stem_traits.h_max.shape == (4 * fixture_flora.n_pfts,)
     assert stem_traits.h_max.sum() == 4 * flora_df["h_max"].sum()
+    assert stem_traits._n_stems == 4 * fixture_flora.n_pfts
 
     # Remove all but the first two rows and what's left should be aligned with the
     # original data
     stem_traits.drop_cohort_data(drop_indices=np.arange(2, 8))
     assert_allclose(stem_traits.h_max, flora_df["h_max"])
+    assert stem_traits._n_stems == fixture_flora.n_pfts

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -816,6 +816,9 @@ def test_StemAllometry_CohortMethods(rtmodel_flora, rtmodel_data):
     )
     check_data = stem_allometry.crown_fraction.copy()
 
+    # Check the count attribute
+    assert stem_allometry._n_stems == rtmodel_flora.n_pfts
+
     # Check failure mode
     with pytest.raises(ValueError) as excep:
         stem_allometry.add_cohort_data(new_data=dict(a=1))
@@ -831,11 +834,13 @@ def test_StemAllometry_CohortMethods(rtmodel_flora, rtmodel_data):
     stem_allometry.add_cohort_data(new_data=stem_allometry)
     assert stem_allometry.crown_fraction.shape == (n_entries, 2 * rtmodel_flora.n_pfts)
     assert stem_allometry.crown_fraction.sum() == 2 * check_data.sum()
+    assert stem_allometry._n_stems == 2 * rtmodel_flora.n_pfts
 
     # Remove the rows from the first copy and what's left should be aligned with the
     # original data
     stem_allometry.drop_cohort_data(drop_indices=np.arange(rtmodel_flora.n_pfts))
     assert_allclose(stem_allometry.crown_fraction, check_data)
+    assert stem_allometry._n_stems == rtmodel_flora.n_pfts
 
 
 def test_StemAllocation(rtmodel_flora, rtmodel_data):


### PR DESCRIPTION
# Description

The classes inheriting from `pyrealm.demography.core.CohortMethods` all have an attribute (`n_cohorts`, `n_pfts`, `_n_stems`) that just provide a simple count of the number of things being stored in the class. The `add_cohorts` and `drop_cohorts` methods do not currently update those counts.

This PR adds a new class attribute to those subclasses (`count_attr`) that identifies the instance attribute name used to store the count. The `add_cohorts` and `drop_cohorts` methods now update those attributes. In addition, the `Community.add_cohorts` and ``Community.drop_cohorts` now also update `Community.n_cohorts` - this method is independent of `pyrealm.demography.core.CohortMethods` because it has to update multiple data classes - but still needs to track the count correctly.

Fixes #478

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
