### PR TITLE
Broadcastable array inputs

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -45,6 +45,8 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest -m "not profiling and not broadcasting" --cov-report xml
+
+    - name: Run broadcasting tests
       run: poetry run pytest -m "broadcasting"
 
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -44,7 +44,8 @@ jobs:
       run: poetry install
 
     - name: Run tests
-      run: poetry run pytest -m "not profiling" --cov-report xml
+      run: poetry run pytest -m "not profiling and not broadcasting" --cov-report xml
+      run: poetry run pytest -m "broadcasting"
 
     - name: Upload coverage reports to Codecov
       id: codecov

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -16,7 +16,7 @@ class AnnualValueCalculator:
 
     This class is used to calculate annual means and totals from time series data. An
     instance is created by providing a set of timings for the times series data, either
-    as an an array of datetimes or as an AcclimationModel instance from a
+    as a one-dimensional array of datetimes or as an AcclimationModel instance from a
     SubdailyPModel, which provides validated datetimes at subdaily temporal resolutions.
 
     The calculation process accounts for observations that span year boundaries, such as
@@ -100,11 +100,12 @@ class AnnualValueCalculator:
             or (
                 isinstance(timing, np.ndarray)
                 and np.issubdtype(timing.dtype, np.datetime64)
+                and timing.ndim == 1
             )
         ):
             raise ValueError(
                 "The timings argument must be an AcclimationModel "
-                "or an array of datetime64 values"
+                "or a one-dimensional array of datetime64 values"
             )
 
         if isinstance(timing, AcclimationModel):
@@ -316,6 +317,12 @@ class AnnualValueCalculator:
         else:
             weights = self.duration_weights
 
+        # Make weights broadcastable in case vals is multidimensional
+        if values.ndim > 1:
+            for i, wghts in enumerate(weights):
+                shape = (wghts.shape[0],) + (1,) * (values.ndim - 1)
+                weights[i] = wghts.reshape(shape)
+
         # Calculate the weighted mean in a np.nan friendly way: the product of np.nan
         # and a weight is np.nan and the isnan term omits the weights of nan
         # observations from the weighted average.
@@ -376,6 +383,12 @@ class AnnualValueCalculator:
             ]
         else:
             weights = self.fractional_weights
+
+        # Make weights broadcastable in case vals is multidimensional
+        if values.ndim > 1:
+            for i, wghts in enumerate(weights):
+                shape = (wghts.shape[0],) + (1,) * (values.ndim - 1)
+                weights[i] = wghts.reshape(shape)
 
         return np.array(
             [np.nansum(vals * wghts) for vals, wghts in zip(values_by_year, weights)]

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -33,7 +33,7 @@ class AnnualValueCalculator:
     the ``year_completeness`` attribute records what fraction of a year has been sampled
     to give a particular value.
 
-    .. Note:
+    .. Note::
 
         The class handles a wide range of different possible sampling frequencies and
         calculates weights for observations using the duration of observations with
@@ -289,6 +289,10 @@ class AnnualValueCalculator:
         the observations marked as the growing season are set to zero. The calculation
         handles missing values.
 
+        The annual means can be computed for a range of different sites by using n-D
+        array for ``values``. In this case time is assumed along axis 0 and so an n-D
+        array will be returned with annual values along axis 0.
+
         Example:
             >>> # Three years of monthly data
             >>> datetimes = np.arange(
@@ -330,6 +334,7 @@ class AnnualValueCalculator:
         # Calculate the weighted mean in a np.nan friendly way: the product of np.nan
         # and a weight is np.nan and the isnan term omits the weights of nan
         # observations from the weighted average.
+        # The mean is computed along just the time (0) axis.
         return np.array(
             [
                 np.nansum(vals * wghts, axis=0)
@@ -351,6 +356,10 @@ class AnnualValueCalculator:
         ``True``, the weights for observations not identified as growing season values
         are set to zero. The method handles missing data (`np.nan`) but obviously the
         resulting annual total will be reduced.
+
+        The annual totals can be computed for a range of different sites by using an n-D
+        array for ``values``. In this case time is assumed along axis 0 and so an n-D
+        array will be returned with annual values along axis 0.
 
         Example:
             >>> # Three years of monthly data with incomplete years at start and end
@@ -395,6 +404,7 @@ class AnnualValueCalculator:
                 shape = (wghts.shape[0],) + (1,) * (values.ndim - 1)
                 weights[i] = wghts.reshape(shape)
 
+        # The total is computed along just the time (0) axis.
         return np.array(
             [
                 np.nansum(vals * wghts, axis=0)

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -1,6 +1,7 @@
 """This module provides general tools for working with time series data. It currently
 provides the :class:`AnnualValueCalculator`, which is used to calculate annual means and
-totals of time series data.
+totals of time series data, and :func:`broadcast_time`, which is used to broadcast
+arrays over the time axis.
 """  # noqa : D205
 
 from itertools import pairwise
@@ -411,3 +412,32 @@ class AnnualValueCalculator:
                 for vals, wghts in zip(values_by_year, weights)
             ]
         )
+
+
+def broadcast_time(values: NDArray, shape: tuple[int, ...]) -> NDArray:
+    """Broadcast an array along the time (zeroth) axis.
+
+    The ``values`` array must be broadcastable to the full shape, however it does not
+    need the full set of dimensions as defined by ``shape``. The returned array will
+    have the full set of dimensions, and be broadcast along just the zeroth axis.
+
+    Example:
+        >>> broadcast_time(np.ones((1,3)), (2,3))
+        array([[1., 1., 1.],
+               [1., 1., 1.]])
+        >>> broadcast_time(np.ones(3), (2,2,3)).shape
+        (2, 1, 3)
+
+    Args:
+        values: The array to broadcast.
+        shape: The full n-dimensional shape, where the first value is the length of the
+            time axis to broadcast over.
+    """
+    if values.ndim > len(shape):
+        raise ValueError("The input array has more dimensions than the broadcast shape")
+    # Get any missing axes
+    full_shape = (1,) * (len(shape) - len(values.shape)) + values.shape
+    # Define the shape to broadcast to
+    bcast_shape = (shape[0], *full_shape[1:])
+    # Return the broadcasted array
+    return np.broadcast_to(values, bcast_shape)

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -264,7 +264,11 @@ class AnnualValueCalculator:
             values: An array of values.
         """
 
-        if values.shape[0] != self.n_obs:
+        if values.shape[0] == 1:
+            # Broadcast to match the number of observations if constant
+            values = np.broadcast_to(values, (self.n_obs, *values.shape[1:]))
+
+        elif values.shape[0] != self.n_obs:
             raise ValueError(
                 "First axis of values shape does not match number of observations."
             )
@@ -328,7 +332,8 @@ class AnnualValueCalculator:
         # observations from the weighted average.
         return np.array(
             [
-                np.nansum(vals * wghts) / np.nansum(~np.isnan(vals) * wghts)
+                np.nansum(vals * wghts, axis=0)
+                / np.nansum(~np.isnan(vals) * wghts, axis=0)
                 for vals, wghts in zip(values_by_year, weights)
             ]
         )
@@ -391,5 +396,8 @@ class AnnualValueCalculator:
                 weights[i] = wghts.reshape(shape)
 
         return np.array(
-            [np.nansum(vals * wghts) for vals, wghts in zip(values_by_year, weights)]
+            [
+                np.nansum(vals * wghts, axis=0)
+                for vals, wghts in zip(values_by_year, weights)
+            ]
         )

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -17,9 +17,10 @@ from numpy.typing import NDArray
 def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> tuple:
     """Check sets of input variables have congruent shapes.
 
-    This helper function validates inputs to check that they are either scalars or
-    arrays and then that any arrays of the same shape. It returns a tuple of the common
-    shape of the arguments, which is (1,) if all the arguments are scalar.
+    This helper function validates inputs to check that they are either scalars
+    or arrays and that any arrays are of (or broadcastable to) the same
+    shape. It returns a tuple of the common shape of the arguments, which is
+    (1,) if all the arguments are scalar.
 
     Parameters:
         *args: A set of numpy arrays or scalar values
@@ -64,10 +65,13 @@ def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> t
         else:
             raise ValueError(f"Unexpected input to check_input_shapes: {type(val)}")
 
-    # shapes can be an empty set (all scalars) or contain one common shape
-    # otherwise raise an error
+    # shapes can be an empty set (all scalars) or (broadcastable to) one common
+    # shape, otherwise raise an error
     if len(shapes) > 1:
-        raise ValueError("Inputs contain arrays of different shapes.")
+        try:
+            return np.broadcast_shapes(*shapes)
+        except ValueError:
+            raise ValueError("Inputs contain arrays of different shapes.")
 
     if len(shapes) == 1:
         return shapes.pop()

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -54,7 +54,7 @@ def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> t
         if isinstance(val, np.ndarray):
             # Note that 0-dim ndarrays (which are scalars) pass through as do
             # one dimensional arrays with a single value (also a scalar)
-            if val.size > 1:
+            if val.size > 1 or val.ndim > 1:
                 shapes.add(val.shape)
         # elif isinstance(val, Series):
         #    # Note that 0-dim ndarrays (which are scalars) pass through

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -14,36 +14,46 @@ import tabulate
 from numpy.typing import NDArray
 
 
-def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> tuple:
-    """Check sets of input variables have congruent shapes.
+def check_input_shapes(
+    *args: float | int | np.generic | np.ndarray | None,
+    shape: tuple[int, ...] | None = None,
+) -> tuple:
+    """Check sets of input variables have congruent shapes with equal dimensions.
 
-    This helper function validates inputs to check that they are either scalars
-    or arrays and that any arrays are of (or broadcastable to) the same
-    shape. It returns a tuple of the common shape of the arguments, which is
+    This helper function validates inputs to check that they are either scalars or
+    arrays and that any arrays have the same number of dimensions and are broadcastable
+    to the same shape. It returns a tuple of the common shape of the arguments, which is
     (1,) if all the arguments are scalar.
 
     Parameters:
         *args: A set of numpy arrays or scalar values
+        shape: An optional expected result for the common shape.
 
     Returns:
         The common shape of any array inputs or 1 if all inputs are scalar.
 
     Raises:
-        ValueError: if the inputs contain arrays of differing shapes.
+        ValueError: if the inputs contain arrays of differing shapes or dimensions.
 
     Examples:
         >>> check_input_shapes(np.array([1,2,3]), 5)
         (3,)
         >>> check_input_shapes(4, 5)
         (1,)
-        >>> check_input_shapes(np.array([1,2,3]), np.array([1,2]))
+        >>> check_input_shapes(np.array([1,2,3]), np.array([1,2,4]))
         Traceback (most recent call last):
         ...
         ValueError: Inputs contain arrays of different shapes.
+        >>> check_input_shapes(np.array([1,2,3]), np.array([2,3]))
+        Traceback (most recent call last):
+        ...
+        ValueError: Inputs contain arrays of different dimensions.
     """
 
     # Collect the shapes of the inputs
     shapes = set()
+    if shape:
+        shapes.add(shape)
 
     # DESIGN NOTES - currently allow:
     #   - scalars,
@@ -68,6 +78,9 @@ def check_input_shapes(*args: float | int | np.generic | np.ndarray | None) -> t
     # shapes can be an empty set (all scalars) or (broadcastable to) one common
     # shape, otherwise raise an error
     if len(shapes) > 1:
+        ndims = {len(shape) for shape in shapes}
+        if len(ndims) > 1:
+            raise ValueError("Inputs contain arrays of different dimensions.")
         try:
             return np.broadcast_shapes(*shapes)
         except ValueError:

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -40,11 +40,11 @@ def check_input_shapes(
         (3,)
         >>> check_input_shapes(4, 5)
         (1,)
-        >>> check_input_shapes(np.array([1,2,3]), np.array([1,2,4]))
+        >>> check_input_shapes(np.ones((1,2,3)), np.ones((1,2,4)))
         Traceback (most recent call last):
         ...
         ValueError: Inputs contain arrays of different shapes.
-        >>> check_input_shapes(np.array([1,2,3]), np.array([2,3]))
+        >>> check_input_shapes(np.ones((1,2,3)), np.ones((2,3)))
         Traceback (most recent call last):
         ...
         ValueError: Inputs contain arrays of different dimensions.

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -305,8 +305,8 @@ class CommunityCanopyData(PandasExporter):
     ground below the canopy is stored as the `transmission_to_ground` attribute.
 
     Args:
-        layer_absorption: The expected light absorption for cohorts within each layer.
-        layer_leaf_area_index: The leaf area index of cohorts within layers.
+        absorption: The expected light absorption for cohorts within each layer.
+        leaf_area_index: The leaf area index of cohorts within layers.
         cohort_leaf_area: The total leaf area of each cohort in each layer.
         cell_area: The area of the cell containing the community.
     """

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -275,7 +275,7 @@ class Flora(PandasExporter):
     """
 
     # The only init argument.
-    pfts: InitVar[Sequence[type[PlantFunctionalTypeStrict]]]
+    pfts: InitVar[Sequence[PlantFunctionalTypeStrict]]
     r"""A sequence of plant functional type instances to include in the Flora."""
 
     # A class variable setting the names of PFT traits held as arrays.
@@ -333,7 +333,7 @@ class Flora(PandasExporter):
     """Proportion of stem height at which maximum crown radius is found."""
 
     # - other instance attributes
-    pft_dict: dict[str, type[PlantFunctionalTypeStrict]] = field(init=False)
+    pft_dict: dict[str, PlantFunctionalTypeStrict] = field(init=False)
     """A dictionary of the original plant functional type instances, keyed by name."""
     pft_indices: dict[str, int] = field(init=False)
     """An dictionary giving the index of each PFT name in the trait array attributes."""
@@ -347,7 +347,7 @@ class Flora(PandasExporter):
     gpp_topslice: NDArray[np.float64] = field(init=False)
     """Proportion of GPP to topslice before allocation."""
 
-    def __post_init__(self, pfts: Sequence[type[PlantFunctionalTypeStrict]]) -> None:
+    def __post_init__(self, pfts: Sequence[PlantFunctionalTypeStrict]) -> None:
         # Check the PFT data
         if (not isinstance(pfts, Sequence)) or (
             not all([isinstance(v, PlantFunctionalTypeStrict) for v in pfts])

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -127,7 +127,7 @@ class FaparLimitation:
         self._check_shapes()
 
         # Make sure the aridity index is not zero
-        if aridity_index <= 0:
+        if np.any(aridity_index <= 0):
             raise ValueError("The aridity index has to be positive.")
 
         # Constants used for phenology computations

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -226,9 +226,11 @@ class C3C4Competition:
         # Step 4: remove areas below minimum temperature
         # mypy - this is a short term fix awaiting better resolution of mixed scalar and
         #        array inputs.
+        below_t_min = np.broadcast_to(below_t_min, self.shape)
         frac_c4[below_t_min] = 0  # type: ignore
 
         # Step 5: remove cropland areas
+        cropland = np.broadcast_to(cropland, self.shape)
         frac_c4[cropland] = np.nan  # type: ignore
 
         self.frac_c4: NDArray[np.float64] = frac_c4

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -189,8 +189,8 @@ class C3C4Competition:
         gpp_c3: NDArray[np.float64],
         gpp_c4: NDArray[np.float64],
         treecover: NDArray[np.float64],
-        below_t_min: NDArray[np.float64],
-        cropland: NDArray[np.float64],
+        below_t_min: NDArray[np.bool],
+        cropland: NDArray[np.bool],
         c3c4_const: C3C4Const = C3C4Const(),
     ):
         warn_experimental("C3C4Competition")

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -598,7 +598,9 @@ class SubdailyPModel(PModelABC):
 
     Args:
         env: An instance of
-           :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`
+           :class:`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`. The first
+           dimension of the data must be time with an equal length to the acclimation
+           model or a length of 1 if constant in time.
         acclim_model: An instance of
             :class:`~pyrealm.pmodel.acclimation.AcclimationModel`
         method_kphio: The method to use for calculating the quantum yield
@@ -705,10 +707,11 @@ class SubdailyPModel(PModelABC):
         # Store the acclimation model
         self.acclim_model = acclim_model
 
-        if self.acclim_model.datetimes.shape[0] != self.env.tc.shape[0]:
+        datetimes = self.acclim_model.datetimes
+        if self.shape[0] not in (datetimes.shape[0], 1):
             raise ValueError(
-                "The PModelEnvironment data and AcclimationModel datetimes "
-                "are of different lengths."
+                "The first dimension of the PModelEnvironment data is a different "
+                "length to the number of AcclimationModel datetimes."
             )
 
         if not hasattr(self.acclim_model, "include"):
@@ -747,7 +750,7 @@ class SubdailyPModel(PModelABC):
 
             try:
                 for values in previous_realised.values():
-                    _ = np.broadcast_shapes(self.env.tc.shape, values.shape)
+                    _ = np.broadcast_shapes(self.shape, values.shape)
             except ValueError:
                 raise ValueError(
                     "`previous_realised` arrays have wrong shape in SubdailyPModel"
@@ -779,8 +782,15 @@ class SubdailyPModel(PModelABC):
         for env_var_name in daily_environment_vars:
             env_var = getattr(self.env, env_var_name)
             if env_var is not None:
+                # Broadcast the first dimension (if constant) since the acclimation
+                # model requires this dimension to be equal to the number of times
+                env_var_shape = (1,) * (len(self.shape) - env_var.ndim) + env_var.shape
+                env_var_bcast = np.broadcast_to(
+                    env_var,
+                    [datetimes.shape[0], *env_var_shape[1:]],
+                )
                 daily_environment[env_var_name] = self.acclim_model.get_daily_means(
-                    values=env_var,
+                    values=env_var_bcast,
                 )
 
         # Calculate the acclimation environment passing on the constants definitions.

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -79,14 +79,13 @@ class DailyEvapFluxes:
         state when iterating over time.
         """
 
-        # Check input shapes are valid and broadcast along the time axis
-        # This is necessary because of the indexing in estimate_aet
-        # solar.nu is used because it should have the full time length
-        shape = check_input_shapes(pa, tc, self.solar.nu)
+        self.shape: tuple = check_input_shapes(pa, tc, shape=self.solar.shape)
+        """The array shape of the input variables"""
 
+        # Broadcast along the time axis (necessary for the indexing in estimate_aet)
         def bcast_time(var: NDArray) -> NDArray:
-            full_shape = (1,) * (len(shape) - len(var.shape)) + var.shape
-            bcast_shape = (len(self.solar.dates), *full_shape[1:])
+            full_shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
+            bcast_shape = (self.shape[0], *full_shape[1:])
             return np.broadcast_to(var, bcast_shape)
 
         pa = bcast_time(pa)
@@ -148,10 +147,10 @@ class DailyEvapFluxes:
         # subset the calculations to particular request days or use the entire array of
         # soil moisture. The slice here is used to programatically select `array[:]`.
         if day_idx is None:
-            check_input_shapes(wn, self.sat)
-            didx: int | slice = slice(self.sat.shape[0])
+            check_input_shapes(wn, shape=self.shape)
+            didx: int | slice = slice(self.shape[0])
         else:
-            check_input_shapes(wn, self.sat[day_idx])
+            check_input_shapes(wn, shape=self.shape[1:])
             didx = day_idx
 
         # Calculate evaporative supply rate (sw), mm/h

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -79,6 +79,19 @@ class DailyEvapFluxes:
         state when iterating over time.
         """
 
+        # Check input shapes are valid and broadcast along the time axis
+        # This is necessary because of the indexing in estimate_aet
+        # solar.nu is used because it should have the full time length
+        shape = check_input_shapes(pa, tc, self.solar.nu)
+
+        def bcast_time(var: NDArray) -> NDArray:
+            full_shape = (1,) * (len(shape) - len(var.shape)) + var.shape
+            bcast_shape = (len(self.solar.dates), *full_shape[1:])
+            return np.broadcast_to(var, bcast_shape)
+
+        pa = bcast_time(pa)
+        tc = bcast_time(tc)
+
         # Slope of saturation vap press temp curve, Pa/K
         self.sat = calc_saturation_vapour_pressure_slope(tc)
 

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -80,8 +80,15 @@ class DailyEvapFluxes:
         state when iterating over time.
         """
 
-        self.shape: tuple = check_input_shapes(pa, tc, shape=self.solar.shape)
-        """The array shape of the input variables"""
+        try:
+            self.shape: tuple = check_input_shapes(pa, tc, shape=self.solar.shape)
+            """The array shape of the input variables"""
+        except ValueError:
+            msg = (
+                "The shape of DailyEvapFluxes inputs are inconsistent with each other "
+                "or the DailySolarFluxes data"
+            )
+            raise ValueError(msg)
 
         # Broadcast along the time axis (necessary for the indexing in estimate_aet)
         pa = broadcast_time(pa, self.shape)
@@ -143,11 +150,16 @@ class DailyEvapFluxes:
         # subset the calculations to particular request days or use the entire array of
         # soil moisture. The slice here is used to programatically select `array[:]`.
         if day_idx is None:
-            check_input_shapes(wn, shape=self.shape)
+            splash_shape = self.shape
             didx: int | slice = slice(self.shape[0])
         else:
-            check_input_shapes(wn, shape=self.shape[1:])
+            splash_shape = self.shape[1:]
             didx = day_idx
+        try:
+            check_input_shapes(wn, shape=splash_shape)
+        except ValueError:
+            msg = "The shape of wn does not match the existing SPLASH model data"
+            raise ValueError(msg)
 
         # Calculate evaporative supply rate (sw), mm/h
         sw = self.core_const.k_Cw * wn / self.kWm

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -13,6 +13,7 @@ from pyrealm.core.hygro import (
     calc_psychrometric_constant,
     calc_saturation_vapour_pressure_slope,
 )
+from pyrealm.core.time_series import broadcast_time
 from pyrealm.core.utilities import check_input_shapes
 from pyrealm.core.water import calc_density_h2o
 from pyrealm.splash.solar import DailySolarFluxes
@@ -83,13 +84,8 @@ class DailyEvapFluxes:
         """The array shape of the input variables"""
 
         # Broadcast along the time axis (necessary for the indexing in estimate_aet)
-        def bcast_time(var: NDArray) -> NDArray:
-            full_shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
-            bcast_shape = (self.shape[0], *full_shape[1:])
-            return np.broadcast_to(var, bcast_shape)
-
-        pa = bcast_time(pa)
-        tc = bcast_time(tc)
+        pa = broadcast_time(pa, self.shape)
+        tc = broadcast_time(tc, self.shape)
 
         # Slope of saturation vap press temp curve, Pa/K
         self.sat = calc_saturation_vapour_pressure_slope(tc)

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -93,9 +93,10 @@ class DailySolarFluxes:
 
         # Validate the inputs
         shapes = check_input_shapes(latitude, elevation, sunshine_fraction, temperature)
-        if len(self.dates) != shapes[0]:
+        if shapes[0] not in (len(self.dates), 1):
             raise ValueError(
-                "The calendar is not the same length as the first axis of inputs "
+                "The first axis of inputs is neither the same as the calendar or length"
+                " one (constant in time)"
             )
 
         # Calculate heliocentric longitudes (nu and lambda), Berger (1978)
@@ -118,7 +119,7 @@ class DailySolarFluxes:
         # the other inputs. These need to be broadcastable to the shape of the other
         # inputs. The expand_dims variable gets a list of the axes to expand onto -
         # which will be an empty list when ndim=1, leaving the targets unchanged.
-        expand_dims = list(np.arange(1, elevation.ndim))
+        expand_dims = list(np.arange(1, len(shapes)))
         self.nu = np.expand_dims(nu, axis=expand_dims)
         self.lambda_ = np.expand_dims(lambda_, axis=expand_dims)
         self.distance_factor = np.expand_dims(distance_factor, axis=expand_dims)

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -92,8 +92,14 @@ class DailySolarFluxes:
         """Populates key fluxes from input variables."""
 
         # Validate the inputs
-        shapes = check_input_shapes(latitude, elevation, sunshine_fraction, temperature)
-        if shapes[0] not in (len(self.dates), 1):
+        self.shape: tuple = check_input_shapes(
+            latitude, elevation, sunshine_fraction, temperature
+        )
+        """The array shape of the input variables"""
+
+        if self.shape[0] == 1:
+            self.shape = (len(self.dates), *self.shape[1:])
+        elif self.shape[0] != len(self.dates):
             raise ValueError(
                 "The first axis of inputs is neither the same as the calendar or length"
                 " one (constant in time)"
@@ -119,7 +125,7 @@ class DailySolarFluxes:
         # the other inputs. These need to be broadcastable to the shape of the other
         # inputs. The expand_dims variable gets a list of the axes to expand onto -
         # which will be an empty list when ndim=1, leaving the targets unchanged.
-        expand_dims = list(np.arange(1, len(shapes)))
+        expand_dims = list(np.arange(1, len(self.shape)))
         self.nu = np.expand_dims(nu, axis=expand_dims)
         self.lambda_ = np.expand_dims(lambda_, axis=expand_dims)
         self.distance_factor = np.expand_dims(distance_factor, axis=expand_dims)

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -12,6 +12,7 @@ from pyrealm.constants import CoreConst
 from pyrealm.core.bounds import BoundsChecker
 from pyrealm.core.calendar import Calendar
 from pyrealm.core.pressure import calc_patm
+from pyrealm.core.time_series import broadcast_time
 from pyrealm.core.utilities import check_input_shapes
 from pyrealm.splash.evap import DailyEvapFluxes
 from pyrealm.splash.solar import DailySolarFluxes
@@ -84,16 +85,11 @@ class SplashModel:
 
         # Broadcast all the inputs over time to simplify the daily indexing if any
         # inputs are constant over time
-        def bcast_time(var: NDArray) -> NDArray:
-            full_shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
-            bcast_shape = (self.shape[0], *full_shape[1:])
-            return np.broadcast_to(var, bcast_shape)
-
-        elv = bcast_time(elv)
-        lat = bcast_time(lat)
-        sf = bcast_time(sf)
-        tc = bcast_time(tc)
-        pn = bcast_time(pn)
+        elv = broadcast_time(elv, self.shape)
+        lat = broadcast_time(lat, self.shape)
+        sf = broadcast_time(sf, self.shape)
+        tc = broadcast_time(tc, self.shape)
+        pn = broadcast_time(pn, self.shape)
 
         self.elv: NDArray[np.float64] = elv
         """The elevation of sites."""

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -69,13 +69,14 @@ class SplashModel:
         bounds_checker: BoundsChecker = BoundsChecker(),
     ):
         # Check input sizes are congurent
-        # TODO - think about broadcasting lat and elv rather than forcing users to do
-        #        this in advance. xarray would be good here for identifying axes and
+        # TODO - xarray would be good here for identifying axes and
         #        checking congruence more widely.
         self.shape: tuple = check_input_shapes(elv, lat, sf, tc, pn)
         """The array shape of the input variables"""
 
-        if self.shape[0] not in (len(dates), 1):
+        if self.shape[0] == 1:
+            self.shape = (len(dates), *self.shape[1:])
+        elif self.shape[0] != len(dates):
             raise ValueError(
                 "The first dimension of inputs must either match the number of dates or"
                 " have a length of one."

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -279,11 +279,18 @@ class SplashModel:
         # Check day_idx inputs to map either the single time index given in day_idx or
         # the whole dataset.
         if day_idx is None:
-            check_input_shapes(previous_wn, shape=self.shape)
+            splash_shape = self.shape
             didx: int | slice = slice(self.shape[0])
         else:
-            check_input_shapes(previous_wn, shape=self.shape[1:])
+            splash_shape = self.shape[1:]
             didx = day_idx
+        try:
+            check_input_shapes(previous_wn, shape=splash_shape)
+        except ValueError:
+            msg = (
+                "The shape of previous_wn does not match the existing SPLASH model data"
+            )
+            raise ValueError(msg)
 
         # Calculate the expected aet_d given the previous wn
         if np.any((previous_wn < 0) | (previous_wn > self.kWm)):
@@ -323,7 +330,11 @@ class SplashModel:
             A tuple of numpy arrays containing predicted AET, soil moisture and runoff.
         """
 
-        check_input_shapes(wn_init, shape=self.shape[1:])
+        try:
+            check_input_shapes(wn_init, shape=self.shape[1:])
+        except ValueError:
+            msg = "The shape of wn_init does not match the existing SPLASH model data"
+            raise ValueError(msg)
 
         # Create storage for outputs
         aet_out = np.full_like(self.tc, np.nan)

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -75,8 +75,24 @@ class SplashModel:
         self.shape: tuple = check_input_shapes(elv, lat, sf, tc, pn)
         """The array shape of the input variables"""
 
-        if len(dates) != self.shape[0]:
-            raise ValueError("Number of dates must match the first dimension of inputs")
+        if self.shape[0] not in (len(dates), 1):
+            raise ValueError(
+                "The first dimension of inputs must either match the number of dates or"
+                " have a length of one."
+            )
+
+        # Broadcast all the inputs over time to simplify the daily indexing if any
+        # inputs are constant over time
+        def bcast_time(var: NDArray) -> NDArray:
+            shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
+            bcast_shape = (len(dates), *shape[1:])
+            return np.broadcast_to(var, bcast_shape)
+
+        elv = bcast_time(elv)
+        lat = bcast_time(lat)
+        sf = bcast_time(sf)
+        tc = bcast_time(tc)
+        pn = bcast_time(pn)
 
         self.elv: NDArray[np.float64] = elv
         """The elevation of sites."""
@@ -178,7 +194,7 @@ class SplashModel:
         date_end = date_start + pd.DateOffset(years=1)
         num_days = (date_end - date_start).days
 
-        if self.shape[0] < num_days:
+        if len(self.dates) < num_days:
             raise ValueError("Cannot equilibrate - less than one year of data")
 
         # Run the equilibration loop

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -85,8 +85,8 @@ class SplashModel:
         # Broadcast all the inputs over time to simplify the daily indexing if any
         # inputs are constant over time
         def bcast_time(var: NDArray) -> NDArray:
-            shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
-            bcast_shape = (len(dates), *shape[1:])
+            full_shape = (1,) * (len(self.shape) - len(var.shape)) + var.shape
+            bcast_shape = (self.shape[0], *full_shape[1:])
             return np.broadcast_to(var, bcast_shape)
 
         elv = bcast_time(elv)
@@ -283,10 +283,10 @@ class SplashModel:
         # Check day_idx inputs to map either the single time index given in day_idx or
         # the whole dataset.
         if day_idx is None:
-            check_input_shapes(previous_wn, self.pn)
+            check_input_shapes(previous_wn, shape=self.shape)
             didx: int | slice = slice(self.shape[0])
         else:
-            check_input_shapes(previous_wn, self.pn[day_idx])
+            check_input_shapes(previous_wn, shape=self.shape[1:])
             didx = day_idx
 
         # Calculate the expected aet_d given the previous wn
@@ -327,7 +327,7 @@ class SplashModel:
             A tuple of numpy arrays containing predicted AET, soil moisture and runoff.
         """
 
-        # TODO - check input shapes
+        check_input_shapes(wn_init, shape=self.shape[1:])
 
         # Create storage for outputs
         aet_out = np.full_like(self.tc, np.nan)

--- a/tests/broadcasting/README.md
+++ b/tests/broadcasting/README.md
@@ -1,0 +1,5 @@
+# Tests for correct broadcasting of array inputs
+
+This directory contains the tests to check any functions / methods that accept array
+inputs. This is to ensure that the outputs / attributes are unchanged when broadcastable
+arrays are used in place of the full size arrays.

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -1,0 +1,279 @@
+import inspect
+
+import numpy as np
+
+import pyrealm
+from pyrealm.demography.flora import PlantFunctionalType, PlantFunctionalTypeStrict
+
+
+def get_package_modules(pkg):
+    import importlib
+    import pkgutil
+
+    modules = []
+    for _, modname, ispkg in pkgutil.walk_packages(
+        pkg.__path__, prefix=pkg.__name__ + "."
+    ):
+        if not ispkg:
+            modules.append(importlib.import_module(modname))
+    return modules
+
+
+def get_module_callables(module):
+    """Returns an iterable including the function/method name, callable, and (if a method) class."""
+    for name, obj in inspect.getmembers(module):
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            yield name, obj, None
+        elif inspect.isclass(obj):
+            for mname, method in inspect.getmembers(obj, predicate=inspect.isfunction):
+                yield f"{name}.{mname}", method, obj
+
+
+def is_instance_method(cls, name):
+    if cls is None:
+        return False
+    attr = inspect.getattr_static(cls, name)
+    if isinstance(attr, (staticmethod, classmethod)):
+        return False
+    else:
+        return True
+
+
+def is_array_type(typ):
+    from dataclasses import InitVar
+    from types import UnionType
+    from typing import Union, get_args, get_origin
+
+    origin = get_origin(typ)  # Get the unannotated type, i.e. X from X[...]
+
+    # Handle Union[...] or X | Y
+    if origin in (Union, UnionType):
+        return any(is_array_type(arg) for arg in get_args(typ))
+
+    # Handle dataclasses.InitVar[...]
+    if isinstance(typ, InitVar):
+        return is_array_type(typ.type)
+
+    try:
+        # Handle annotated types like NDArray[np.float32]
+        if origin is not None:
+            return issubclass(origin, np.ndarray)
+
+        # Handle basic types
+        return issubclass(typ, np.ndarray)
+
+    except TypeError:
+        return False
+
+
+def has_array_input(method):
+    from typing import get_type_hints
+
+    try:
+        hints = get_type_hints(method)
+        hints = {k: v for k, v in hints.items() if k != "return"}
+    except NameError:
+        return False
+
+    return any(is_array_type(typ) for typ in hints.values())
+
+
+def extract_numpy_dtype(typ) -> np.dtype:
+    """Extract a numpy dtype from NDArray annotation."""
+    from typing import get_args, get_origin
+
+    dtype = np.float64
+
+    args = get_args(typ)
+    if not args:
+        return dtype  # If no annotation
+
+    for arg in args:
+        # args could be like: (tuple[int, ...], numpy.dtype[numpy.datetime64])
+        if get_origin(arg) is np.dtype:
+            dtype_args = get_args(arg)
+            try:
+                dtype = np.dtype(dtype_args[0]).type
+            except TypeError:
+                continue
+        # Or like (np.float64)
+        elif isinstance(arg, type) and issubclass(arg, np.generic):
+            dtype = np.dtype(arg)
+
+    # Use a default unit if a datetime
+    if dtype == np.datetime64:
+        dtype = np.dtype("datetime64[D]")
+
+    return dtype
+
+
+def initialise_type_default(typ, shape):
+    """Define the default value for each type."""
+    from collections.abc import Sequence
+    from dataclasses import InitVar
+    from random import randint
+    from typing import Any, get_args, get_origin
+
+    # Handle any wrapped types
+    # InitVar[T]
+    if isinstance(typ, InitVar):
+        typ = typ.type
+    # Sequence[T] (create a sequence of 2)
+    origin = get_origin(typ)
+    args = get_args(typ)
+    if origin is Sequence:
+        inner_type = args[0] if args else Any
+        return [initialise_type_default(inner_type, shape) for _ in range(2)]
+    # Type[T]
+    if origin is type:
+        return initialise_type_default(args[0], shape)
+
+    # Numpy arrays
+    if is_array_type(typ):
+        dtype = extract_numpy_dtype(typ)
+        if dtype == np.datetime64:
+            return np.full(shape, np.datetime64("2000-01-01"), dtype=dtype)
+        else:
+            return np.ones(shape, dtype=dtype)
+
+    # Other types
+    elif typ == str:
+        return ""
+    elif typ == int:
+        return 1
+    elif typ == float:
+        return 1
+    elif typ == Any:
+        return None
+    elif typ == PlantFunctionalTypeStrict:
+        return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
+    elif len(inspect.signature(typ).parameters) > 0:
+        return initialise_class(typ, shape)
+    else:
+        return typ()
+
+
+manual_test_parameters = {
+    # 'Bounds.lower': 0,
+    # 'Bounds.interval_type': '[]',
+    'Cohorts.__init__.dbh_values': np.zeros(3),
+    'Cohorts.__init__.n_individuals': np.ones(3),
+    'Cohorts.__init__.pft_names': np.array(['Tree1', 'Tree2', 'Tree3'], dtype=np.str_),
+    'Flora.__init__.pfts': [PlantFunctionalType(name='Tree1'), PlantFunctionalType(name='Tree2'), PlantFunctionalType(name='Tree3')],
+    'Canopy.__init__.fit_ppa': True,
+}
+
+
+def generate_args(name, method, shape):
+    """Generate the arguments needed for a function. Requires type hinting.
+    Numpy arrays are defined using the shape argument.
+    """
+    from typing import get_type_hints
+
+    kwargs = {}
+    sig = inspect.signature(method)
+    for param_name, param in sig.parameters.items():
+        method_arg_name = f"{name}.{param_name}"
+        # Set manually defined values
+        if method_arg_name in manual_test_parameters:
+            kwargs[param_name] = manual_test_parameters[method_arg_name]
+        # Skip unnecesary arguments
+        elif param_name == "self" or param.kind in (
+            param.VAR_POSITIONAL,
+            param.VAR_KEYWORD,
+        ):
+            continue
+        # Set default arguments
+        elif param.default is not param.empty:
+            kwargs[param_name] = param.default
+        # Initialise any other arguments
+        else:
+            if param.annotation is param.empty:
+                raise Exception(f"Missing annotation for {method_arg_name}")
+            # Get the contexts of the pyrealm classes to pass to get_type_hints
+            globalns = {}
+            for module in get_package_modules(pyrealm):
+                globalns.update(vars(module))
+            # Resolve any string annotations
+            typ = get_type_hints(method, globalns=globalns).get(
+                param_name, param.annotation
+            )
+            kwargs[param_name] = initialise_type_default(typ, shape)
+    return kwargs
+
+
+def initialise_class(cls, shape):
+    init_name = f"{cls.__name__}.__init__"
+    print("Initialising:", init_name)
+    args = generate_args(init_name, cls.__init__, shape)
+    return cls(**args)
+
+
+def is_equal(val1, val2):
+    if isinstance(val1, np.ndarray):
+        return np.all(val1 == val2)
+
+    elif isinstance(val1, tuple) and isinstance(val2, tuple):
+        if len(val1) != len(val2):
+            return False
+        return all(is_equal(v1, v2) for v1, v2 in zip(val1, val2))
+
+    elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
+        return compare_instances(val1, val2)
+
+    else:
+        return val1 == val2
+
+
+def compare_instances(instance1, instance2):
+    dict1 = instance1.__dict__
+    dict2 = instance2.__dict__
+    for key in dict1:
+        if not is_equal(dict1[key], dict2[key]):
+            return False
+    return True
+
+
+shape = (3, 1, 1)
+shape_full = (3, 2, 2)
+
+for mod in get_package_modules(pyrealm):
+    for name, method, cls in get_module_callables(mod):
+        if not has_array_input(method):
+            continue
+
+        print(name)
+
+        # Generate the arguments for the method
+        args = generate_args(name, method, shape)
+        args_full = generate_args(name, method, shape_full)
+
+        if is_instance_method(cls, method.__name__):
+            print("CM", name)
+            # First initialise class and get bound methods
+            instance1 = initialise_class(cls, shape)
+            instance2 = initialise_class(cls, shape_full)
+            method1 = getattr(instance1, method.__name__)
+            method2 = getattr(instance2, method.__name__)
+            # Run the method
+            result = method1(**args)
+            result_full = method2(**args_full)
+            # Compare results
+            is_correct = is_equal(result, result_full) and compare_instances(
+                instance1, instance2
+            )
+            print("CM", name, is_correct)
+
+        else:
+            print("FN", name)
+            # Run the method
+            result = method(**args)
+            result_full = method(**args_full)
+            # Compare results
+            is_correct = is_equal(result, result_full)
+            print("FN", name, is_correct)
+
+        print()
+        # # Compare the results to see if they are identical
+        # if (not is_correct):
+        # raise Error(f'Results do not match in {name}')

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -3,7 +3,11 @@ import inspect
 import numpy as np
 
 import pyrealm
-from pyrealm.demography.flora import PlantFunctionalType, PlantFunctionalTypeStrict, StemTraits
+from pyrealm.demography.flora import (
+    PlantFunctionalType,
+    PlantFunctionalTypeStrict,
+    StemTraits,
+)
 
 
 def get_package_modules(pkg):
@@ -113,26 +117,27 @@ def extract_numpy_dtype(typ) -> np.dtype:
 # Demography parameters
 n_pft = 3
 n_heights = 2
-pft_names = [f"Tree{i+1}" for i in range(n_pft)]
+pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
 crown_m = np.arange(n_pft)
 crown_n = np.arange(n_pft)
-crown_z = np.linspace(5, 15, n_heights)[:,np.newaxis]
+crown_z = np.linspace(5, 15, n_heights)[:, np.newaxis]
 crown_stem_height = np.full(n_pft, 10)
 crown_area = np.full(n_pft, 10)
 crown_q_m = np.full(n_pft, 3)
 crown_z_max = np.full(n_pft, 10)
-crown_q_z = np.full((n_heights,n_pft), 10)
+crown_q_z = np.full((n_heights, n_pft), 10)
 crown_n_ind = np.full(n_pft, 2)
+
 
 def initialise_type_default(typ, shape):
     """Define the default value for each type."""
     from collections.abc import Sequence
     from dataclasses import InitVar
     from random import randint
-    from typing import Any, Union, get_args, get_origin
     from types import UnionType
+    from typing import Any, Union, get_args, get_origin
 
-    from pyrealm.demography.flora import Flora, StemTraits, PlantFunctionalTypeStrict
+    from pyrealm.demography.flora import Flora
 
     # Handle any wrapped types
     # InitVar[T]
@@ -230,12 +235,19 @@ manual_test_parameters = {
     # "AcclimationModel.datetimes": np.full(3, np.datetime64("2000-01-01")),
     "AcclimationModel.datetimes": np.arange(0, 48, dtype="datetime64[h]"),
     "AcclimationModel.set_nearest.time": np.timedelta64(12, "h"),
-    "AcclimationModel._validate_and_set_datetimes.datetimes": np.arange(0, 48, dtype="datetime64[h]"),
+    "AcclimationModel._validate_and_set_datetimes.datetimes": np.arange(
+        0, 48, dtype="datetime64[h]"
+    ),
     "AcclimationModel._get_subdaily_interpolation_xy.values": np.ones(2),
     "AcclimationModel.fill_daily_to_subdaily.values": np.ones(2),
     "AcclimationModel.get_window_values.values": np.ones(48),
     "AcclimationModel.get_daily_means.values": np.ones(48),
-    "calculate_kattge_knorr_arrhenius_factor.coef": {'ha': 1, 'hd': 1, 'entropy_intercept': 1, 'entropy_slope': 1},
+    "calculate_kattge_knorr_arrhenius_factor.coef": {
+        "ha": 1,
+        "hd": 1,
+        "entropy_intercept": 1,
+        "entropy_slope": 1,
+    },
     ## Demography uses 1D arrays
     "Cohorts.dbh_values": np.zeros(n_pft),
     "Cohorts.n_individuals": np.ones(n_pft),
@@ -243,11 +255,11 @@ manual_test_parameters = {
     "Flora.pfts": [PlantFunctionalType(name=name) for name in pft_names],
     "Flora.get_stem_traits.pft_names": pft_names,
     "Canopy.fit_ppa": True,
-    "CohortCanopyData.projected_leaf_area": np.ones((n_heights,n_pft)),
+    "CohortCanopyData.projected_leaf_area": np.ones((n_heights, n_pft)),
     "CohortCanopyData.n_individuals": np.ones(n_pft),
     "CohortCanopyData.pft_lai": np.ones(n_pft),
     "CohortCanopyData.pft_par_ext": np.ones(n_pft),
-    "CommunityCanopyData.cohort_transmissivity": np.ones((n_heights,n_pft)),
+    "CommunityCanopyData.cohort_transmissivity": np.ones((n_heights, n_pft)),
     "StemAllometry.at_dbh": np.full(n_pft, 0.5),
     "StemAllocation.whole_crown_gpp": np.full(n_pft, 0.5),
     "CrownProfile.z": crown_z,
@@ -305,14 +317,15 @@ def initialise_class(cls, shape):
     if name in additional_init_methods:
         mname = additional_init_methods[name]
         method = getattr(instance, mname)
-        args = generate_args(name+"."+mname, method, shape)
+        args = generate_args(name + "." + mname, method, shape)
         method(**args)
     return instance
 
 
 def is_equal(val1, val2):
     if isinstance(val1, np.ndarray):
-        if (val1.shape != val2.shape): return False
+        if val1.shape != val2.shape:
+            return False
         return np.all(val1 == val2)
 
     elif isinstance(val1, tuple) and isinstance(val2, tuple):

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -156,11 +156,15 @@ def initialise_type_default(typ, shape):
 manual_test_parameters = {
     # 'Bounds.lower': 0,
     # 'Bounds.interval_type': '[]',
-    'Cohorts.__init__.dbh_values': np.zeros(3),
-    'Cohorts.__init__.n_individuals': np.ones(3),
-    'Cohorts.__init__.pft_names': np.array(['Tree1', 'Tree2', 'Tree3'], dtype=np.str_),
-    'Flora.__init__.pfts': [PlantFunctionalType(name='Tree1'), PlantFunctionalType(name='Tree2'), PlantFunctionalType(name='Tree3')],
-    'Canopy.__init__.fit_ppa': True,
+    "Cohorts.__init__.dbh_values": np.zeros(3),
+    "Cohorts.__init__.n_individuals": np.ones(3),
+    "Cohorts.__init__.pft_names": np.array(["Tree1", "Tree2", "Tree3"], dtype=np.str_),
+    "Flora.__init__.pfts": [
+        PlantFunctionalType(name="Tree1"),
+        PlantFunctionalType(name="Tree2"),
+        PlantFunctionalType(name="Tree3"),
+    ],
+    "Canopy.__init__.fit_ppa": True,
 }
 
 

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -4,10 +4,10 @@ This ensures that the outputs/attributes of any functions/methods are unchanged 
 broadcastable array inputs are used in place of the full size arrays.
 
 To resolve failing tests there are a few options to use in utils.py:
-    - `skip_methods`: For irrelevant methods (e.g. 1D inputs only).
-    - `ignore_outputs`: To ignore comparing specific outputs or class attributes.
+    - `SKIP_METHODS`: For irrelevant methods (e.g. 1D inputs only).
+    - `IGNORE_OUTPUTS`: To ignore comparing specific outputs or class attributes.
     - `defined_method_args`: To manually define specific arguments for methods.
-    - `additional_init_methods`: For classes needing to call additional methods.
+    - `ADDITIONAL_INIT_METHODS`: For classes needing to call additional methods.
 """
 
 import warnings
@@ -26,20 +26,20 @@ from utils import (
 
 from pyrealm.core.experimental import ExperimentalFeatureWarning
 
-shape_full: list[tuple[int, ...]]
-shape_full = [(3, 2, 2)]
-shapes_list = [
+SHAPE_FULL: list[tuple[int, ...]]
+SHAPE_FULL = [(3, 2, 2)]
+SHAPES_LIST = [
     [(3, 2, 2), (1, 2, 2), (3, 1, 1), (1, 1, 1)],
     [(1, 2, 2), (3, 2, 2)],
     [(3, 1, 1), (1, 2, 2), (3, 2, 2)],
     [(1, 1, 1)],
 ]
-method_list = get_method_list()
+METHOD_LIST = get_method_list()
 
 
 @pytest.mark.broadcasting
-@pytest.mark.parametrize("shapes", shapes_list)
-@pytest.mark.parametrize("method_info", method_list, ids=[m[0] for m in method_list])
+@pytest.mark.parametrize("shapes", SHAPES_LIST)
+@pytest.mark.parametrize("method_info", METHOD_LIST, ids=[m[0] for m in METHOD_LIST])
 def test_array_input_broadcasting(
     method_info: tuple[str, Callable, type | None],
     shapes: list[tuple[int, ...]],
@@ -59,7 +59,7 @@ def test_array_input_broadcasting(
 
     # Generate the arguments for the function / method
     ctx = Context(name, shapes)
-    ctx_full = Context(name, shape_full)
+    ctx_full = Context(name, SHAPE_FULL)
     args = generate_args(method, ctx)
     args_full = generate_args(method, ctx_full)
 
@@ -86,9 +86,3 @@ def test_array_input_broadcasting(
     if not is_equal(result, result_full):
         result_comparison = comparison_string(result, result_full)
         raise ValueError(f"Results do not match in {name} ({result_comparison})")
-
-
-if __name__ == "__main__":
-    for method_info in method_list:
-        for shapes in shapes_list:
-            test_array_input_broadcasting(method_info, shapes)

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -26,11 +26,6 @@ from utils import (
 
 from pyrealm.core.experimental import ExperimentalFeatureWarning
 
-warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
-warnings.filterwarnings("ignore", category=RuntimeWarning)
-warnings.filterwarnings("ignore", category=UserWarning)
-
-
 shape_full: list[tuple[int, ...]]
 shape_full = [(3, 2, 2)]
 shapes_list = [
@@ -56,6 +51,10 @@ def test_array_input_broadcasting(
     the outputs (and all class attributes for class methods). Raises a ValueError if
     incorrect.
     """
+    warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
+    warnings.filterwarnings("ignore", category=RuntimeWarning)
+    warnings.filterwarnings("ignore", category=UserWarning)
+
     name, method, cls = method_info
 
     # Generate the arguments for the function / method

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -131,6 +131,18 @@ def method_args(argument: str, ctx: "Context"):
     arguments: dict = method_arguments_list.get(ctx.name, {})
 
     # Arguments that use temporary variables or depend on parents
+
+    if ctx.name.split(".")[0] == "AnnualValueCalculator":
+        # Needs one-dimensional times
+        nTime = 3
+        if ctx.name == "AnnualValueCalculator":
+            arguments = {"timing": np.arange(0, nTime, dtype="datetime64[D]")}
+        elif ctx.name in [
+            "AnnualValueCalculator._split_values_by_year",
+            "AnnualValueCalculator.get_annual_means",
+            "AnnualValueCalculator.get_annual_totals",
+        ]:
+            arguments = {"values": np.ones((nTime, *shape[1:]))}
     if ctx.name == "SolarDailyFluxes":
         nTime = 4
         solarShape = (1 if shape[0] == 1 else nTime, *shape[1:])

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -8,11 +8,13 @@ import dataclasses
 import inspect
 import warnings
 from collections.abc import Callable, Iterator
-from types import ModuleType
-from typing import Any, Union, cast
+from dataclasses import InitVar
+from types import ModuleType, UnionType
+from typing import Any, Union, cast, get_args, get_origin
 
 import numpy as np
 import numpy.typing as npt
+import pytest
 
 import pyrealm
 from pyrealm.core.calendar import Calendar
@@ -76,8 +78,26 @@ skip_methods = [
 
 
 # These methods require specific arguments
-def method_args(argument: str, ctx: "Context"):
-    """Return any manually defined arguments for the current callable in the context."""
+def defined_method_args(argument: str, ctx: "Context") -> Any | None:
+    """Return any manually defined arguments for the current function / method.
+
+    This is done by defining an `arguments` dictionary for the function and then
+    returning the value (if any) of the specific `argument`.
+
+    Parameters
+    ----------
+    argument : str
+        The name of the input argument to define.
+    ctx : Context
+        The context containing the name of the function (`ctx.name`) and the parent
+        classes / class method being tested (`ctx.parents`).
+
+    Returns:
+    -------
+    Any | None
+        The manually defined value for the argument, or `None` if it can be set by the
+        defaults.
+    """
     shape = ctx.shape()
 
     # PModel parameters
@@ -206,6 +226,7 @@ def get_package_modules(pkg: ModuleType) -> list[ModuleType]:
     ):
         if not ispkg:
             modules.append(importlib.import_module(modname))
+
     return modules
 
 
@@ -242,21 +263,27 @@ def is_instance_method(cls: type | None, method_name: str) -> bool:
 
 
 ## Functions to get the argument datatypes
+def strip_wrapped_types(typ: Any) -> Any:
+    """Handle basic wrapped types to get the inner type."""
+    # InitVar[T] -> T
+    if isinstance(typ, InitVar):
+        strip_wrapped_types(typ.type)
+    # Type[T] -> T
+    if get_origin(typ) is type:
+        args = get_args(typ)
+
+        return strip_wrapped_types(args[0])
+    return typ
+
+
 def is_array_type(typ: Any) -> bool:
     """Returns True if the type is a numpy array."""
-    from dataclasses import InitVar
-    from types import UnionType
-    from typing import get_args, get_origin
+    typ = strip_wrapped_types(typ)
 
-    origin = get_origin(typ)  # Get the unannotated type, i.e. X from X[...]
-
-    # Handle Union[...] or X | Y
+    # If Union[...] or X | Y then check both types
+    origin = get_origin(typ)  # Get the unannotated type, i.e. X[...] -> X
     if origin in (Union, UnionType):
         return any(is_array_type(arg) for arg in get_args(typ))
-
-    # Handle dataclasses.InitVar[...]
-    if isinstance(typ, InitVar):
-        return is_array_type(typ.type)
 
     try:
         # Handle annotated types like NDArray[np.float32]
@@ -285,8 +312,6 @@ def has_array_input(method: Callable) -> bool:
 
 def extract_numpy_dtype(typ: Any) -> npt.DTypeLike:
     """Extract a numpy dtype from NDArray annotation."""
-    from typing import get_args, get_origin
-
     dtype: npt.DTypeLike = np.float64
 
     args = get_args(typ)
@@ -348,33 +373,25 @@ class Context:
 def initialise_type_default(typ: Any, ctx: Context) -> Any:
     """Define the default value for each type."""
     from collections.abc import Sequence
-    from dataclasses import InitVar
     from random import randint
-    from types import UnionType
-    from typing import get_args, get_origin
 
     from pyrealm.demography.flora import Flora
 
-    # Handle any wrapped types
-    # InitVar[T]
-    if isinstance(typ, InitVar):
-        typ = typ.type
-    # Sequence[T] (create a sequence of 2)
+    # Handle basic wrapped types
+    typ = strip_wrapped_types(typ)
+
+    # If Sequence[T]: create a list of 2 objects
     origin = get_origin(typ)
     args = get_args(typ)
     if origin is Sequence:
         inner_type = args[0] if args else Any
         return [initialise_type_default(inner_type, ctx) for _ in range(2)]
-    # Type[T]
-    if origin is type:
-        return initialise_type_default(args[0], ctx)
-    # Union[...] or X | Y
+
+    # If Union[...] or X | Y: Create an array if an option, otherwise use the first type
     if origin in (Union, UnionType):
-        # Use an array if an option
         for arg in args:
             if is_array_type(arg):
                 return initialise_type_default(arg, ctx)
-        # Otherwise first type in list
         return initialise_type_default(args[0], ctx)
 
     pft_names = ["Tree1", "Tree2", "Tree3"]
@@ -384,7 +401,7 @@ def initialise_type_default(typ: Any, ctx: Context) -> Any:
         dtype = extract_numpy_dtype(typ)
         shape = ctx.shape()
         if np.issubdtype(dtype, np.datetime64):
-            return np.full(shape, np.datetime64("2000-01-01"), dtype=dtype)
+            return np.arange(0, np.prod(shape), dtype="datetime64[D]").reshape(shape)
         else:
             return np.ones(shape, dtype=dtype)
 
@@ -425,7 +442,7 @@ def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
         ctx.i_arg += 1
 
         # Set manually defined values
-        manual_arg = method_args(param_name, ctx)
+        manual_arg = defined_method_args(param_name, ctx)
         if manual_arg is not None:
             kwargs[param_name] = manual_arg
 
@@ -483,7 +500,7 @@ def is_equal(val1: Any, val2: Any) -> bool:
         both_nan = np.isnan(val1_b) & np.isnan(val2_b)
         return bool(np.all(equal | both_nan))
 
-    elif isinstance(val1, tuple) and isinstance(val2, tuple):
+    elif isinstance(val1, list | tuple) and isinstance(val2, list | tuple):
         if len(val1) != len(val2):
             return False
         return all(is_equal(v1, v2) for v1, v2 in zip(val1, val2))
@@ -495,71 +512,77 @@ def is_equal(val1: Any, val2: Any) -> bool:
         return val1 == val2
 
 
-def compare_instances(instance1: Any, instance2: Any) -> bool:
-    """Compare if two class instances have equal attributes."""
+def compare_instances(instance1: Any, instance2: Any):
+    """Raises ValueError if the two class instances do not have equal attributes."""
     dict1 = instance1.__dict__
     dict2 = instance2.__dict__
     for key in dict1:
         if not is_equal(dict1[key], dict2[key]):
-            print(f"{instance1.__class__.__name__}: {key} not equal")
-            # print(dict1[key])
-            # print(dict2[key])
-            # raise ValueError
-            return False
-    return True
+            raise ValueError(f"{instance1.__class__.__name__}: {key} not equal")
 
 
-shapes: list[tuple[int, ...]]
-shape_full: list[tuple[int, ...]]
-shapes = [(3, 2, 2), (1, 2, 2), (3, 1, 1), (1, 1, 1)]
-shapes = [(1, 2, 2), (3, 2, 2)]
-# shapes = [(3, 1, 1), (1, 2, 2), (3, 2, 2)]
-# shapes = [(1, 1, 1)]
-shape_full = [(3, 2, 2)]
-
+method_list = []
 for mod in get_package_modules(pyrealm):
     for name, method, cls in get_module_callables(mod):
-        if not has_array_input(method) or name in skip_methods:
-            continue
+        if has_array_input(method) and name not in skip_methods:
+            method_list.append((name, method, cls))
 
-        is_correct = True
+shape_full: list[tuple[int, ...]]
+shape_full = [(3, 2, 2)]
+shapes_list = [
+    [(3, 2, 2), (1, 2, 2), (3, 1, 1), (1, 1, 1)],
+    [(1, 2, 2), (3, 2, 2)],
+    [(3, 1, 1), (1, 2, 2), (3, 2, 2)],
+    [(1, 1, 1)],
+]
 
-        # Generate the arguments for the method
-        ctx = Context(name, shapes)
-        ctx_full = Context(name, shape_full)
-        args = generate_args(method, ctx)
-        args_full = generate_args(method, ctx_full)
 
-        if is_instance_method(cls, method.__name__):
-            cls = cast(type, cls)  # Make mypy aware this cannot be None
-            # First initialise class and get bound methods
-            instance1 = initialise_class(cls, ctx)
-            instance2 = initialise_class(cls, ctx_full)
-            method1 = getattr(instance1, method.__name__)
-            method2 = getattr(instance2, method.__name__)
-            # Run the method
-            result = method1(**args)
-            result_full = method2(**args_full)
-            # Compare results
-            is_correct = is_equal(result, result_full)
-            if not is_correct:
-                print(name, ": Result not equal")
-            is_correct = is_equal(result, result_full) and compare_instances(
-                instance1, instance2
-            )
+@pytest.mark.parametrize("shapes", shapes_list)
+@pytest.mark.parametrize("method_info", method_list, ids=[m[0] for m in method_list])
+def test_array_input_broadcasting(
+    method_info: tuple[str, Callable, type | None],
+    shapes: list[tuple[int, ...]],
+):
+    """Test to run all module callables to check if broadcasting affects the results.
 
-        else:
-            # Run the method
-            result = method(**args)
-            result_full = method(**args_full)
-            # Compare results
-            is_correct = is_equal(result, result_full)
-            if not is_correct:
-                print(name, ": Result not equal")
+    Each method / function is run twice. Once with all array inputs in their full
+    broadcasted shape, and another with equivalent, broadcastable inputs. Then compare
+    the outputs (and all class attributes for class methods). Raises a ValueError if
+    incorrect.
+    """
+    name, method, cls = method_info
 
-        # if (not is_correct):
-        #     print(name)
-        #     print()
-        # # Compare the results to see if they are identical
-        # if (not is_correct):
-        # raise Error(f'Results do not match in {name}')
+    # Generate the arguments for the function / method
+    ctx = Context(name, shapes)
+    ctx_full = Context(name, shape_full)
+    args = generate_args(method, ctx)
+    args_full = generate_args(method, ctx_full)
+
+    # If a class method (initialises class and compares attributes)
+    if is_instance_method(cls, method.__name__):
+        cls = cast(type, cls)  # Make mypy aware this cannot be None
+        # First initialise class and get bound methods
+        instance1 = initialise_class(cls, ctx)
+        instance2 = initialise_class(cls, ctx_full)
+        method1 = getattr(instance1, method.__name__)
+        method2 = getattr(instance2, method.__name__)
+        # Run the method
+        result = method1(**args)
+        result_full = method2(**args_full)
+        compare_instances(instance1, instance2)  # Fail if attributes not equal
+
+    # If a function / static method
+    else:
+        # Run the method
+        result = method(**args)
+        result_full = method(**args_full)
+
+    # Fail if function outputs not equal
+    if not is_equal(result, result_full):
+        raise RuntimeError(f"Results do not match in {name}")
+
+
+if __name__ == "__main__":
+    shapes = shapes_list[0]
+    for method_info in method_list:
+        test_array_input_broadcasting(method_info, shapes)

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -29,8 +29,12 @@ warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
+
+## Lists / functions to manually define arguments, methods or outputs to ignore, etc.
+
 # These methods are not relevant or are incompatible without additional work
 skip_methods = [
+    "evaluate_horner_polynomial",  # Coefficients are 1D
     # PModel
     "AcclimationModel.set_include",
     "PModelABC",  # Cannot init ABC
@@ -74,6 +78,26 @@ skip_methods = [
     "calculate_sapwood_respiration",
     "calculate_stem_masses",
     "calculate_whole_crown_gpp",
+]
+
+
+# Ignore these outputs, they are not expected to be equal.
+# Formats: [fn name] for function results, [class]:[attr] for class attributes
+ignore_outputs = [
+    "Cohorts:_cohort_id",
+    "Calendar:n_dates",
+    "C3C4Competition:shape",
+    "CalcCarbonIsotopes:shape",
+    "PModelEnvironment:shape",
+    "PModel:shape",
+    "SubdailyPModel:shape",
+    "OptimalChiC4:shape",
+    "OptimalChiC4NoGamma:shape",
+    "OptimalChiPrentice14:shape",
+    "QuantumYieldTemperature:shape",
+    "QuantumYieldFixed:shape",
+    "JmaxLimitationWang17:_shape",
+    "SplashModel:shape",
 ]
 
 
@@ -128,9 +152,9 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
         "SplashModel.calculate_soil_moisture": {"wn_init": np.full(shape[1:], 10)},
         "PModelEnvironment": {"patm": np.full(shape, 100000)},
         "TwoLeafIrradiance": {"patm": np.full(shape, 100000)},
-        ## Demography uses 1D arrays
+        ## Demography uses 1D arrays (a lot of these could probably be skipped)
         "Cohorts": {
-            "dbh_values": np.zeros(n_pft),
+            "dbh_values": np.full(n_pft, 2),
             "n_individuals": np.ones(n_pft),
             "pft_names": np.array(pft_names, dtype=np.str_),
         },
@@ -140,13 +164,20 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
         "CohortCanopyData": {
             "projected_leaf_area": np.ones((n_heights, n_pft)),
             "n_individuals": np.ones(n_pft),
-            "pft_lai": np.ones(n_pft),
-            "pft_par_ext": np.ones(n_pft),
+            "lai": np.ones(n_pft),
+            "par_ext": np.ones(n_pft),
         },
-        "CommunityCanopyData": {"cohort_transmissivity": np.ones((n_heights, n_pft))},
+        "CommunityCanopyData": {
+            "absorption": np.full((n_heights, n_pft), 0.5),
+            "leaf_area_index": np.full((n_heights, n_pft), 0.5),
+            "cohort_leaf_area": np.full((n_heights, n_pft), 1),
+        },
         "StemAllometry": {"at_dbh": np.full(n_pft, 0.5)},
         "StemAllocation": {"whole_crown_gpp": np.full(n_pft, 0.5)},
         "CrownProfile": {"z": np.linspace(5, 15, n_heights)[:, np.newaxis]},
+        "Cohorts.drop_cohort_data": {"drop_indices": [0, 1]},
+        "StemAllometry.drop_cohort_data": {"drop_indices": [0, 1]},
+        "Community.drop_cohorts": {"drop_indices": [0, 1]},
     }
     arguments: dict = method_arguments_list.get(ctx.name, {})
 
@@ -164,17 +195,28 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
         ]:
             shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
             arguments = {"values": np.ones(shape2)}
-    if ctx.name == "SolarDailyFluxes":
+
+    if ctx.name.split(".")[0] in ["DailySolarFluxes", "DailyEvapFluxes"]:
+        # Needs first dimension to match the dates
         nTime = 4
-        solarShape = (1 if shape[0] == 1 else nTime, *shape[1:])
-        arguments = {
-            "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
-            "latitude": np.full(solarShape, 10),
-            "elvation": np.full(solarShape, 10),
-            "sf": np.full(solarShape, 0.5),
-            "tc": np.full(solarShape, 25),
-            "pn": np.full(solarShape, 10),
-        }
+        shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
+        if ctx.name == "DailySolarFluxes":
+            arguments = {
+                "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
+                "latitude": np.full(shape2, 10),
+                "elevation": np.full(shape2, 10),
+                "sunshine_fraction": np.full(shape2, 0.5),
+                "temperature": np.full(shape2, 25),
+            }
+        elif ctx.name == "DailyEvapFluxes":
+            arguments = {
+                "pa": np.full(shape2, 10),
+                "tc": np.full(shape2, 25),
+                "kWm": np.full(shape2, 150),
+            }
+        elif ctx.name == "DailyEvapFluxes.estimate_aet":
+            arguments = {"wn": np.full(shape2, 10)}
+
     if ctx.name == "SplashModel":
         if (
             ctx.parents
@@ -193,6 +235,7 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
             "tc": np.full(splashShape, 25),
             "pn": np.full(splashShape, 10),
         }
+
     if ctx.name == "PModelEnvironment":
         if ctx.parents and ctx.parents[-1] == "SubdailyPModel":
             # SubdailyPModel needs more than 1 day (uses 48 hourly times)
@@ -268,7 +311,7 @@ def strip_wrapped_types(typ: Any) -> Any:
     """Handle basic wrapped types to get the inner type."""
     # InitVar[T] -> T
     if isinstance(typ, InitVar):
-        strip_wrapped_types(typ.type)
+        return strip_wrapped_types(typ.type)
     # Type[T] -> T
     if get_origin(typ) is type:
         args = get_args(typ)
@@ -402,7 +445,7 @@ def initialise_type_default(typ: Any, ctx: Context) -> Any:
         dtype = extract_numpy_dtype(typ)
         shape = ctx.shape()
         if np.issubdtype(dtype, np.datetime64):
-            return np.arange(0, np.prod(shape), dtype="datetime64[D]").reshape(shape)
+            return np.full(shape, 1, dtype="datetime64[D]")
         else:
             return np.ones(shape, dtype=dtype)
 
@@ -514,13 +557,29 @@ def is_equal(val1: Any, val2: Any) -> bool:
         return val1 == val2
 
 
+def _comparison_string(val1: Any, val2: Any) -> str:
+    def value_string(val: Any) -> str:
+        if isinstance(val, np.ndarray) and val.size > 5:
+            val_str = f"<array> {val.shape}"
+        else:
+            val_str = str(val).replace("\n", " ")
+        val_str = val_str[:30] + ".." if len(val_str) > 30 else val_str
+        return val_str
+
+    return value_string(val1) + " != " + value_string(val2)
+
+
 def compare_instances(instance1: Any, instance2: Any):
     """Raises ValueError if the two class instances do not have equal attributes."""
     dict1 = instance1.__dict__
     dict2 = instance2.__dict__
+    class_name = instance1.__class__.__name__
     for key in dict1:
+        if f"{class_name}:{key}" in ignore_outputs:
+            continue
         if not is_equal(dict1[key], dict2[key]):
-            raise ValueError(f"{instance1.__class__.__name__}: {key} not equal")
+            attr_comparison = _comparison_string(dict1[key], dict2[key])
+            raise ValueError(f"{class_name}: {key} not equal ({attr_comparison})")
 
 
 method_list = []
@@ -581,10 +640,11 @@ def test_array_input_broadcasting(
 
     # Fail if function outputs not equal
     if not is_equal(result, result_full):
-        raise RuntimeError(f"Results do not match in {name}")
+        result_comparison = _comparison_string(result, result_full)
+        raise ValueError(f"Results do not match in {name} ({result_comparison})")
 
 
 if __name__ == "__main__":
-    shapes = shapes_list[0]
     for method_info in method_list:
-        test_array_input_broadcasting(method_info, shapes)
+        for shapes in shapes_list:
+            test_array_input_broadcasting(method_info, shapes)

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -2,591 +2,34 @@
 
 This ensures that the outputs/attributes of any functions/methods are unchanged when
 broadcastable array inputs are used in place of the full size arrays.
+
+To resolve failing tests there are a few options to use in utils.py:
+    - `skip_methods`: For irrelevant methods (e.g. 1D inputs only).
+    - `ignore_outputs`: To ignore comparing specific outputs or class attributes.
+    - `defined_method_args`: To manually define specific arguments for methods.
+    - `additional_init_methods`: For classes needing to call additional methods.
 """
 
-import dataclasses
-import inspect
 import warnings
-from collections.abc import Callable, Iterator
-from dataclasses import InitVar
-from types import ModuleType, UnionType
-from typing import Any, Union, cast, get_args, get_origin
+from collections.abc import Callable
 
-import numpy as np
-import numpy.typing as npt
 import pytest
-
-import pyrealm
-from pyrealm.core.calendar import Calendar
-from pyrealm.core.experimental import ExperimentalFeatureWarning
-from pyrealm.demography.flora import (
-    PlantFunctionalType,
-    PlantFunctionalTypeStrict,
-    StemTraits,
+from utils import (
+    Context,
+    compare_instances,
+    comparison_string,
+    generate_args,
+    get_method_list,
+    initialise_class,
+    is_equal,
 )
+
+from pyrealm.core.experimental import ExperimentalFeatureWarning
 
 warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
 warnings.filterwarnings("ignore", category=RuntimeWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
-
-## Lists / functions to manually define arguments, methods or outputs to ignore, etc.
-
-# These methods are not relevant or are incompatible without additional work
-skip_methods = [
-    "evaluate_horner_polynomial",  # Coefficients are 1D
-    # PModel
-    "AcclimationModel.set_include",
-    "PModelABC",  # Cannot init ABC
-    "QuantumYieldABC",  # Cannot init ABC
-    "OptimalChiABC.estimate_chi",  # Cannot init ABC
-    "OptimalChiC4RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
-    "OptimalChiC4NoGammaRootzoneStress.estimate_chi",  # Requires rootzonestress in PME
-    "OptimalChiPrentice14RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
-    "OptimalChiLavergne20C3.estimate_chi",  # Requires theta in PME
-    "OptimalChiLavergne20C4.estimate_chi",  # Requires theta in PME
-    "QuantumYieldSandoval",  # Requires aridity_index in PME
-    "QuantumYieldSandoval.peak_quantum_yield",  # Requires aridity_index in PME
-    # Demography - mostly 1d arrays (dataframes)
-    "CohortMethods.drop_cohort_data",
-    "StemTraits",
-    "StemTraits.drop_cohort_data",
-    "_enforce_2D",
-    "calculate_stem_projected_leaf_area_at_z",
-    "get_crown_xy",
-    "calculate_relative_crown_radius_at_z",
-    "calculate_stem_projected_crown_area_at_z",
-    "solve_canopy_area_filling_height",
-    "calculate_crown_areas",
-    "calculate_crown_fractions",
-    "calculate_crown_r0",
-    "calculate_crown_z_max",
-    "calculate_dbh_from_height",
-    "calculate_fine_root_respiration",
-    "calculate_fine_root_turnover",
-    "calculate_foliage_masses",
-    "calculate_foliage_turnover",
-    "calculate_foliar_respiration",
-    "calculate_gpp_topslice",
-    "calculate_growth_increments",
-    "calculate_heights",
-    "calculate_net_primary_productivity",
-    "calculate_reproductive_tissue_mass",
-    "calculate_reproductive_tissue_respiration",
-    "calculate_reproductive_tissue_turnover",
-    "calculate_sapwood_masses",
-    "calculate_sapwood_respiration",
-    "calculate_stem_masses",
-    "calculate_whole_crown_gpp",
-]
-
-
-# Ignore these outputs, they are not expected to be equal.
-# Formats: [fn name] for function results, [class]:[attr] for class attributes
-ignore_outputs = [
-    "Cohorts:_cohort_id",
-    "Calendar:n_dates",
-    "C3C4Competition:shape",
-    "CalcCarbonIsotopes:shape",
-    "PModelEnvironment:shape",
-    "PModel:shape",
-    "SubdailyPModel:shape",
-    "OptimalChiC4:shape",
-    "OptimalChiC4NoGamma:shape",
-    "OptimalChiPrentice14:shape",
-    "QuantumYieldTemperature:shape",
-    "QuantumYieldFixed:shape",
-    "JmaxLimitationWang17:_shape",
-    "SplashModel:shape",
-]
-
-
-# These methods require specific arguments
-def defined_method_args(argument: str, ctx: "Context") -> Any | None:
-    """Return any manually defined arguments for the current function / method.
-
-    This is done by defining an `arguments` dictionary for the function and then
-    returning the value (if any) of the specific `argument`.
-
-    Parameters
-    ----------
-    argument : str
-        The name of the input argument to define.
-    ctx : Context
-        The context containing the name of the function (`ctx.name`) and the parent
-        classes / class method being tested (`ctx.parents`).
-
-    Returns:
-    -------
-    Any | None
-        The manually defined value for the argument, or `None` if it can be set by the
-        defaults.
-    """
-    shape = ctx.shape()
-
-    # PModel parameters
-    splashDatesLen = 10
-    # Demography parameters
-    n_pft = 3
-    n_heights = 2
-    pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
-
-    method_arguments_list: dict[str, dict] = {
-        ## PModel
-        # Subdaily data needs more than 1 day of times (uses 48 hours)
-        "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},
-        "AcclimationModel.set_nearest": {"time": np.timedelta64(12, "h")},
-        "AcclimationModel._validate_and_set_datetimes": {
-            "datetimes": np.arange(0, 48, dtype="datetime64[h]")
-        },
-        "AcclimationModel._get_subdaily_interpolation_xy": {"values": np.ones(2)},
-        "AcclimationModel.fill_daily_to_subdaily": {"values": np.ones((2, *shape[1:]))},
-        "AcclimationModel.get_window_values": {"values": np.ones(48)},
-        "AcclimationModel.get_daily_means": {"values": np.ones(48)},
-        "calculate_kattge_knorr_arrhenius_factor": {
-            "coef": {"ha": 1, "hd": 1, "entropy_intercept": 1, "entropy_slope": 1}
-        },
-        "SplashModel.estimate_daily_water_balance": {
-            "previous_wn": np.full(shape[1:], splashDatesLen),
-        },
-        "SplashModel.calculate_soil_moisture": {"wn_init": np.full(shape[1:], 10)},
-        "PModelEnvironment": {"patm": np.full(shape, 100000)},
-        "TwoLeafIrradiance": {"patm": np.full(shape, 100000)},
-        ## Demography uses 1D arrays (a lot of these could probably be skipped)
-        "Cohorts": {
-            "dbh_values": np.full(n_pft, 2),
-            "n_individuals": np.ones(n_pft),
-            "pft_names": np.array(pft_names, dtype=np.str_),
-        },
-        "Flora": {"pfts": [PlantFunctionalType(name=name) for name in pft_names]},
-        "Flora.get_stem_traits": {"pft_names": pft_names},
-        "Canopy": {"fit_ppa": True},
-        "CohortCanopyData": {
-            "projected_leaf_area": np.ones((n_heights, n_pft)),
-            "n_individuals": np.ones(n_pft),
-            "lai": np.ones(n_pft),
-            "par_ext": np.ones(n_pft),
-        },
-        "CommunityCanopyData": {
-            "absorption": np.full((n_heights, n_pft), 0.5),
-            "leaf_area_index": np.full((n_heights, n_pft), 0.5),
-            "cohort_leaf_area": np.full((n_heights, n_pft), 1),
-        },
-        "StemAllometry": {"at_dbh": np.full(n_pft, 0.5)},
-        "StemAllocation": {"whole_crown_gpp": np.full(n_pft, 0.5)},
-        "CrownProfile": {"z": np.linspace(5, 15, n_heights)[:, np.newaxis]},
-        "Cohorts.drop_cohort_data": {"drop_indices": [0, 1]},
-        "StemAllometry.drop_cohort_data": {"drop_indices": [0, 1]},
-        "Community.drop_cohorts": {"drop_indices": [0, 1]},
-    }
-    arguments: dict = method_arguments_list.get(ctx.name, {})
-
-    # Arguments that use temporary variables or depend on parents
-
-    if ctx.name.split(".")[0] == "AnnualValueCalculator":
-        # Needs one-dimensional times
-        nTime = 3
-        if ctx.name == "AnnualValueCalculator":
-            arguments = {"timing": np.arange(0, nTime, dtype="datetime64[D]")}
-        elif ctx.name in [
-            "AnnualValueCalculator._split_values_by_year",
-            "AnnualValueCalculator.get_annual_means",
-            "AnnualValueCalculator.get_annual_totals",
-        ]:
-            shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
-            arguments = {"values": np.ones(shape2)}
-
-    if ctx.name.split(".")[0] in ["DailySolarFluxes", "DailyEvapFluxes"]:
-        # Needs first dimension to match the dates
-        nTime = 4
-        shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
-        if ctx.name == "DailySolarFluxes":
-            arguments = {
-                "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
-                "latitude": np.full(shape2, 10),
-                "elevation": np.full(shape2, 10),
-                "sunshine_fraction": np.full(shape2, 0.5),
-                "temperature": np.full(shape2, 25),
-            }
-        elif ctx.name == "DailyEvapFluxes":
-            arguments = {
-                "pa": np.full(shape2, 10),
-                "tc": np.full(shape2, 25),
-                "kWm": np.full(shape2, 150),
-            }
-        elif ctx.name == "DailyEvapFluxes.estimate_aet":
-            arguments = {"wn": np.full(shape2, 10)}
-
-    if ctx.name == "SplashModel":
-        if (
-            ctx.parents
-            and ctx.parents[0] == "SplashModel.estimate_initial_soil_moisture"
-        ):
-            # Requires at least 1 year of data
-            nTime = 366
-        else:
-            nTime = splashDatesLen
-        splashShape = (1 if shape[0] == 1 else nTime, *shape[1:])
-        arguments = {
-            "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
-            "lat": np.full(splashShape, 10),
-            "elv": np.full(splashShape, 10),
-            "sf": np.full(splashShape, 0.5),
-            "tc": np.full(splashShape, 25),
-            "pn": np.full(splashShape, 10),
-        }
-
-    if ctx.name == "PModelEnvironment":
-        if ctx.parents and ctx.parents[-1] == "SubdailyPModel":
-            # SubdailyPModel needs more than 1 day (uses 48 hourly times)
-            envShape = (1 if shape[0] == 1 else 48, *shape[1:])
-            arguments = {
-                "tc": np.full(envShape, 20),
-                "vpd": np.full(envShape, 40),
-                "co2": np.full(envShape, 1000),
-                "patm": np.full(envShape, 101325),
-                "fapar": np.full(envShape, 1),
-                "ppfd": np.full(envShape, 800),
-            }
-
-    return arguments.get(argument)
-
-
-# Call additional methods when initialising these classes
-additional_init_methods = {
-    "AcclimationModel": "set_nearest",
-}
-
-
-## Functions to get the list of callables
-def get_package_modules(pkg: ModuleType) -> list[ModuleType]:
-    """Get a list of modules contained within the package."""
-    import importlib
-    import pkgutil
-
-    modules = []
-    for _, modname, ispkg in pkgutil.walk_packages(
-        pkg.__path__, prefix=pkg.__name__ + "."
-    ):
-        if not ispkg:
-            modules.append(importlib.import_module(modname))
-
-    return modules
-
-
-def get_module_callables(
-    module: ModuleType,
-) -> Iterator[tuple[str, Callable, type | None]]:
-    """Get the callables contained within a module.
-
-    Returns an iterable including the function/method name, callable, and (if a method)
-    class.
-    """
-    for name, obj in inspect.getmembers(module):
-        if getattr(obj, "__module__", None) != module.__name__:
-            continue
-        if inspect.isfunction(obj) or inspect.ismethod(obj):
-            yield name, obj, None
-        elif inspect.isclass(obj):
-            for mname, method in inspect.getmembers(obj, predicate=inspect.isfunction):
-                if mname in ["__init__", "__post_init__"]:
-                    yield name, method, obj
-                else:
-                    yield f"{name}.{mname}", method, obj
-
-
-def is_instance_method(cls: type | None, method_name: str) -> bool:
-    """Returns True if the method is not static or a classmethod."""
-    if cls is None:
-        return False
-    attr = inspect.getattr_static(cls, method_name)
-    if isinstance(attr, staticmethod | classmethod):
-        return False
-    else:
-        return True
-
-
-## Functions to get the argument datatypes
-def strip_wrapped_types(typ: Any) -> Any:
-    """Handle basic wrapped types to get the inner type."""
-    # InitVar[T] -> T
-    if isinstance(typ, InitVar):
-        return strip_wrapped_types(typ.type)
-    # Type[T] -> T
-    if get_origin(typ) is type:
-        args = get_args(typ)
-
-        return strip_wrapped_types(args[0])
-    return typ
-
-
-def is_array_type(typ: Any) -> bool:
-    """Returns True if the type is a numpy array."""
-    typ = strip_wrapped_types(typ)
-
-    # If Union[...] or X | Y then check both types
-    origin = get_origin(typ)  # Get the unannotated type, i.e. X[...] -> X
-    if origin in (Union, UnionType):
-        return any(is_array_type(arg) for arg in get_args(typ))
-
-    try:
-        # Handle annotated types like NDArray[np.float32]
-        if origin is not None:
-            return issubclass(origin, np.ndarray)
-
-        # Handle basic types
-        return issubclass(typ, np.ndarray)
-
-    except TypeError:
-        return False
-
-
-def has_array_input(method: Callable) -> bool:
-    """Returns True if any of the method arguments are a numpy array."""
-    from typing import get_type_hints
-
-    try:
-        hints = get_type_hints(method)
-        hints = {k: v for k, v in hints.items() if k != "return"}
-    except NameError:
-        return False
-
-    return any(is_array_type(typ) for typ in hints.values())
-
-
-def extract_numpy_dtype(typ: Any) -> npt.DTypeLike:
-    """Extract a numpy dtype from NDArray annotation."""
-    dtype: npt.DTypeLike = np.float64
-
-    args = get_args(typ)
-    if not args:
-        return dtype  # If no annotation
-
-    for arg in args:
-        # args could be like: (tuple[int, ...], numpy.dtype[numpy.datetime64])
-        if get_origin(arg) is np.dtype:
-            dtype_args = get_args(arg)
-            try:
-                dtype = np.dtype(dtype_args[0]).type
-            except TypeError:
-                continue
-        # Or like (np.float64)
-        elif isinstance(arg, type) and issubclass(arg, np.generic):
-            dtype = np.dtype(arg)
-
-    # Use a default unit if a datetime
-    if dtype == np.datetime64:
-        dtype = np.dtype("datetime64[D]")
-
-    return dtype
-
-
-## Functions to initialise arguments and classes
-@dataclasses.dataclass
-class Context:
-    """Context class to pass between functions.
-
-    Used to initialise of arguments that depend on array shapes and the heirarchical
-    function/argument class structure.
-
-    Attributes:
-        name (str): Name of the current method/function/class.
-        shapes (list[tuple[int, ...]]): Shapes to iterate over when generating array
-            arguments.
-        i_arg (int): Index of the current argument, used to select a shape.
-        parents (list[str]): Hierarchy of names leading to the current function/class.
-            The first value will be the name of the callable being tested. If it is a
-            class method, the second value will be the name of the class.
-    """
-
-    name: str
-    shapes: list[tuple[int, ...]]
-    i_arg: int = 0
-    parents: list[str] = dataclasses.field(default_factory=list)
-    """A list of the superior function / classes for the current context."""
-
-    def new(self, name: str) -> "Context":
-        """Generate a context for a new function/class, updating the heirarchy."""
-        return Context(name, self.shapes, self.i_arg, [*self.parents, self.name])
-
-    def shape(self) -> tuple[int, ...]:
-        """Return the shape for index `i_arg`."""
-        return self.shapes[self.i_arg % len(self.shapes)]
-
-
-def initialise_type_default(typ: Any, ctx: Context) -> Any:
-    """Define the default value for each type."""
-    from collections.abc import Sequence
-    from random import randint
-
-    from pyrealm.demography.flora import Flora
-
-    # Handle basic wrapped types
-    typ = strip_wrapped_types(typ)
-
-    # If Sequence[T]: create a list of 2 objects
-    origin = get_origin(typ)
-    args = get_args(typ)
-    if origin is Sequence:
-        inner_type = args[0] if args else Any
-        return [initialise_type_default(inner_type, ctx) for _ in range(2)]
-
-    # If Union[...] or X | Y: Create an array if an option, otherwise use the first type
-    if origin in (Union, UnionType):
-        for arg in args:
-            if is_array_type(arg):
-                return initialise_type_default(arg, ctx)
-        return initialise_type_default(args[0], ctx)
-
-    pft_names = ["Tree1", "Tree2", "Tree3"]
-
-    # Numpy arrays
-    if is_array_type(typ):
-        dtype = extract_numpy_dtype(typ)
-        shape = ctx.shape()
-        if np.issubdtype(dtype, np.datetime64):
-            return np.full(shape, 1, dtype="datetime64[D]")
-        else:
-            return np.ones(shape, dtype=dtype)
-
-    # Other types
-    elif typ is str:
-        return ""
-    elif typ is bool:
-        return True
-    elif typ is int:
-        return 1
-    elif typ is float:
-        return 1
-    elif typ is Any:
-        return None
-    elif typ is PlantFunctionalTypeStrict:
-        return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
-    elif typ is Flora:
-        return Flora([PlantFunctionalType(name=name) for name in pft_names])
-    elif typ is StemTraits:
-        return initialise_type_default(Flora, ctx).get_stem_traits(pft_names)
-    elif len(inspect.signature(typ).parameters) > 0:
-        return initialise_class(typ, ctx)
-    else:
-        return typ()
-
-
-def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
-    """Generate the arguments needed for a function.
-
-    Requires type hinting. Numpy arrays are defined using the shapes argument.
-    """
-    from typing import get_type_hints
-
-    kwargs = {}
-    sig = inspect.signature(method)
-    ctx.i_arg = 0
-    for param_name, param in sig.parameters.items():
-        ctx.i_arg += 1
-
-        # Set manually defined values
-        manual_arg = defined_method_args(param_name, ctx)
-        if manual_arg is not None:
-            kwargs[param_name] = manual_arg
-
-        # Skip unnecesary arguments
-        elif param_name == "self" or param.kind in (
-            param.VAR_POSITIONAL,
-            param.VAR_KEYWORD,
-        ):
-            continue
-
-        # Set default arguments
-        elif param.default is not param.empty:
-            kwargs[param_name] = param.default
-
-        # Initialise any other arguments
-        else:
-            if param.annotation is param.empty:
-                raise Exception(f"Missing annotation for {ctx.name}:{param_name}")
-            # Get the contexts of the pyrealm classes to pass to get_type_hints
-            globalns = {}
-            for module in get_package_modules(pyrealm):
-                globalns.update(vars(module))
-            # Resolve any string annotations
-            typ = get_type_hints(method, globalns=globalns).get(
-                param_name, param.annotation
-            )
-            kwargs[param_name] = initialise_type_default(typ, ctx)
-
-    return kwargs
-
-
-def initialise_class(cls: type, ctx: Context) -> Any:
-    """Initialise class input arguments and then the class."""
-    name = cls.__name__
-    ctx_class = ctx.new(name)
-    args = generate_args(cls.__init__, ctx_class)  # type: ignore[misc]
-    instance = cls(**args)
-    # If there are any additional methods required for initialisation call these
-    if name in additional_init_methods:
-        mname = additional_init_methods[name]
-        method = getattr(instance, mname)
-        args = generate_args(method, ctx_class.new(name + "." + mname))
-        method(**args)
-    return instance
-
-
-## Functions to compare the results
-def is_equal(val1: Any, val2: Any) -> bool:
-    """Compare if two variables are equal."""
-    if isinstance(val1, np.ndarray):
-        if np.issubdtype(val1.dtype, np.str_):
-            return np.array_equal(val1, val2)
-        val1_b, val2_b = np.broadcast_arrays(val1, val2)
-        equal = val1_b == val2_b
-        both_nan = np.isnan(val1_b) & np.isnan(val2_b)
-        return bool(np.all(equal | both_nan))
-
-    elif isinstance(val1, list | tuple) and isinstance(val2, list | tuple):
-        if len(val1) != len(val2):
-            return False
-        return all(is_equal(v1, v2) for v1, v2 in zip(val1, val2))
-
-    elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
-        compare_instances(val1, val2)  # Raises if not equal
-        return True
-
-    else:
-        return val1 == val2
-
-
-def _comparison_string(val1: Any, val2: Any) -> str:
-    def value_string(val: Any) -> str:
-        if isinstance(val, np.ndarray) and val.size > 5:
-            val_str = f"<array> {val.shape}"
-        else:
-            val_str = str(val).replace("\n", " ")
-        val_str = val_str[:30] + ".." if len(val_str) > 30 else val_str
-        return val_str
-
-    return value_string(val1) + " != " + value_string(val2)
-
-
-def compare_instances(instance1: Any, instance2: Any):
-    """Raises ValueError if the two class instances do not have equal attributes."""
-    dict1 = instance1.__dict__
-    dict2 = instance2.__dict__
-    class_name = instance1.__class__.__name__
-    for key in dict1:
-        if f"{class_name}:{key}" in ignore_outputs:
-            continue
-        if not is_equal(dict1[key], dict2[key]):
-            attr_comparison = _comparison_string(dict1[key], dict2[key])
-            raise ValueError(f"{class_name}: {key} not equal ({attr_comparison})")
-
-
-method_list = []
-for mod in get_package_modules(pyrealm):
-    for name, method, cls in get_module_callables(mod):
-        if has_array_input(method) and name not in skip_methods:
-            method_list.append((name, method, cls))
 
 shape_full: list[tuple[int, ...]]
 shape_full = [(3, 2, 2)]
@@ -596,6 +39,7 @@ shapes_list = [
     [(3, 1, 1), (1, 2, 2), (3, 2, 2)],
     [(1, 1, 1)],
 ]
+method_list = get_method_list()
 
 
 @pytest.mark.parametrize("shapes", shapes_list)
@@ -620,8 +64,7 @@ def test_array_input_broadcasting(
     args_full = generate_args(method, ctx_full)
 
     # If a class method (initialises class and compares attributes)
-    if is_instance_method(cls, method.__name__):
-        cls = cast(type, cls)  # Make mypy aware this cannot be None
+    if cls is not None:
         # First initialise class and get bound methods
         instance1 = initialise_class(cls, ctx)
         instance2 = initialise_class(cls, ctx_full)
@@ -630,7 +73,8 @@ def test_array_input_broadcasting(
         # Run the method
         result = method1(**args)
         result_full = method2(**args_full)
-        compare_instances(instance1, instance2)  # Fail if attributes not equal
+        # Fail if attributes not equal
+        compare_instances(instance1, instance2)
 
     # If a function / static method
     else:
@@ -640,7 +84,7 @@ def test_array_input_broadcasting(
 
     # Fail if function outputs not equal
     if not is_equal(result, result_full):
-        result_comparison = _comparison_string(result, result_full)
+        result_comparison = comparison_string(result, result_full)
         raise ValueError(f"Results do not match in {name} ({result_comparison})")
 
 

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -96,7 +96,7 @@ def method_args(argument: str, ctx: "Context"):
             "datetimes": np.arange(0, 48, dtype="datetime64[h]")
         },
         "AcclimationModel._get_subdaily_interpolation_xy": {"values": np.ones(2)},
-        "AcclimationModel.fill_daily_to_subdaily": {"values": np.ones(2)},
+        "AcclimationModel.fill_daily_to_subdaily": {"values": np.ones((2, *shape[1:]))},
         "AcclimationModel.get_window_values": {"values": np.ones(48)},
         "AcclimationModel.get_daily_means": {"values": np.ones(48)},
         "calculate_kattge_knorr_arrhenius_factor": {
@@ -131,6 +131,17 @@ def method_args(argument: str, ctx: "Context"):
     arguments: dict = method_arguments_list.get(ctx.name, {})
 
     # Arguments that use temporary variables or depend on parents
+    if ctx.name == "SolarDailyFluxes":
+        nTime = 4
+        solarShape = (1 if shape[0] == 1 else nTime, *shape[1:])
+        arguments = {
+            "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
+            "latitude": np.full(solarShape, 10),
+            "elvation": np.full(solarShape, 10),
+            "sf": np.full(solarShape, 0.5),
+            "tc": np.full(solarShape, 25),
+            "pn": np.full(solarShape, 10),
+        }
     if ctx.name == "SplashModel":
         if (
             ctx.parents
@@ -489,6 +500,8 @@ def compare_instances(instance1: Any, instance2: Any) -> bool:
 shapes: list[tuple[int, ...]]
 shape_full: list[tuple[int, ...]]
 shapes = [(3, 2, 2), (1, 2, 2), (3, 1, 1), (1, 1, 1)]
+shapes = [(1, 2, 2), (3, 2, 2)]
+# shapes = [(3, 1, 1), (1, 2, 2), (3, 2, 2)]
 # shapes = [(1, 1, 1)]
 shape_full = [(3, 2, 2)]
 

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -1,188 +1,31 @@
+"""This module contains the tests to check broadcastable array inputs.
+
+This ensures that the outputs/attributes of any functions/methods are unchanged when
+broadcastable array inputs are used in place of the full size arrays.
+"""
+
+import dataclasses
 import inspect
+import warnings
+from collections.abc import Callable, Iterator
+from types import ModuleType
+from typing import Any, Union, cast
 
 import numpy as np
+import numpy.typing as npt
 
 import pyrealm
 from pyrealm.core.calendar import Calendar
+from pyrealm.core.experimental import ExperimentalFeatureWarning
 from pyrealm.demography.flora import (
     PlantFunctionalType,
     PlantFunctionalTypeStrict,
     StemTraits,
 )
 
-
-def get_package_modules(pkg):
-    import importlib
-    import pkgutil
-
-    modules = []
-    for _, modname, ispkg in pkgutil.walk_packages(
-        pkg.__path__, prefix=pkg.__name__ + "."
-    ):
-        if not ispkg:
-            modules.append(importlib.import_module(modname))
-    return modules
-
-
-def get_module_callables(module):
-    """Returns an iterable including the function/method name, callable, and (if a method) class."""
-    for name, obj in inspect.getmembers(module):
-        if inspect.isfunction(obj) or inspect.ismethod(obj):
-            yield name, obj, None
-        elif inspect.isclass(obj):
-            for mname, method in inspect.getmembers(obj, predicate=inspect.isfunction):
-                if mname in ["__init__", "__post_init__"]:
-                    yield name, method, obj
-                else:
-                    yield f"{name}.{mname}", method, obj
-
-
-def is_instance_method(cls, name):
-    if cls is None:
-        return False
-    attr = inspect.getattr_static(cls, name)
-    if isinstance(attr, (staticmethod, classmethod)):
-        return False
-    else:
-        return True
-
-
-def is_array_type(typ):
-    from dataclasses import InitVar
-    from types import UnionType
-    from typing import Union, get_args, get_origin
-
-    origin = get_origin(typ)  # Get the unannotated type, i.e. X from X[...]
-
-    # Handle Union[...] or X | Y
-    if origin in (Union, UnionType):
-        return any(is_array_type(arg) for arg in get_args(typ))
-
-    # Handle dataclasses.InitVar[...]
-    if isinstance(typ, InitVar):
-        return is_array_type(typ.type)
-
-    try:
-        # Handle annotated types like NDArray[np.float32]
-        if origin is not None:
-            return issubclass(origin, np.ndarray)
-
-        # Handle basic types
-        return issubclass(typ, np.ndarray)
-
-    except TypeError:
-        return False
-
-
-def has_array_input(method):
-    from typing import get_type_hints
-
-    try:
-        hints = get_type_hints(method)
-        hints = {k: v for k, v in hints.items() if k != "return"}
-    except NameError:
-        return False
-
-    return any(is_array_type(typ) for typ in hints.values())
-
-
-def extract_numpy_dtype(typ) -> np.dtype:
-    """Extract a numpy dtype from NDArray annotation."""
-    from typing import get_args, get_origin
-
-    dtype = np.float64
-
-    args = get_args(typ)
-    if not args:
-        return dtype  # If no annotation
-
-    for arg in args:
-        # args could be like: (tuple[int, ...], numpy.dtype[numpy.datetime64])
-        if get_origin(arg) is np.dtype:
-            dtype_args = get_args(arg)
-            try:
-                dtype = np.dtype(dtype_args[0]).type
-            except TypeError:
-                continue
-        # Or like (np.float64)
-        elif isinstance(arg, type) and issubclass(arg, np.generic):
-            dtype = np.dtype(arg)
-
-    # Use a default unit if a datetime
-    if dtype == np.datetime64:
-        dtype = np.dtype("datetime64[D]")
-
-    return dtype
-
-
-# Demography parameters
-n_pft = 3
-n_heights = 2
-pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
-
-
-def initialise_type_default(typ, shape):
-    """Define the default value for each type."""
-    from collections.abc import Sequence
-    from dataclasses import InitVar
-    from random import randint
-    from types import UnionType
-    from typing import Any, Union, get_args, get_origin
-
-    from pyrealm.demography.flora import Flora
-
-    # Handle any wrapped types
-    # InitVar[T]
-    if isinstance(typ, InitVar):
-        typ = typ.type
-    # Sequence[T] (create a sequence of 2)
-    origin = get_origin(typ)
-    args = get_args(typ)
-    if origin is Sequence:
-        inner_type = args[0] if args else Any
-        return [initialise_type_default(inner_type, shape) for _ in range(2)]
-    # Type[T]
-    if origin is type:
-        return initialise_type_default(args[0], shape)
-    # Union[...] or X | Y
-    if origin in (Union, UnionType):
-        # Use an array if an option
-        for arg in args:
-            if is_array_type(arg):
-                return initialise_type_default(arg, shape)
-        # Otherwise first type in list
-        return initialise_type_default(args[0], shape)
-
-    # Numpy arrays
-    if is_array_type(typ):
-        dtype = extract_numpy_dtype(typ)
-        if np.issubdtype(dtype, np.datetime64):
-            return np.full(shape, np.datetime64("2000-01-01"), dtype=dtype)
-        else:
-            return np.ones(shape, dtype=dtype)
-
-    # Other types
-    elif typ == str:
-        return ""
-    elif typ == bool:
-        return True
-    elif typ == int:
-        return 1
-    elif typ == float:
-        return 1
-    elif typ == Any:
-        return None
-    elif typ == PlantFunctionalTypeStrict:
-        return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
-    elif typ == Flora:
-        return Flora([PlantFunctionalType(name=name) for name in pft_names])
-    elif typ == StemTraits:
-        return initialise_type_default(Flora, shape).get_stem_traits(pft_names)
-    elif len(inspect.signature(typ).parameters) > 0:
-        return initialise_class(typ, {}, shape)
-    else:
-        return typ()
-
+warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
 
 # These methods are not relevant or are incompatible without additional work
 skip_methods = [
@@ -233,10 +76,19 @@ skip_methods = [
 
 
 # These methods require specific arguments
-def manual_arguments(method_name, shape):
-    method_arguments = {
+def method_args(argument: str, ctx: "Context"):
+    """Return any manually defined arguments for the current callable in the context."""
+    shape = ctx.shape()
+
+    # PModel parameters
+    splashDatesLen = 10
+    # Demography parameters
+    n_pft = 3
+    n_heights = 2
+    pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
+
+    method_arguments_list: dict[str, dict] = {
         ## PModel
-        # "AcclimationModel.datetimes": np.full(3, np.datetime64("2000-01-01")),
         # Subdaily data needs more than 1 day of times (uses 48 hours)
         "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},
         "AcclimationModel.set_nearest": {"time": np.timedelta64(12, "h")},
@@ -250,7 +102,12 @@ def manual_arguments(method_name, shape):
         "calculate_kattge_knorr_arrhenius_factor": {
             "coef": {"ha": 1, "hd": 1, "entropy_intercept": 1, "entropy_slope": 1}
         },
-        "SplashModel": {"dates": Calendar(np.arange(0, 3, dtype="datetime64[D]"))},
+        "SplashModel.estimate_daily_water_balance": {
+            "previous_wn": np.full(shape[1:], splashDatesLen),
+        },
+        "SplashModel.calculate_soil_moisture": {"wn_init": np.full(shape[1:], 10)},
+        "PModelEnvironment": {"patm": np.full(shape, 100000)},
+        "TwoLeafIrradiance": {"patm": np.full(shape, 100000)},
         ## Demography uses 1D arrays
         "Cohorts": {
             "dbh_values": np.zeros(n_pft),
@@ -271,40 +128,41 @@ def manual_arguments(method_name, shape):
         "StemAllocation": {"whole_crown_gpp": np.full(n_pft, 0.5)},
         "CrownProfile": {"z": np.linspace(5, 15, n_heights)[:, np.newaxis]},
     }
-    if method_name == "SplashModel.calculate_soil_moisture":
-        return {"wn_init": np.full(shape[1:], 10)}
-    if method_name == "SubdailyPModel":
-        # Need a PModelEnvironment with 48 hour times
-        envShape = (1 if shape[0] == 1 else 48, *shape[1:])
-        return {
-            "env": pyrealm.pmodel.PModelEnvironment(
-                tc=np.full(envShape, 20),
-                vpd=np.full(envShape, 40),
-                co2=np.full(envShape, 1000),
-                patm=np.full(envShape, 101325),
-                fapar=np.full(envShape, 1),
-                ppfd=np.full(envShape, 8000),
-            )
-        }
+    arguments: dict = method_arguments_list.get(ctx.name, {})
 
-    return method_arguments.get(method_name, {})
-
-
-# These methods need specific class initialisation parameters
-def method_class_arguments(method_name, shape):
-    if method_name == "SplashModel.estimate_initial_soil_moisture":
-        # Requires at least 1 year of data
-        nTime = 366
-        timeShape = (nTime if shape[0] != 1 else 1, *shape[1:])
-        return {
+    # Arguments that use temporary variables or depend on parents
+    if ctx.name == "SplashModel":
+        if (
+            ctx.parents
+            and ctx.parents[0] == "SplashModel.estimate_initial_soil_moisture"
+        ):
+            # Requires at least 1 year of data
+            nTime = 366
+        else:
+            nTime = splashDatesLen
+        splashShape = (1 if shape[0] == 1 else nTime, *shape[1:])
+        arguments = {
             "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
-            "lat": np.full(timeShape, 0),
-            "elv": np.full(timeShape, 10),
-            "sf": np.full(timeShape, 0.5),
-            "tc": np.full(timeShape, 25),
-            "pn": np.full(timeShape, 10),
+            "lat": np.full(splashShape, 10),
+            "elv": np.full(splashShape, 10),
+            "sf": np.full(splashShape, 0.5),
+            "tc": np.full(splashShape, 25),
+            "pn": np.full(splashShape, 10),
         }
-    return {}
+    if ctx.name == "PModelEnvironment":
+        if ctx.parents and ctx.parents[-1] == "SubdailyPModel":
+            # SubdailyPModel needs more than 1 day (uses 48 hourly times)
+            envShape = (1 if shape[0] == 1 else 48, *shape[1:])
+            arguments = {
+                "tc": np.full(envShape, 20),
+                "vpd": np.full(envShape, 40),
+                "co2": np.full(envShape, 1000),
+                "patm": np.full(envShape, 101325),
+                "fapar": np.full(envShape, 1),
+                "ppfd": np.full(envShape, 800),
+            }
+
+    return arguments.get(argument)
 
 
 # Call additional methods when initialising these classes
@@ -313,31 +171,256 @@ additional_init_methods = {
 }
 
 
-def generate_args(name, method, manual_args, shape):
-    """Generate the arguments needed for a function. Requires type hinting.
-    Numpy arrays are defined using the shape argument.
+## Functions to get the list of callables
+def get_package_modules(pkg: ModuleType) -> list[ModuleType]:
+    """Get a list of modules contained within the package."""
+    import importlib
+    import pkgutil
+
+    modules = []
+    for _, modname, ispkg in pkgutil.walk_packages(
+        pkg.__path__, prefix=pkg.__name__ + "."
+    ):
+        if not ispkg:
+            modules.append(importlib.import_module(modname))
+    return modules
+
+
+def get_module_callables(
+    module: ModuleType,
+) -> Iterator[tuple[str, Callable, type | None]]:
+    """Get the callables contained within a module.
+
+    Returns an iterable including the function/method name, callable, and (if a method)
+    class.
+    """
+    for name, obj in inspect.getmembers(module):
+        if getattr(obj, "__module__", None) != module.__name__:
+            continue
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            yield name, obj, None
+        elif inspect.isclass(obj):
+            for mname, method in inspect.getmembers(obj, predicate=inspect.isfunction):
+                if mname in ["__init__", "__post_init__"]:
+                    yield name, method, obj
+                else:
+                    yield f"{name}.{mname}", method, obj
+
+
+def is_instance_method(cls: type | None, method_name: str) -> bool:
+    """Returns True if the method is not static or a classmethod."""
+    if cls is None:
+        return False
+    attr = inspect.getattr_static(cls, method_name)
+    if isinstance(attr, staticmethod | classmethod):
+        return False
+    else:
+        return True
+
+
+## Functions to get the argument datatypes
+def is_array_type(typ: Any) -> bool:
+    """Returns True if the type is a numpy array."""
+    from dataclasses import InitVar
+    from types import UnionType
+    from typing import get_args, get_origin
+
+    origin = get_origin(typ)  # Get the unannotated type, i.e. X from X[...]
+
+    # Handle Union[...] or X | Y
+    if origin in (Union, UnionType):
+        return any(is_array_type(arg) for arg in get_args(typ))
+
+    # Handle dataclasses.InitVar[...]
+    if isinstance(typ, InitVar):
+        return is_array_type(typ.type)
+
+    try:
+        # Handle annotated types like NDArray[np.float32]
+        if origin is not None:
+            return issubclass(origin, np.ndarray)
+
+        # Handle basic types
+        return issubclass(typ, np.ndarray)
+
+    except TypeError:
+        return False
+
+
+def has_array_input(method: Callable) -> bool:
+    """Returns True if any of the method arguments are a numpy array."""
+    from typing import get_type_hints
+
+    try:
+        hints = get_type_hints(method)
+        hints = {k: v for k, v in hints.items() if k != "return"}
+    except NameError:
+        return False
+
+    return any(is_array_type(typ) for typ in hints.values())
+
+
+def extract_numpy_dtype(typ: Any) -> npt.DTypeLike:
+    """Extract a numpy dtype from NDArray annotation."""
+    from typing import get_args, get_origin
+
+    dtype: npt.DTypeLike = np.float64
+
+    args = get_args(typ)
+    if not args:
+        return dtype  # If no annotation
+
+    for arg in args:
+        # args could be like: (tuple[int, ...], numpy.dtype[numpy.datetime64])
+        if get_origin(arg) is np.dtype:
+            dtype_args = get_args(arg)
+            try:
+                dtype = np.dtype(dtype_args[0]).type
+            except TypeError:
+                continue
+        # Or like (np.float64)
+        elif isinstance(arg, type) and issubclass(arg, np.generic):
+            dtype = np.dtype(arg)
+
+    # Use a default unit if a datetime
+    if dtype == np.datetime64:
+        dtype = np.dtype("datetime64[D]")
+
+    return dtype
+
+
+## Functions to initialise arguments and classes
+@dataclasses.dataclass
+class Context:
+    """Context class to pass between functions.
+
+    Used to initialise of arguments that depend on array shapes and the heirarchical
+    function/argument class structure.
+
+    Attributes:
+        name (str): Name of the current method/function/class.
+        shapes (list[tuple[int, ...]]): Shapes to iterate over when generating array
+            arguments.
+        i_arg (int): Index of the current argument, used to select a shape.
+        parents (list[str]): Hierarchy of names leading to the current function/class.
+            The first value will be the name of the callable being tested. If it is a
+            class method, the second value will be the name of the class.
+    """
+
+    name: str
+    shapes: list[tuple[int, ...]]
+    i_arg: int = 0
+    parents: list[str] = dataclasses.field(default_factory=list)
+    """A list of the superior function / classes for the current context."""
+
+    def new(self, name: str) -> "Context":
+        """Generate a context for a new function/class, updating the heirarchy."""
+        return Context(name, self.shapes, self.i_arg, [*self.parents, self.name])
+
+    def shape(self) -> tuple[int, ...]:
+        """Return the shape for index `i_arg`."""
+        return self.shapes[self.i_arg % len(self.shapes)]
+
+
+def initialise_type_default(typ: Any, ctx: Context) -> Any:
+    """Define the default value for each type."""
+    from collections.abc import Sequence
+    from dataclasses import InitVar
+    from random import randint
+    from types import UnionType
+    from typing import get_args, get_origin
+
+    from pyrealm.demography.flora import Flora
+
+    # Handle any wrapped types
+    # InitVar[T]
+    if isinstance(typ, InitVar):
+        typ = typ.type
+    # Sequence[T] (create a sequence of 2)
+    origin = get_origin(typ)
+    args = get_args(typ)
+    if origin is Sequence:
+        inner_type = args[0] if args else Any
+        return [initialise_type_default(inner_type, ctx) for _ in range(2)]
+    # Type[T]
+    if origin is type:
+        return initialise_type_default(args[0], ctx)
+    # Union[...] or X | Y
+    if origin in (Union, UnionType):
+        # Use an array if an option
+        for arg in args:
+            if is_array_type(arg):
+                return initialise_type_default(arg, ctx)
+        # Otherwise first type in list
+        return initialise_type_default(args[0], ctx)
+
+    pft_names = ["Tree1", "Tree2", "Tree3"]
+
+    # Numpy arrays
+    if is_array_type(typ):
+        dtype = extract_numpy_dtype(typ)
+        shape = ctx.shape()
+        if np.issubdtype(dtype, np.datetime64):
+            return np.full(shape, np.datetime64("2000-01-01"), dtype=dtype)
+        else:
+            return np.ones(shape, dtype=dtype)
+
+    # Other types
+    elif typ is str:
+        return ""
+    elif typ is bool:
+        return True
+    elif typ is int:
+        return 1
+    elif typ is float:
+        return 1
+    elif typ is Any:
+        return None
+    elif typ is PlantFunctionalTypeStrict:
+        return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
+    elif typ is Flora:
+        return Flora([PlantFunctionalType(name=name) for name in pft_names])
+    elif typ is StemTraits:
+        return initialise_type_default(Flora, ctx).get_stem_traits(pft_names)
+    elif len(inspect.signature(typ).parameters) > 0:
+        return initialise_class(typ, ctx)
+    else:
+        return typ()
+
+
+def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
+    """Generate the arguments needed for a function.
+
+    Requires type hinting. Numpy arrays are defined using the shapes argument.
     """
     from typing import get_type_hints
 
     kwargs = {}
     sig = inspect.signature(method)
+    ctx.i_arg = 0
     for param_name, param in sig.parameters.items():
+        ctx.i_arg += 1
+
         # Set manually defined values
-        if param_name in manual_args:
-            kwargs[param_name] = manual_args[param_name]
+        manual_arg = method_args(param_name, ctx)
+        if manual_arg is not None:
+            kwargs[param_name] = manual_arg
+
         # Skip unnecesary arguments
         elif param_name == "self" or param.kind in (
             param.VAR_POSITIONAL,
             param.VAR_KEYWORD,
         ):
             continue
+
         # Set default arguments
         elif param.default is not param.empty:
             kwargs[param_name] = param.default
+
         # Initialise any other arguments
         else:
             if param.annotation is param.empty:
-                raise Exception(f"Missing annotation for {name}:{param_name}")
+                raise Exception(f"Missing annotation for {ctx.name}:{param_name}")
             # Get the contexts of the pyrealm classes to pass to get_type_hints
             globalns = {}
             for module in get_package_modules(pyrealm):
@@ -346,31 +429,36 @@ def generate_args(name, method, manual_args, shape):
             typ = get_type_hints(method, globalns=globalns).get(
                 param_name, param.annotation
             )
-            kwargs[param_name] = initialise_type_default(typ, shape)
+            kwargs[param_name] = initialise_type_default(typ, ctx)
+
     return kwargs
 
 
-def initialise_class(cls, method_class_args, shape):
+def initialise_class(cls: type, ctx: Context) -> Any:
+    """Initialise class input arguments and then the class."""
     name = cls.__name__
-    # print("Initialising:", name)
-    manual_args = manual_arguments(name, shape) | method_class_args
-    args = generate_args(name, cls.__init__, manual_args, shape)
+    ctx_class = ctx.new(name)
+    args = generate_args(cls.__init__, ctx_class)  # type: ignore[misc]
     instance = cls(**args)
     # If there are any additional methods required for initialisation call these
     if name in additional_init_methods:
         mname = additional_init_methods[name]
         method = getattr(instance, mname)
-        manual_method_args = manual_arguments(name + "." + mname, shape)
-        args = generate_args(name + "." + mname, method, manual_method_args, shape)
+        args = generate_args(method, ctx_class.new(name + "." + mname))
         method(**args)
     return instance
 
 
-def is_equal(val1, val2):
+## Functions to compare the results
+def is_equal(val1: Any, val2: Any) -> bool:
+    """Compare if two variables are equal."""
     if isinstance(val1, np.ndarray):
-        if val1.shape != val2.shape:
-            return False
-        return np.all(val1 == val2)
+        if np.issubdtype(val1.dtype, np.str_):
+            return np.array_equal(val1, val2)
+        val1_b, val2_b = np.broadcast_arrays(val1, val2)
+        equal = val1_b == val2_b
+        both_nan = np.isnan(val1_b) & np.isnan(val2_b)
+        return bool(np.all(equal | both_nan))
 
     elif isinstance(val1, tuple) and isinstance(val2, tuple):
         if len(val1) != len(val2):
@@ -384,45 +472,56 @@ def is_equal(val1, val2):
         return val1 == val2
 
 
-def compare_instances(instance1, instance2):
+def compare_instances(instance1: Any, instance2: Any) -> bool:
+    """Compare if two class instances have equal attributes."""
     dict1 = instance1.__dict__
     dict2 = instance2.__dict__
     for key in dict1:
         if not is_equal(dict1[key], dict2[key]):
+            print(f"{instance1.__class__.__name__}: {key} not equal")
+            # print(dict1[key])
+            # print(dict2[key])
+            # raise ValueError
             return False
     return True
 
 
-shape = (3, 1, 1)
-shape_full = (3, 2, 2)
+shapes: list[tuple[int, ...]]
+shape_full: list[tuple[int, ...]]
+shapes = [(3, 2, 2), (1, 2, 2), (3, 1, 1), (1, 1, 1)]
+# shapes = [(1, 1, 1)]
+shape_full = [(3, 2, 2)]
 
 for mod in get_package_modules(pyrealm):
     for name, method, cls in get_module_callables(mod):
         if not has_array_input(method) or name in skip_methods:
             continue
 
-        print(name)
+        is_correct = True
 
         # Generate the arguments for the method
-        manual_args = manual_arguments(name, shape)
-        args = generate_args(name, method, manual_args, shape)
-        args_full = generate_args(name, method, manual_args, shape_full)
+        ctx = Context(name, shapes)
+        ctx_full = Context(name, shape_full)
+        args = generate_args(method, ctx)
+        args_full = generate_args(method, ctx_full)
 
         if is_instance_method(cls, method.__name__):
+            cls = cast(type, cls)  # Make mypy aware this cannot be None
             # First initialise class and get bound methods
-            method_class_args = method_class_arguments(name, shape)
-            instance1 = initialise_class(cls, method_class_args, shape)
-            instance2 = initialise_class(cls, method_class_args, shape_full)
+            instance1 = initialise_class(cls, ctx)
+            instance2 = initialise_class(cls, ctx_full)
             method1 = getattr(instance1, method.__name__)
             method2 = getattr(instance2, method.__name__)
             # Run the method
             result = method1(**args)
             result_full = method2(**args_full)
             # Compare results
+            is_correct = is_equal(result, result_full)
+            if not is_correct:
+                print(name, ": Result not equal")
             is_correct = is_equal(result, result_full) and compare_instances(
                 instance1, instance2
             )
-            print("Correct?", is_correct)
 
         else:
             # Run the method
@@ -430,9 +529,12 @@ for mod in get_package_modules(pyrealm):
             result_full = method(**args_full)
             # Compare results
             is_correct = is_equal(result, result_full)
-            print("Correct?", is_correct)
+            if not is_correct:
+                print(name, ": Result not equal")
 
-        print()
+        # if (not is_correct):
+        #     print(name)
+        #     print()
         # # Compare the results to see if they are identical
         # if (not is_correct):
         # raise Error(f'Results do not match in {name}')

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -10,7 +10,6 @@ To resolve failing tests there are a few options to use in utils.py:
     - `ADDITIONAL_INIT_METHODS`: For classes needing to call additional methods.
 """
 
-import warnings
 from collections.abc import Callable
 
 import pytest
@@ -23,8 +22,6 @@ from utils import (
     initialise_class,
     is_equal,
 )
-
-from pyrealm.core.experimental import ExperimentalFeatureWarning
 
 SHAPE_FULL: list[tuple[int, ...]]
 SHAPE_FULL = [(3, 2, 2)]
@@ -40,6 +37,9 @@ METHOD_LIST = get_method_list()
 @pytest.mark.broadcasting
 @pytest.mark.parametrize("shapes", SHAPES_LIST)
 @pytest.mark.parametrize("method_info", METHOD_LIST, ids=[m[0] for m in METHOD_LIST])
+@pytest.mark.filterwarnings("ignore::ExperimentalFeatureWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_array_input_broadcasting(
     method_info: tuple[str, Callable, type | None],
     shapes: list[tuple[int, ...]],
@@ -51,10 +51,6 @@ def test_array_input_broadcasting(
     the outputs (and all class attributes for class methods). Raises a ValueError if
     incorrect.
     """
-    warnings.filterwarnings("ignore", category=ExperimentalFeatureWarning)
-    warnings.filterwarnings("ignore", category=RuntimeWarning)
-    warnings.filterwarnings("ignore", category=UserWarning)
-
     name, method, cls = method_info
 
     # Generate the arguments for the function / method

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -162,7 +162,8 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
             "AnnualValueCalculator.get_annual_means",
             "AnnualValueCalculator.get_annual_totals",
         ]:
-            arguments = {"values": np.ones((nTime, *shape[1:]))}
+            shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
+            arguments = {"values": np.ones(shape2)}
     if ctx.name == "SolarDailyFluxes":
         nTime = 4
         solarShape = (1 if shape[0] == 1 else nTime, *shape[1:])
@@ -506,7 +507,8 @@ def is_equal(val1: Any, val2: Any) -> bool:
         return all(is_equal(v1, v2) for v1, v2 in zip(val1, val2))
 
     elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
-        return compare_instances(val1, val2)
+        compare_instances(val1, val2)  # Raises if not equal
+        return True
 
     else:
         return val1 == val2

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -3,6 +3,7 @@ import inspect
 import numpy as np
 
 import pyrealm
+from pyrealm.core.calendar import Calendar
 from pyrealm.demography.flora import (
     PlantFunctionalType,
     PlantFunctionalTypeStrict,
@@ -118,15 +119,6 @@ def extract_numpy_dtype(typ) -> np.dtype:
 n_pft = 3
 n_heights = 2
 pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
-crown_m = np.arange(n_pft)
-crown_n = np.arange(n_pft)
-crown_z = np.linspace(5, 15, n_heights)[:, np.newaxis]
-crown_stem_height = np.full(n_pft, 10)
-crown_area = np.full(n_pft, 10)
-crown_q_m = np.full(n_pft, 3)
-crown_z_max = np.full(n_pft, 10)
-crown_q_z = np.full((n_heights, n_pft), 10)
-crown_n_ind = np.full(n_pft, 2)
 
 
 def initialise_type_default(typ, shape):
@@ -164,7 +156,7 @@ def initialise_type_default(typ, shape):
     # Numpy arrays
     if is_array_type(typ):
         dtype = extract_numpy_dtype(typ)
-        if dtype == np.datetime64:
+        if np.issubdtype(dtype, np.datetime64):
             return np.full(shape, np.datetime64("2000-01-01"), dtype=dtype)
         else:
             return np.ones(shape, dtype=dtype)
@@ -187,7 +179,7 @@ def initialise_type_default(typ, shape):
     elif typ == StemTraits:
         return initialise_type_default(Flora, shape).get_stem_traits(pft_names)
     elif len(inspect.signature(typ).parameters) > 0:
-        return initialise_class(typ, shape)
+        return initialise_class(typ, {}, shape)
     else:
         return typ()
 
@@ -196,7 +188,17 @@ def initialise_type_default(typ, shape):
 skip_methods = [
     # PModel
     "AcclimationModel.set_include",
-    # Demography
+    "PModelABC",  # Cannot init ABC
+    "QuantumYieldABC",  # Cannot init ABC
+    "OptimalChiABC.estimate_chi",  # Cannot init ABC
+    "OptimalChiC4RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiC4NoGammaRootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiPrentice14RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiLavergne20C3.estimate_chi",  # Requires theta in PME
+    "OptimalChiLavergne20C4.estimate_chi",  # Requires theta in PME
+    "QuantumYieldSandoval",  # Requires aridity_index in PME
+    "QuantumYieldSandoval.peak_quantum_yield",  # Requires aridity_index in PME
+    # Demography - mostly 1d arrays (dataframes)
     "CohortMethods.drop_cohort_data",
     "StemTraits",
     "StemTraits.drop_cohort_data",
@@ -229,41 +231,81 @@ skip_methods = [
     "calculate_whole_crown_gpp",
 ]
 
+
 # These methods require specific arguments
-manual_test_parameters = {
-    ## PModel
-    # "AcclimationModel.datetimes": np.full(3, np.datetime64("2000-01-01")),
-    "AcclimationModel.datetimes": np.arange(0, 48, dtype="datetime64[h]"),
-    "AcclimationModel.set_nearest.time": np.timedelta64(12, "h"),
-    "AcclimationModel._validate_and_set_datetimes.datetimes": np.arange(
-        0, 48, dtype="datetime64[h]"
-    ),
-    "AcclimationModel._get_subdaily_interpolation_xy.values": np.ones(2),
-    "AcclimationModel.fill_daily_to_subdaily.values": np.ones(2),
-    "AcclimationModel.get_window_values.values": np.ones(48),
-    "AcclimationModel.get_daily_means.values": np.ones(48),
-    "calculate_kattge_knorr_arrhenius_factor.coef": {
-        "ha": 1,
-        "hd": 1,
-        "entropy_intercept": 1,
-        "entropy_slope": 1,
-    },
-    ## Demography uses 1D arrays
-    "Cohorts.dbh_values": np.zeros(n_pft),
-    "Cohorts.n_individuals": np.ones(n_pft),
-    "Cohorts.pft_names": np.array(pft_names, dtype=np.str_),
-    "Flora.pfts": [PlantFunctionalType(name=name) for name in pft_names],
-    "Flora.get_stem_traits.pft_names": pft_names,
-    "Canopy.fit_ppa": True,
-    "CohortCanopyData.projected_leaf_area": np.ones((n_heights, n_pft)),
-    "CohortCanopyData.n_individuals": np.ones(n_pft),
-    "CohortCanopyData.pft_lai": np.ones(n_pft),
-    "CohortCanopyData.pft_par_ext": np.ones(n_pft),
-    "CommunityCanopyData.cohort_transmissivity": np.ones((n_heights, n_pft)),
-    "StemAllometry.at_dbh": np.full(n_pft, 0.5),
-    "StemAllocation.whole_crown_gpp": np.full(n_pft, 0.5),
-    "CrownProfile.z": crown_z,
-}
+def manual_arguments(method_name, shape):
+    method_arguments = {
+        ## PModel
+        # "AcclimationModel.datetimes": np.full(3, np.datetime64("2000-01-01")),
+        # Subdaily data needs more than 1 day of times (uses 48 hours)
+        "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},
+        "AcclimationModel.set_nearest": {"time": np.timedelta64(12, "h")},
+        "AcclimationModel._validate_and_set_datetimes": {
+            "datetimes": np.arange(0, 48, dtype="datetime64[h]")
+        },
+        "AcclimationModel._get_subdaily_interpolation_xy": {"values": np.ones(2)},
+        "AcclimationModel.fill_daily_to_subdaily": {"values": np.ones(2)},
+        "AcclimationModel.get_window_values": {"values": np.ones(48)},
+        "AcclimationModel.get_daily_means": {"values": np.ones(48)},
+        "calculate_kattge_knorr_arrhenius_factor": {
+            "coef": {"ha": 1, "hd": 1, "entropy_intercept": 1, "entropy_slope": 1}
+        },
+        "SplashModel": {"dates": Calendar(np.arange(0, 3, dtype="datetime64[D]"))},
+        ## Demography uses 1D arrays
+        "Cohorts": {
+            "dbh_values": np.zeros(n_pft),
+            "n_individuals": np.ones(n_pft),
+            "pft_names": np.array(pft_names, dtype=np.str_),
+        },
+        "Flora": {"pfts": [PlantFunctionalType(name=name) for name in pft_names]},
+        "Flora.get_stem_traits": {"pft_names": pft_names},
+        "Canopy": {"fit_ppa": True},
+        "CohortCanopyData": {
+            "projected_leaf_area": np.ones((n_heights, n_pft)),
+            "n_individuals": np.ones(n_pft),
+            "pft_lai": np.ones(n_pft),
+            "pft_par_ext": np.ones(n_pft),
+        },
+        "CommunityCanopyData": {"cohort_transmissivity": np.ones((n_heights, n_pft))},
+        "StemAllometry": {"at_dbh": np.full(n_pft, 0.5)},
+        "StemAllocation": {"whole_crown_gpp": np.full(n_pft, 0.5)},
+        "CrownProfile": {"z": np.linspace(5, 15, n_heights)[:, np.newaxis]},
+    }
+    if method_name == "SplashModel.calculate_soil_moisture":
+        return {"wn_init": np.full(shape[1:], 10)}
+    if method_name == "SubdailyPModel":
+        # Need a PModelEnvironment with 48 hour times
+        envShape = (1 if shape[0] == 1 else 48, *shape[1:])
+        return {
+            "env": pyrealm.pmodel.PModelEnvironment(
+                tc=np.full(envShape, 20),
+                vpd=np.full(envShape, 40),
+                co2=np.full(envShape, 1000),
+                patm=np.full(envShape, 101325),
+                fapar=np.full(envShape, 1),
+                ppfd=np.full(envShape, 8000),
+            )
+        }
+
+    return method_arguments.get(method_name, {})
+
+
+# These methods need specific class initialisation parameters
+def method_class_arguments(method_name, shape):
+    if method_name == "SplashModel.estimate_initial_soil_moisture":
+        # Requires at least 1 year of data
+        nTime = 366
+        timeShape = (nTime if shape[0] != 1 else 1, *shape[1:])
+        return {
+            "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
+            "lat": np.full(timeShape, 0),
+            "elv": np.full(timeShape, 10),
+            "sf": np.full(timeShape, 0.5),
+            "tc": np.full(timeShape, 25),
+            "pn": np.full(timeShape, 10),
+        }
+    return {}
+
 
 # Call additional methods when initialising these classes
 additional_init_methods = {
@@ -271,7 +313,7 @@ additional_init_methods = {
 }
 
 
-def generate_args(name, method, shape):
+def generate_args(name, method, manual_args, shape):
     """Generate the arguments needed for a function. Requires type hinting.
     Numpy arrays are defined using the shape argument.
     """
@@ -280,10 +322,9 @@ def generate_args(name, method, shape):
     kwargs = {}
     sig = inspect.signature(method)
     for param_name, param in sig.parameters.items():
-        method_arg_name = f"{name}.{param_name}"
         # Set manually defined values
-        if method_arg_name in manual_test_parameters:
-            kwargs[param_name] = manual_test_parameters[method_arg_name]
+        if param_name in manual_args:
+            kwargs[param_name] = manual_args[param_name]
         # Skip unnecesary arguments
         elif param_name == "self" or param.kind in (
             param.VAR_POSITIONAL,
@@ -296,7 +337,7 @@ def generate_args(name, method, shape):
         # Initialise any other arguments
         else:
             if param.annotation is param.empty:
-                raise Exception(f"Missing annotation for {method_arg_name}")
+                raise Exception(f"Missing annotation for {name}:{param_name}")
             # Get the contexts of the pyrealm classes to pass to get_type_hints
             globalns = {}
             for module in get_package_modules(pyrealm):
@@ -309,15 +350,18 @@ def generate_args(name, method, shape):
     return kwargs
 
 
-def initialise_class(cls, shape):
+def initialise_class(cls, method_class_args, shape):
     name = cls.__name__
-    print("Initialising:", name)
-    args = generate_args(name, cls.__init__, shape)
+    # print("Initialising:", name)
+    manual_args = manual_arguments(name, shape) | method_class_args
+    args = generate_args(name, cls.__init__, manual_args, shape)
     instance = cls(**args)
+    # If there are any additional methods required for initialisation call these
     if name in additional_init_methods:
         mname = additional_init_methods[name]
         method = getattr(instance, mname)
-        args = generate_args(name + "." + mname, method, shape)
+        manual_method_args = manual_arguments(name + "." + mname, shape)
+        args = generate_args(name + "." + mname, method, manual_method_args, shape)
         method(**args)
     return instance
 
@@ -353,8 +397,6 @@ shape = (3, 1, 1)
 shape_full = (3, 2, 2)
 
 for mod in get_package_modules(pyrealm):
-    print(mod)
-    print()
     for name, method, cls in get_module_callables(mod):
         if not has_array_input(method) or name in skip_methods:
             continue
@@ -362,14 +404,15 @@ for mod in get_package_modules(pyrealm):
         print(name)
 
         # Generate the arguments for the method
-        args = generate_args(name, method, shape)
-        args_full = generate_args(name, method, shape_full)
+        manual_args = manual_arguments(name, shape)
+        args = generate_args(name, method, manual_args, shape)
+        args_full = generate_args(name, method, manual_args, shape_full)
 
         if is_instance_method(cls, method.__name__):
-            print("CM", name)
             # First initialise class and get bound methods
-            instance1 = initialise_class(cls, shape)
-            instance2 = initialise_class(cls, shape_full)
+            method_class_args = method_class_arguments(name, shape)
+            instance1 = initialise_class(cls, method_class_args, shape)
+            instance2 = initialise_class(cls, method_class_args, shape_full)
             method1 = getattr(instance1, method.__name__)
             method2 = getattr(instance2, method.__name__)
             # Run the method
@@ -379,16 +422,15 @@ for mod in get_package_modules(pyrealm):
             is_correct = is_equal(result, result_full) and compare_instances(
                 instance1, instance2
             )
-            print("CM", name, is_correct)
+            print("Correct?", is_correct)
 
         else:
-            print("FN", name)
             # Run the method
             result = method(**args)
             result_full = method(**args_full)
             # Compare results
             is_correct = is_equal(result, result_full)
-            print("FN", name, is_correct)
+            print("Correct?", is_correct)
 
         print()
         # # Compare the results to see if they are identical

--- a/tests/broadcasting/test_broadcasting.py
+++ b/tests/broadcasting/test_broadcasting.py
@@ -42,6 +42,7 @@ shapes_list = [
 method_list = get_method_list()
 
 
+@pytest.mark.broadcasting
 @pytest.mark.parametrize("shapes", shapes_list)
 @pytest.mark.parametrize("method_info", method_list, ids=[m[0] for m in method_list])
 def test_array_input_broadcasting(

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -86,6 +86,8 @@ ignore_outputs = [
     "QuantumYieldFixed:shape",
     "JmaxLimitationWang17:_shape",
     "SplashModel:shape",
+    "DailySolarFluxes:shape",
+    "DailyEvapFluxes:shape",
 ]
 
 
@@ -135,7 +137,7 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
             "coef": {"ha": 1, "hd": 1, "entropy_intercept": 1, "entropy_slope": 1}
         },
         "SplashModel.estimate_daily_water_balance": {
-            "previous_wn": np.full(shape[1:], splashDatesLen),
+            "previous_wn": np.full((splashDatesLen, *shape[1:]), 10),
         },
         "SplashModel.calculate_soil_moisture": {"wn_init": np.full(shape[1:], 10)},
         "PModelEnvironment": {"patm": np.full(shape, 100000)},

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -1,4 +1,37 @@
-"""Contains utility functions used in test_broadcasting.py."""
+"""Contains utility functions used in test_broadcasting.py.
+
+The structure of the test is:
+- Iterate through the methods / functions of the library.
+- Generate input arguments according to their type hint, with the shape of array
+  arguments defined. This may be called recursively for some types.
+- Check if the function is a class method, if so instantiate the class using the
+  same approach.
+- Call the function once with broadcastable array shapes and once with the fully
+  broadcast inputs. And check the result is the same (but not necessarily the shape).
+- For class methods also check the class attributes are equivalent.
+
+The functions / objects in this file are broadly split into five sections. With the main
+functions listed below:
+1. To manually define function arguments / which functions to ignore, etc in order to
+   fix errors.
+   - `SKIP_METHODS`
+   - `IGNORE_OUTPUTS`
+   - `ADDITIONAL_INIT_METHODS`
+   - `defined_method_args`
+2. To get the list of functions / methods in the library.
+   - `get_method_list`
+3. To get the argument datatypes from the annotations. These are used in section 4.
+4. To initialise function arguments and classes.
+   - `generate_args`
+   - `initialise_class`
+   - `Context` - To keep track of the array shapes and when checking values in section 1
+5. To compare the function outputs / class attributes.
+   - `is_equal`
+   - `compare_instances`
+
+The functions that are not used in `test_broadcasting` and are only used within this
+file are marked private.
+"""
 
 import dataclasses
 import inspect
@@ -21,7 +54,7 @@ from pyrealm.demography.flora import (
 ## Lists / functions to manually define arguments, methods or outputs to ignore, etc.
 
 # These methods are not relevant or are incompatible without additional work
-skip_methods = [
+SKIP_METHODS = [
     "evaluate_horner_polynomial",  # Coefficients are 1D
     # PModel
     "AcclimationModel.set_include",
@@ -71,7 +104,7 @@ skip_methods = [
 
 # Ignore these outputs, they are not expected to be equal.
 # Formats: [fn name] for function results, [class]:[attr] for class attributes
-ignore_outputs = [
+IGNORE_OUTPUTS = [
     "Cohorts:_cohort_id",
     "Calendar:n_dates",
     "C3C4Competition:shape",
@@ -239,7 +272,7 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
 
 
 # Call additional methods when initialising these classes
-additional_init_methods = {
+ADDITIONAL_INIT_METHODS = {
     "AcclimationModel": "set_nearest",
 }
 
@@ -310,7 +343,7 @@ def get_method_list() -> list[tuple[str, Callable, type | None]]:
     method_list = []
     for mod in _get_package_modules(pyrealm):
         for name, method, cls in _get_module_callables(mod):
-            if _has_array_input(method) and name not in skip_methods:
+            if _has_array_input(method) and name not in SKIP_METHODS:
                 method_list.append((name, method, cls))
     return method_list
 
@@ -400,8 +433,8 @@ def _extract_numpy_dtype(typ: Any) -> npt.DTypeLike:
 class Context:
     """Context class to pass between functions.
 
-    Used to initialise of arguments that depend on array shapes and the heirarchical
-    function/argument class structure.
+    Used to initialise arguments that depend on array shapes or for manual overrides
+    that rely upon the heirarchy of function/argument definitions.
 
     Attributes:
         name (str): Name of the current method/function/class.
@@ -555,8 +588,8 @@ def initialise_class(cls: type, ctx: Context) -> Any:
     args = generate_args(cls.__init__, ctx_class)  # type: ignore[misc]
     instance = cls(**args)
     # If there are any additional methods required for initialisation call these
-    if name in additional_init_methods:
-        mname = additional_init_methods[name]
+    if name in ADDITIONAL_INIT_METHODS:
+        mname = ADDITIONAL_INIT_METHODS[name]
         method = getattr(instance, mname)
         args = generate_args(method, ctx_class.new(name + "." + mname))
         method(**args)
@@ -607,7 +640,7 @@ def compare_instances(instance1: Any, instance2: Any):
     dict2 = instance2.__dict__
     class_name = instance1.__class__.__name__
     for key in dict1:
-        if f"{class_name}:{key}" in ignore_outputs:
+        if f"{class_name}:{key}" in IGNORE_OUTPUTS:
             continue
         if not is_equal(dict1[key], dict2[key]):
             attr_comparison = comparison_string(dict1[key], dict2[key])

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -1,0 +1,596 @@
+"""Contains utility functions used in test_broadcasting.py."""
+
+import dataclasses
+import inspect
+from collections.abc import Callable, Iterator
+from dataclasses import InitVar
+from types import ModuleType, UnionType
+from typing import Any, Union, get_args, get_origin
+
+import numpy as np
+import numpy.typing as npt
+
+import pyrealm
+from pyrealm.core.calendar import Calendar
+from pyrealm.demography.flora import (
+    PlantFunctionalType,
+    PlantFunctionalTypeStrict,
+    StemTraits,
+)
+
+## Lists / functions to manually define arguments, methods or outputs to ignore, etc.
+
+# These methods are not relevant or are incompatible without additional work
+skip_methods = [
+    "evaluate_horner_polynomial",  # Coefficients are 1D
+    # PModel
+    "AcclimationModel.set_include",
+    "PModelABC",  # Cannot init ABC
+    "QuantumYieldABC",  # Cannot init ABC
+    "OptimalChiABC.estimate_chi",  # Cannot init ABC
+    "OptimalChiC4RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiC4NoGammaRootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiPrentice14RootzoneStress.estimate_chi",  # Requires rootzonestress in PME
+    "OptimalChiLavergne20C3.estimate_chi",  # Requires theta in PME
+    "OptimalChiLavergne20C4.estimate_chi",  # Requires theta in PME
+    "QuantumYieldSandoval",  # Requires aridity_index in PME
+    "QuantumYieldSandoval.peak_quantum_yield",  # Requires aridity_index in PME
+    # Demography - mostly 1d arrays (dataframes)
+    "CohortMethods.drop_cohort_data",
+    "StemTraits",
+    "StemTraits.drop_cohort_data",
+    "_enforce_2D",
+    "calculate_stem_projected_leaf_area_at_z",
+    "get_crown_xy",
+    "calculate_relative_crown_radius_at_z",
+    "calculate_stem_projected_crown_area_at_z",
+    "solve_canopy_area_filling_height",
+    "calculate_crown_areas",
+    "calculate_crown_fractions",
+    "calculate_crown_r0",
+    "calculate_crown_z_max",
+    "calculate_dbh_from_height",
+    "calculate_fine_root_respiration",
+    "calculate_fine_root_turnover",
+    "calculate_foliage_masses",
+    "calculate_foliage_turnover",
+    "calculate_foliar_respiration",
+    "calculate_gpp_topslice",
+    "calculate_growth_increments",
+    "calculate_heights",
+    "calculate_net_primary_productivity",
+    "calculate_reproductive_tissue_mass",
+    "calculate_reproductive_tissue_respiration",
+    "calculate_reproductive_tissue_turnover",
+    "calculate_sapwood_masses",
+    "calculate_sapwood_respiration",
+    "calculate_stem_masses",
+    "calculate_whole_crown_gpp",
+]
+
+
+# Ignore these outputs, they are not expected to be equal.
+# Formats: [fn name] for function results, [class]:[attr] for class attributes
+ignore_outputs = [
+    "Cohorts:_cohort_id",
+    "Calendar:n_dates",
+    "C3C4Competition:shape",
+    "CalcCarbonIsotopes:shape",
+    "PModelEnvironment:shape",
+    "PModel:shape",
+    "SubdailyPModel:shape",
+    "OptimalChiC4:shape",
+    "OptimalChiC4NoGamma:shape",
+    "OptimalChiPrentice14:shape",
+    "QuantumYieldTemperature:shape",
+    "QuantumYieldFixed:shape",
+    "JmaxLimitationWang17:_shape",
+    "SplashModel:shape",
+]
+
+
+# These methods require specific arguments
+def defined_method_args(argument: str, ctx: "Context") -> Any | None:
+    """Return any manually defined arguments for the current function / method.
+
+    This is done by defining an `arguments` dictionary for the function and then
+    returning the value (if any) of the specific `argument`.
+
+    Parameters
+    ----------
+    argument : str
+        The name of the input argument to define.
+    ctx : Context
+        The context containing the name of the function (`ctx.name`) and the parent
+        classes / class method being tested (`ctx.parents`).
+
+    Returns:
+    -------
+    Any | None
+        The manually defined value for the argument, or `None` if it can be set by the
+        defaults.
+    """
+    shape = ctx.shape()
+
+    # PModel parameters
+    splashDatesLen = 10
+    # Demography parameters
+    n_pft = 3
+    n_heights = 2
+    pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
+
+    method_arguments_list: dict[str, dict] = {
+        ## PModel
+        # Subdaily data needs more than 1 day of times (uses 48 hours)
+        "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},
+        "AcclimationModel.set_nearest": {"time": np.timedelta64(12, "h")},
+        "AcclimationModel._validate_and_set_datetimes": {
+            "datetimes": np.arange(0, 48, dtype="datetime64[h]")
+        },
+        "AcclimationModel._get_subdaily_interpolation_xy": {"values": np.ones(2)},
+        "AcclimationModel.fill_daily_to_subdaily": {"values": np.ones((2, *shape[1:]))},
+        "AcclimationModel.get_window_values": {"values": np.ones(48)},
+        "AcclimationModel.get_daily_means": {"values": np.ones(48)},
+        "calculate_kattge_knorr_arrhenius_factor": {
+            "coef": {"ha": 1, "hd": 1, "entropy_intercept": 1, "entropy_slope": 1}
+        },
+        "SplashModel.estimate_daily_water_balance": {
+            "previous_wn": np.full(shape[1:], splashDatesLen),
+        },
+        "SplashModel.calculate_soil_moisture": {"wn_init": np.full(shape[1:], 10)},
+        "PModelEnvironment": {"patm": np.full(shape, 100000)},
+        "TwoLeafIrradiance": {"patm": np.full(shape, 100000)},
+        ## Demography uses 1D arrays (a lot of these could probably be skipped)
+        "Cohorts": {
+            "dbh_values": np.full(n_pft, 2),
+            "n_individuals": np.ones(n_pft),
+            "pft_names": np.array(pft_names, dtype=np.str_),
+        },
+        "Flora": {"pfts": [PlantFunctionalType(name=name) for name in pft_names]},
+        "Flora.get_stem_traits": {"pft_names": pft_names},
+        "Canopy": {"fit_ppa": True},
+        "CohortCanopyData": {
+            "projected_leaf_area": np.ones((n_heights, n_pft)),
+            "n_individuals": np.ones(n_pft),
+            "lai": np.ones(n_pft),
+            "par_ext": np.ones(n_pft),
+        },
+        "CommunityCanopyData": {
+            "absorption": np.full((n_heights, n_pft), 0.5),
+            "leaf_area_index": np.full((n_heights, n_pft), 0.5),
+            "cohort_leaf_area": np.full((n_heights, n_pft), 1),
+        },
+        "StemAllometry": {"at_dbh": np.full(n_pft, 0.5)},
+        "StemAllocation": {"whole_crown_gpp": np.full(n_pft, 0.5)},
+        "CrownProfile": {"z": np.linspace(5, 15, n_heights)[:, np.newaxis]},
+        "Cohorts.drop_cohort_data": {"drop_indices": [0, 1]},
+        "StemAllometry.drop_cohort_data": {"drop_indices": [0, 1]},
+        "Community.drop_cohorts": {"drop_indices": [0, 1]},
+    }
+    arguments: dict = method_arguments_list.get(ctx.name, {})
+
+    # Arguments that use temporary variables or depend on parents
+
+    if ctx.name.split(".")[0] == "AnnualValueCalculator":
+        # Needs one-dimensional times
+        nTime = 3
+        if ctx.name == "AnnualValueCalculator":
+            arguments = {"timing": np.arange(0, nTime, dtype="datetime64[D]")}
+        elif ctx.name in [
+            "AnnualValueCalculator._split_values_by_year",
+            "AnnualValueCalculator.get_annual_means",
+            "AnnualValueCalculator.get_annual_totals",
+        ]:
+            shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
+            arguments = {"values": np.ones(shape2)}
+
+    if ctx.name.split(".")[0] in ["DailySolarFluxes", "DailyEvapFluxes"]:
+        # Needs first dimension to match the dates
+        nTime = 4
+        shape2 = (1 if shape[0] == 1 else nTime, *shape[1:])
+        if ctx.name == "DailySolarFluxes":
+            arguments = {
+                "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
+                "latitude": np.full(shape2, 10),
+                "elevation": np.full(shape2, 10),
+                "sunshine_fraction": np.full(shape2, 0.5),
+                "temperature": np.full(shape2, 25),
+            }
+        elif ctx.name == "DailyEvapFluxes":
+            arguments = {
+                "pa": np.full(shape2, 10),
+                "tc": np.full(shape2, 25),
+                "kWm": np.full(shape2, 150),
+            }
+        elif ctx.name == "DailyEvapFluxes.estimate_aet":
+            arguments = {"wn": np.full(shape2, 10)}
+
+    if ctx.name == "SplashModel":
+        if (
+            ctx.parents
+            and ctx.parents[0] == "SplashModel.estimate_initial_soil_moisture"
+        ):
+            # Requires at least 1 year of data
+            nTime = 366
+        else:
+            nTime = splashDatesLen
+        splashShape = (1 if shape[0] == 1 else nTime, *shape[1:])
+        arguments = {
+            "dates": Calendar(np.arange(0, nTime, dtype="datetime64[D]")),
+            "lat": np.full(splashShape, 10),
+            "elv": np.full(splashShape, 10),
+            "sf": np.full(splashShape, 0.5),
+            "tc": np.full(splashShape, 25),
+            "pn": np.full(splashShape, 10),
+        }
+
+    if ctx.name == "PModelEnvironment":
+        if ctx.parents and ctx.parents[-1] == "SubdailyPModel":
+            # SubdailyPModel needs more than 1 day (uses 48 hourly times)
+            envShape = (1 if shape[0] == 1 else 48, *shape[1:])
+            arguments = {
+                "tc": np.full(envShape, 20),
+                "vpd": np.full(envShape, 40),
+                "co2": np.full(envShape, 1000),
+                "patm": np.full(envShape, 101325),
+                "fapar": np.full(envShape, 1),
+                "ppfd": np.full(envShape, 800),
+            }
+
+    return arguments.get(argument)
+
+
+# Call additional methods when initialising these classes
+additional_init_methods = {
+    "AcclimationModel": "set_nearest",
+}
+
+
+## Functions to get the list of callables
+def _get_package_modules(pkg: ModuleType) -> list[ModuleType]:
+    """Get a list of modules contained within the package."""
+    import importlib
+    import pkgutil
+
+    modules = []
+    for _, modname, ispkg in pkgutil.walk_packages(
+        pkg.__path__, prefix=pkg.__name__ + "."
+    ):
+        if not ispkg:
+            modules.append(importlib.import_module(modname))
+
+    return modules
+
+
+def _is_instance_method(cls: type | None, method_name: str) -> bool:
+    """Returns True if the method is not static or a classmethod."""
+    if cls is None:
+        return False
+    attr = inspect.getattr_static(cls, method_name)
+    if isinstance(attr, staticmethod | classmethod):
+        return False
+    else:
+        return True
+
+
+def _get_module_callables(
+    module: ModuleType,
+) -> Iterator[tuple[str, Callable, type | None]]:
+    """Get the callables contained within a module.
+
+    Returns an iterable including the function/method name, callable, and (if a method)
+    class.
+    """
+    for name, obj in inspect.getmembers(module):
+        if getattr(obj, "__module__", None) != module.__name__:
+            continue
+        if inspect.isfunction(obj) or inspect.ismethod(obj):
+            yield name, obj, None
+        elif inspect.isclass(obj):
+            for mname, method in inspect.getmembers(obj, predicate=inspect.isfunction):
+                if mname in ["__init__", "__post_init__"]:
+                    full_name = name
+                else:
+                    full_name = f"{name}.{mname}"
+
+                if not _is_instance_method(obj, mname):
+                    class_obj = None
+                else:
+                    class_obj = obj
+
+                yield full_name, method, class_obj
+
+
+def get_method_list() -> list[tuple[str, Callable, type | None]]:
+    """Get a list of callables that take array inputs in the Pyrelam package.
+
+    Returns:
+    --------
+    list[tuple[str, Callable, type | None]
+        A list of callables, each containing the name ([function] or [class].[method]),
+        the callable object, and the type of the class (for class instance methods).
+    """
+    method_list = []
+    for mod in _get_package_modules(pyrealm):
+        for name, method, cls in _get_module_callables(mod):
+            if _has_array_input(method) and name not in skip_methods:
+                method_list.append((name, method, cls))
+    return method_list
+
+
+## Functions to get the argument datatypes
+def _strip_wrapped_types(typ: Any) -> Any:
+    """Handle basic wrapped types to get the inner type."""
+    # InitVar[T] -> T
+    if isinstance(typ, InitVar):
+        return _strip_wrapped_types(typ.type)
+    # Type[T] -> T
+    if get_origin(typ) is type:
+        args = get_args(typ)
+
+        return _strip_wrapped_types(args[0])
+    return typ
+
+
+def _is_array_type(typ: Any) -> bool:
+    """Returns True if the type is a numpy array."""
+    typ = _strip_wrapped_types(typ)
+
+    # If Union[...] or X | Y then check both types
+    origin = get_origin(typ)  # Get the unannotated type, i.e. X[...] -> X
+    if origin in (Union, UnionType):
+        return any(_is_array_type(arg) for arg in get_args(typ))
+
+    try:
+        # Handle annotated types like NDArray[np.float32]
+        if origin is not None:
+            return issubclass(origin, np.ndarray)
+
+        # Handle basic types
+        return issubclass(typ, np.ndarray)
+
+    except TypeError:
+        return False
+
+
+def _has_array_input(method: Callable) -> bool:
+    """Returns True if any of the method arguments are a numpy array."""
+    from typing import get_type_hints
+
+    try:
+        hints = get_type_hints(method)
+        hints = {k: v for k, v in hints.items() if k != "return"}
+    except NameError:
+        return False
+
+    return any(_is_array_type(typ) for typ in hints.values())
+
+
+def _extract_numpy_dtype(typ: Any) -> npt.DTypeLike:
+    """Extract a numpy dtype from NDArray annotation."""
+    dtype: npt.DTypeLike = np.float64
+
+    args = get_args(typ)
+    if not args:
+        return dtype  # If no annotation
+
+    for arg in args:
+        # args could be like: (tuple[int, ...], numpy.dtype[numpy.datetime64])
+        if get_origin(arg) is np.dtype:
+            dtype_args = get_args(arg)
+            try:
+                dtype = np.dtype(dtype_args[0]).type
+            except TypeError:
+                continue
+        # Or like (np.float64)
+        elif isinstance(arg, type) and issubclass(arg, np.generic):
+            dtype = np.dtype(arg)
+
+    # Use a default unit if a datetime
+    if dtype == np.datetime64:
+        dtype = np.dtype("datetime64[D]")
+
+    return dtype
+
+
+## Functions to initialise arguments and classes
+@dataclasses.dataclass
+class Context:
+    """Context class to pass between functions.
+
+    Used to initialise of arguments that depend on array shapes and the heirarchical
+    function/argument class structure.
+
+    Attributes:
+        name (str): Name of the current method/function/class.
+        shapes (list[tuple[int, ...]]): Shapes to iterate over when generating array
+            arguments.
+        i_arg (int): Index of the current argument, used to select a shape.
+        parents (list[str]): Hierarchy of names leading to the current function/class.
+            The first value will be the name of the callable being tested. If it is a
+            class method, the second value will be the name of the class.
+    """
+
+    name: str
+    shapes: list[tuple[int, ...]]
+    i_arg: int = 0
+    parents: list[str] = dataclasses.field(default_factory=list)
+    """A list of the superior function / classes for the current context."""
+
+    def new(self, name: str) -> "Context":
+        """Generate a context for a new function/class, updating the heirarchy."""
+        return Context(name, self.shapes, self.i_arg, [*self.parents, self.name])
+
+    def shape(self) -> tuple[int, ...]:
+        """Return the shape for index `i_arg`."""
+        return self.shapes[self.i_arg % len(self.shapes)]
+
+
+def _initialise_type_default(typ: Any, ctx: Context) -> Any:
+    """Define the default value for each type."""
+    from collections.abc import Sequence
+    from random import randint
+
+    from pyrealm.demography.flora import Flora
+
+    # Handle basic wrapped types
+    typ = _strip_wrapped_types(typ)
+
+    # If Sequence[T]: create a list of 2 objects
+    origin = get_origin(typ)
+    args = get_args(typ)
+    if origin is Sequence:
+        inner_type = args[0] if args else Any
+        return [_initialise_type_default(inner_type, ctx) for _ in range(2)]
+
+    # If Union[...] or X | Y: Create an array if an option, otherwise use the first type
+    if origin in (Union, UnionType):
+        for arg in args:
+            if _is_array_type(arg):
+                return _initialise_type_default(arg, ctx)
+        return _initialise_type_default(args[0], ctx)
+
+    pft_names = ["Tree1", "Tree2", "Tree3"]
+
+    # Numpy arrays
+    if _is_array_type(typ):
+        dtype = _extract_numpy_dtype(typ)
+        shape = ctx.shape()
+        if np.issubdtype(dtype, np.datetime64):
+            return np.full(shape, 1, dtype="datetime64[D]")
+        else:
+            return np.ones(shape, dtype=dtype)
+
+    # Other types
+    elif typ is str:
+        return ""
+    elif typ is bool:
+        return True
+    elif typ is int:
+        return 1
+    elif typ is float:
+        return 1
+    elif typ is Any:
+        return None
+    elif typ is PlantFunctionalTypeStrict:
+        return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
+    elif typ is Flora:
+        return Flora([PlantFunctionalType(name=name) for name in pft_names])
+    elif typ is StemTraits:
+        return _initialise_type_default(Flora, ctx).get_stem_traits(pft_names)
+    elif len(inspect.signature(typ).parameters) > 0:
+        return initialise_class(typ, ctx)
+    else:
+        return typ()
+
+
+def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
+    """Generate the arguments needed for a function.
+
+    Requires type hinting. Numpy arrays are defined using the shapes argument.
+    """
+    from typing import get_type_hints
+
+    kwargs = {}
+    sig = inspect.signature(method)
+    ctx.i_arg = 0
+    for param_name, param in sig.parameters.items():
+        ctx.i_arg += 1
+
+        # Set manually defined values
+        manual_arg = defined_method_args(param_name, ctx)
+        if manual_arg is not None:
+            kwargs[param_name] = manual_arg
+
+        # Skip unnecesary arguments
+        elif param_name == "self" or param.kind in (
+            param.VAR_POSITIONAL,
+            param.VAR_KEYWORD,
+        ):
+            continue
+
+        # Set default arguments
+        elif param.default is not param.empty:
+            kwargs[param_name] = param.default
+
+        # Initialise any other arguments
+        else:
+            if param.annotation is param.empty:
+                raise Exception(f"Missing annotation for {ctx.name}:{param_name}")
+            # Get the contexts of the pyrealm classes to pass to get_type_hints
+            globalns = {}
+            for module in _get_package_modules(pyrealm):
+                globalns.update(vars(module))
+            # Resolve any string annotations
+            typ = get_type_hints(method, globalns=globalns).get(
+                param_name, param.annotation
+            )
+            kwargs[param_name] = _initialise_type_default(typ, ctx)
+
+    return kwargs
+
+
+def initialise_class(cls: type, ctx: Context) -> Any:
+    """Initialise class input arguments and then the class."""
+    name = cls.__name__
+    ctx_class = ctx.new(name)
+    args = generate_args(cls.__init__, ctx_class)  # type: ignore[misc]
+    instance = cls(**args)
+    # If there are any additional methods required for initialisation call these
+    if name in additional_init_methods:
+        mname = additional_init_methods[name]
+        method = getattr(instance, mname)
+        args = generate_args(method, ctx_class.new(name + "." + mname))
+        method(**args)
+    return instance
+
+
+## Functions to compare the results
+def is_equal(val1: Any, val2: Any) -> bool:
+    """Compare if two variables are equal."""
+    if isinstance(val1, np.ndarray):
+        if np.issubdtype(val1.dtype, np.str_):
+            return np.array_equal(val1, val2)
+        val1_b, val2_b = np.broadcast_arrays(val1, val2)
+        equal = val1_b == val2_b
+        both_nan = np.isnan(val1_b) & np.isnan(val2_b)
+        return bool(np.all(equal | both_nan))
+
+    elif isinstance(val1, list | tuple) and isinstance(val2, list | tuple):
+        if len(val1) != len(val2):
+            return False
+        return all(is_equal(v1, v2) for v1, v2 in zip(val1, val2))
+
+    elif hasattr(val1, "__dict__") and hasattr(val2, "__dict__"):
+        compare_instances(val1, val2)  # Raises if not equal
+        return True
+
+    else:
+        return val1 == val2
+
+
+def comparison_string(val1: Any, val2: Any) -> str:
+    """Returns a string representation of two variables that are not equal."""
+
+    def value_string(val: Any) -> str:
+        if isinstance(val, np.ndarray) and val.size > 5:
+            val_str = f"<array> {val.shape}"
+        else:
+            val_str = str(val).replace("\n", " ")
+        val_str = val_str[:30] + ".." if len(val_str) > 30 else val_str
+        return val_str
+
+    return value_string(val1) + " != " + value_string(val2)
+
+
+def compare_instances(instance1: Any, instance2: Any):
+    """Raises ValueError if the two class instances do not have equal attributes."""
+    dict1 = instance1.__dict__
+    dict2 = instance2.__dict__
+    class_name = instance1.__class__.__name__
+    for key in dict1:
+        if f"{class_name}:{key}" in ignore_outputs:
+            continue
+        if not is_equal(dict1[key], dict2[key]):
+            attr_comparison = comparison_string(dict1[key], dict2[key])
+            raise ValueError(f"{class_name}: {key} not equal ({attr_comparison})")

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -150,7 +150,7 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
     pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
 
     method_arguments_list: dict[str, dict] = {
-        "broadcast_time": {"shape": (3, shape[1:])},
+        "broadcast_time": {"shape": (3, *shape[1:])},
         ## PModel
         # Subdaily data needs more than 1 day of times (uses 48 hours)
         "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -117,6 +117,7 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
     pft_names = [f"Tree{i + 1}" for i in range(n_pft)]
 
     method_arguments_list: dict[str, dict] = {
+        "broadcast_time": {"shape": (3, shape[1:])},
         ## PModel
         # Subdaily data needs more than 1 day of times (uses 48 hours)
         "AcclimationModel": {"datetimes": np.arange(0, 48, dtype="datetime64[h]")},

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -98,19 +98,14 @@ def defined_method_args(argument: str, ctx: "Context") -> Any | None:
     This is done by defining an `arguments` dictionary for the function and then
     returning the value (if any) of the specific `argument`.
 
-    Parameters
-    ----------
-    argument : str
-        The name of the input argument to define.
-    ctx : Context
-        The context containing the name of the function (`ctx.name`) and the parent
-        classes / class method being tested (`ctx.parents`).
+    Args:
+        argument (str): The name of the input argument to define.
+        ctx (Context): The context containing the name of the function (`ctx.name`) and
+        the parent classes / class method being tested (`ctx.parents`).
 
     Returns:
-    -------
-    Any | None
-        The manually defined value for the argument, or `None` if it can be set by the
-        defaults.
+        Any | None: The manually defined value for the argument, or `None` if it can be
+        set by the defaults.
     """
     shape = ctx.shape()
 
@@ -280,8 +275,9 @@ def _get_module_callables(
 ) -> Iterator[tuple[str, Callable, type | None]]:
     """Get the callables contained within a module.
 
-    Returns an iterable including the function/method name, callable, and (if a method)
-    class.
+    Returns:
+        An iterable including the function/method name, callable, and (if a method)
+        class.
     """
     for name, obj in inspect.getmembers(module):
         if getattr(obj, "__module__", None) != module.__name__:
@@ -307,8 +303,6 @@ def get_method_list() -> list[tuple[str, Callable, type | None]]:
     """Get a list of callables that take array inputs in the Pyrelam package.
 
     Returns:
-    --------
-    list[tuple[str, Callable, type | None]
         A list of callables, each containing the name ([function] or [class].[method]),
         the callable object, and the type of the class (for class instance methods).
     """
@@ -489,7 +483,15 @@ def _initialise_type_default(typ: Any, ctx: Context) -> Any:
 def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
     """Generate the arguments needed for a function.
 
-    Requires type hinting. Numpy arrays are defined using the shapes argument.
+    Requires type hinting. Numpy arrays are defined using the shapes information in the
+    Context.
+
+    Args:
+        method (Callable): The function or method to generate arguments for.
+        ctx (Context): The context for shape and parent information.
+
+    Returns:
+        dict[str, Any]: The generated arguments for the function/method.
     """
     from typing import get_type_hints
 
@@ -533,7 +535,15 @@ def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
 
 
 def initialise_class(cls: type, ctx: Context) -> Any:
-    """Initialise class input arguments and then the class."""
+    """Initialise class input arguments and then the class.
+
+    Args:
+        cls (type): The class to initialise.
+        ctx (Context): The context for shape and parent information.
+
+    Returns:
+        Any: The initialised class instance.
+    """
     name = cls.__name__
     ctx_class = ctx.new(name)
     args = generate_args(cls.__init__, ctx_class)  # type: ignore[misc]

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -349,6 +349,11 @@ def _is_array_type(typ: Any) -> bool:
         return False
 
 
+# Resolve issue with get_type_hints failing for InitVars in py3.10
+# Define a stub to make InitVar callable (https://stackoverflow.com/questions/70400639)
+InitVar.__call__ = lambda *args: None  # type: ignore[method-assign]
+
+
 def _has_array_input(method: Callable) -> bool:
     """Returns True if any of the method arguments are a numpy array."""
     from typing import get_type_hints

--- a/tests/unit/core/test_annual_value_calculator.py
+++ b/tests/unit/core/test_annual_value_calculator.py
@@ -19,7 +19,7 @@ from numpy.typing import NDArray
             None,
             pytest.raises(ValueError),
             "The timings argument must be an AcclimationModel "
-            "or an array of datetime64 values",
+            "or a one-dimensional array of datetime64 values",
             None,
             id="timings_not_acclim_or_datetimes",
         ),

--- a/tests/unit/core/test_broadcast_time.py
+++ b/tests/unit/core/test_broadcast_time.py
@@ -1,0 +1,27 @@
+"""Tests the broadcast_time function from time_series.py."""
+
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    argnames="values,shape,expected,raises",
+    argvalues=(
+        (np.ones(1), (3,), np.ones(3), does_not_raise()),
+        (np.ones(3), (3,), np.ones(3), does_not_raise()),
+        (np.ones((1, 2)), (3, 2), np.ones((3, 2)), does_not_raise()),
+        (np.ones((1, 2)), (3, 4), np.ones((3, 2)), does_not_raise()),
+        (np.ones(2), (3, 2, 2), np.ones((3, 1, 2)), does_not_raise()),
+        (np.ones(4), (3,), None, pytest.raises(ValueError)),
+        (np.ones((2, 2)), (2,), None, pytest.raises(ValueError)),
+    ),
+)
+def test_broadcast_time(values, shape, expected, raises):
+    """Test correct outputs and errors for the broadcast_time function."""
+    from pyrealm.core.time_series import broadcast_time
+
+    with raises:
+        result = broadcast_time(values, shape)
+        assert np.array_equal(result, expected)

--- a/tests/unit/core/test_check_input_shapes.py
+++ b/tests/unit/core/test_check_input_shapes.py
@@ -1,0 +1,29 @@
+"""Tests the check_input_shapes function."""
+
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    argnames="inputs, raises",
+    argvalues=[
+        ([0], does_not_raise()),
+        ([None], does_not_raise()),
+        ([np.array([])], does_not_raise()),
+        ([np.ones(3)], does_not_raise()),
+        ([np.ones((3, 2)), np.ones((3, 2))], does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 3))], pytest.raises(ValueError)),
+        ([np.ones((1, 2)), np.ones((3, 1))], does_not_raise()),
+        ([np.ones(2), np.ones((3, 2))], does_not_raise()),
+        ([np.ones(3), np.ones((3, 2))], pytest.raises(ValueError)),
+    ],
+)
+def test_check_input_shapes(inputs, raises):
+    """Tests if the inputs satisfy check_input_shapes."""
+
+    from pyrealm.core.utilities import check_input_shapes
+
+    with raises:
+        check_input_shapes(*inputs)

--- a/tests/unit/core/test_check_input_shapes.py
+++ b/tests/unit/core/test_check_input_shapes.py
@@ -7,23 +7,31 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    argnames="inputs, raises",
+    argnames="inputs, shape, raises",
     argvalues=[
-        ([0], does_not_raise()),
-        ([None], does_not_raise()),
-        ([np.array([])], does_not_raise()),
-        ([np.ones(3)], does_not_raise()),
-        ([np.ones((3, 2)), np.ones((3, 2))], does_not_raise()),
-        ([np.ones((1, 2)), np.ones((3, 3))], pytest.raises(ValueError)),
-        ([np.ones((1, 2)), np.ones((3, 1))], does_not_raise()),
-        ([np.ones(2), np.ones((3, 2))], does_not_raise()),
-        ([np.ones(3), np.ones((3, 2))], pytest.raises(ValueError)),
+        ([0], None, does_not_raise()),
+        ([None], None, does_not_raise()),
+        ([np.array([])], None, does_not_raise()),
+        ([np.ones(3)], None, does_not_raise()),
+        ([np.ones((3, 2)), np.ones((3, 2))], None, does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 2))], None, does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 1))], None, does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 3))], None, pytest.raises(ValueError)),
+        ([np.ones((3, 1, 4)), np.ones((3, 2, 4))], None, does_not_raise()),
+        ([np.ones((1, 1, 4)), np.ones((3, 2, 4))], None, does_not_raise()),
+        ([np.ones(2), np.ones((3, 2))], None, pytest.raises(ValueError)),
+        ([np.ones(3), np.ones((3, 2))], None, pytest.raises(ValueError)),
+        ([0], (1,), does_not_raise()),
+        ([0], (3, 2), does_not_raise()),
+        (np.array([]), (1,), does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 1))], (3, 2), does_not_raise()),
+        ([np.ones((1, 2)), np.ones((3, 1))], (1, 3, 2), pytest.raises(ValueError)),
     ],
 )
-def test_check_input_shapes(inputs, raises):
+def test_check_input_shapes(inputs, shape, raises):
     """Tests if the inputs satisfy check_input_shapes."""
 
     from pyrealm.core.utilities import check_input_shapes
 
     with raises:
-        check_input_shapes(*inputs)
+        check_input_shapes(*inputs, shape=shape)

--- a/tests/unit/phenology/test_fapar_limitation.py
+++ b/tests/unit/phenology/test_fapar_limitation.py
@@ -1,0 +1,33 @@
+"""Tests the FaparLimitation class."""
+
+from contextlib import nullcontext as does_not_raise
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    argnames="aridity_index, raises",
+    argvalues=[
+        (0, pytest.raises(ValueError)),
+        (-1, pytest.raises(ValueError)),
+        (1, does_not_raise()),
+        (np.array([1, 1, 1]), does_not_raise()),
+        (np.array([1, 1, -1]), pytest.raises(ValueError)),
+    ],
+)
+def test_aridity_index_check(aridity_index, raises):
+    """Tests if the AI positivity check is works for both scalar and vector inputs."""
+    from pyrealm.phenology.fapar_limitation import FaparLimitation
+
+    # Inputs are arrays of length 3
+    shape = (3,)
+    with raises:
+        FaparLimitation(
+            annual_total_potential_gpp=np.ones(shape),
+            annual_mean_ca=np.ones(shape),
+            annual_mean_chi=np.ones(shape),
+            annual_mean_vpd=np.ones(shape),
+            annual_total_precip=np.ones(shape),
+            aridity_index=aridity_index,
+        )

--- a/tests/unit/phenology/test_fapar_limitation.py
+++ b/tests/unit/phenology/test_fapar_limitation.py
@@ -29,5 +29,6 @@ def test_aridity_index_check(aridity_index, raises):
             annual_mean_chi=np.ones(shape),
             annual_mean_vpd=np.ones(shape),
             annual_total_precip=np.ones(shape),
+            annual_growing_season_length=np.ones(shape),
             aridity_index=aridity_index,
         )


### PR DESCRIPTION
# Description

I have modified the check_input_shapes function to allow broadcastable shapes (although more of the function could possibly be replaced by `np.broadcast_arrays`). Tests are still needed on the functions that use this to ensure they are indeed compatible with broadcastable arrays.

Fixes #494

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
