### PR TITLE
Remove syntax warnings

### DIFF
--- a/pyrealm/constants/core_const.py
+++ b/pyrealm/constants/core_const.py
@@ -135,10 +135,10 @@ class CoreConst(ConstantsClass):
     """Solar eccentricity (:math:`e`), using default value for 2000 CE 
     :cite:t:`berger:1978a`."""
     solar_obliquity: float = 23.44
-    """Solar obliquity in degrees (:math:`\epsilon`), using default value for 2000 CE
+    r"""Solar obliquity in degrees (:math:`\epsilon`), using default value for 2000 CE
     :cite:t:`berger:1978a`."""
     solar_perihelion: float = 283.0
-    """Solar longitude of perihelion in degrees (:math:`\omega`), using default value
+    r"""Solar longitude of perihelion in degrees (:math:`\omega`), using default value
     for 2000 CE :cite:t:`berger:1978a`."""
 
     # Hygro constants

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -90,14 +90,14 @@ class PModelConst(ConstantsClass):
     and the activation energy (:math:`H_a`, J/mol)."""
 
     kphio_C4: tuple[float, float, float] = (-0.064, 0.03, -0.000464)
-    """Coefficients of the quadratic scaling of the quantum yield of photosynthesis
+    r"""Coefficients of the quadratic scaling of the quantum yield of photosynthesis
     (``phi_0``, :math:`\phi_0`) with temperature for C4 plants, taken from Eqn 5 of
     :cite:t:`cai:2020a`, and adjusted from the original values (-0.008, 0.00375,
     -0.58e-4) to account for an unintentional double scaling to account for the fraction
     of light reaching PS2."""
 
     kphio_C3: tuple[float, float, float] = (0.352, 0.022, -0.00034)
-    """Coefficients of the quadratic scaling of the quantum yield of photosynthesis
+    r"""Coefficients of the quadratic scaling of the quantum yield of photosynthesis
     (``phi_0``, :math:`\phi_0`) with temperature for C3 plants, taken from Table 2 of
     :cite:t:`Bernacchi:2003dc`"""
 
@@ -110,7 +110,7 @@ class PModelConst(ConstantsClass):
             ko25=27480.0,
         )
     )
-    """Coefficients for the estimation of the Michaelis Menten coefficient of
+    r"""Coefficients for the estimation of the Michaelis Menten coefficient of
     Rubisco-limited assimilation. Values are taken from Table 1 of
     :cite:t:`Bernacchi:2001kg` and provide a dictionary of:
     
@@ -129,7 +129,7 @@ class PModelConst(ConstantsClass):
     """
 
     maximum_phi0: float = 1.0 / 8.0
-    """The theoretical maximum intrinsic quantum yield efficiency of photosynthesis
+    r"""The theoretical maximum intrinsic quantum yield efficiency of photosynthesis
     (:math:`\phi_0`, unitless). This value defaults to 1/8 but could be set to 1/9 to
     capture the absence of a Q cycle :cite:`long:1993a`."""
 
@@ -139,7 +139,7 @@ class PModelConst(ConstantsClass):
             gs25_0=4.332,
         )
     )
-    """Coefficients for the estimation of the photorespiratory CO2 compensation point.
+    r"""Coefficients for the estimation of the photorespiratory CO2 compensation point.
     Values are taken from Table 1 of :cite:t:`Bernacchi:2001kg` and provide a dictionary
     of: 
     

--- a/pyrealm/constants/two_leaf.py
+++ b/pyrealm/constants/two_leaf.py
@@ -26,7 +26,7 @@ class TwoLeafConst(ConstantsClass):
     atmospheric_scattering_coef: float = 0.426  # needs citation
     """Scattering coefficient of PAR in the atmosphere (:math:`f_a`, dimensionless)"""
     leaf_scattering_coef: float = 0.15
-    """Scattering coefficient of PAR by leaves by reflection and transmission
+    r"""Scattering coefficient of PAR by leaves by reflection and transmission
     (:math:`\sigma`, dimensionless, Table 2. of :cite:t:`depury:1997a`)"""
     diffuse_reflectance: float = 0.036  # needs citation
     r"""Canopy reflection coefficient for diffuse PAR,(:math:`\rho_{cd}`,

--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -1042,7 +1042,7 @@ class SolarPositions:
     """An array of local meridians given the longitude."""
 
     day_angle: NDArray[np.float64] = field(init=False)
-    """The solar day angle of the observations (:math:`\Gamma`, radians)."""
+    r"""The solar day angle of the observations (:math:`\Gamma`, radians)."""
     equation_of_time: NDArray[np.float64] = field(init=False)
     """The equation of time value for the observations (:math:`E_t`, minutes)."""
     solar_noon: NDArray[np.float64] = field(init=False)
@@ -1050,7 +1050,7 @@ class SolarPositions:
     hour_angle: NDArray[np.float64] = field(init=False)
     """The local hour angle for the observations (:math:`h`, radians)."""
     declination: NDArray[np.float64] = field(init=False)
-    """The declination for the observations ( (:math:`\delta`, radians)."""
+    r"""The declination for the observations ( (:math:`\delta`, radians)."""
     solar_elevation: NDArray[np.float64] = field(init=False)
     r"""The solar elevation for the observations (:math:`\alpha`, radians) ."""
 

--- a/pyrealm/pmodel/two_leaf.py
+++ b/pyrealm/pmodel/two_leaf.py
@@ -628,56 +628,56 @@ class TwoLeafAssimilation:
         """An extinction coefficient capturing the vertical structure of carboxylation
         capacity within the canopy (:math:`k_v`)."""
         self.Vcmax25_canopy: NDArray[np.float64]
-        """The total canopy carboxylation capacity at standard temperature
+        r"""The total canopy carboxylation capacity at standard temperature
         :math:`V_{cmax25\_C}`"""
         self.Vcmax25_sun: NDArray[np.float64]
-        """The maximum rate of carboxylation at standard temperature within sunlit 
+        r"""The maximum rate of carboxylation at standard temperature within sunlit 
         leaves (:math:`V_{cmax25\_Sn}`)"""
         self.Vcmax25_shade: NDArray[np.float64]
-        """The maximum rate of carboxylation at standard temperature within shaded 
+        r"""The maximum rate of carboxylation at standard temperature within shaded 
         leaves (:math:`V_{cmax25\_Sd}`)"""
         self.Vcmax_sun: NDArray[np.float64]
-        """The maximum rate of carboxylation at the observed temperature within sunlit
+        r"""The maximum rate of carboxylation at the observed temperature within sunlit
         leaves (:math:`V_{cmax\_Sn}`)"""
         self.Vcmax_shade: NDArray[np.float64]
-        """The maximum rate of carboxylation at the observed temperature within shaded
+        r"""The maximum rate of carboxylation at the observed temperature within shaded
         leaves (:math:`V_{cmax\_Sd}`)"""
         self.Jmax25_sun: NDArray[np.float64]
-        """The maximum rate of electron transfer at standard temperature within sunlit
+        r"""The maximum rate of electron transfer at standard temperature within sunlit
         leaves (:math:`J_{max25\_Sn}`)"""
         self.Jmax25_shade: NDArray[np.float64]
-        """The maximum rate of electron transfer at standard temperature within shaded
+        r"""The maximum rate of electron transfer at standard temperature within shaded
         leaves (:math:`J_{max25\_Sd}`)"""
         self.Jmax_sun: NDArray[np.float64]
-        """The maximum rate of electron transfer at the observed temperature within
+        r"""The maximum rate of electron transfer at the observed temperature within
         sunlit leaves (:math:`J_{max\_Sn}`)"""
         self.Jmax_shade: NDArray[np.float64]
-        """The maximum rate of electron transfer at the observed temperature within
+        r"""The maximum rate of electron transfer at the observed temperature within
         shaded leaves (:math:`J_{max25\_Sn}`)"""
         self.J_sun: NDArray[np.float64]
-        """The realised rate of electron transfer within sunlit leaves
+        r"""The realised rate of electron transfer within sunlit leaves
         (:math:`J_{Sn}`"""
         self.J_shade: NDArray[np.float64]
-        """The realised rate of electron transfer within sunlit leaves
+        r"""The realised rate of electron transfer within sunlit leaves
         (:math:`J_{Sd}`"""
         self.Av_sun: NDArray[np.float64]
-        """The potential rate of assimilation associated with carboxylation in sunlit
+        r"""The potential rate of assimilation associated with carboxylation in sunlit
         leaves (:math:`A_{v\_Sn}`)."""
         self.Av_shade: NDArray[np.float64]
-        """The potential rate of assimilation associated with carboxylation in shaded
+        r"""The potential rate of assimilation associated with carboxylation in shaded
         leaves (:math:`A_{v\_Sd}`)."""
         self.Aj_sun: NDArray[np.float64]
-        """The potential rate of assimilation associated with electron transfer in
+        r"""The potential rate of assimilation associated with electron transfer in
         sunlit leaves (:math:`A_{j\_Sn}`)."""
         self.Aj_shade: NDArray[np.float64]
-        """The potential rate of assimilation associated with electron transfer in
+        r"""The potential rate of assimilation associated with electron transfer in
         shaded leaves (:math:`A_{j\_Sn}`)."""
         self.A_sun: NDArray[np.float64]
-        """The realised assimilation rate for sunlit leaves (:math:`A_{Sn}`)."""
+        r"""The realised assimilation rate for sunlit leaves (:math:`A_{Sn}`)."""
         self.A_shade: NDArray[np.float64]
-        """The realised assimilation rate for shaded leaves (:math:`A_{Sd}`)."""
+        r"""The realised assimilation rate for shaded leaves (:math:`A_{Sd}`)."""
         self.gpp: NDArray[np.float64]
-        """The gross primary productivity across the sunlit and shaded leaves."""
+        r"""The gross primary productivity across the sunlit and shaded leaves."""
 
         # Automatically run the
         self._calculate_two_leaf_two_stream_gpp()


### PR DESCRIPTION
# Description

This PR just updates a bunch of files containing docstrings that include `:math:` declarations to use raw strings. For example:

```python
"""A string containing :math:`\Gamma`"""
```

contains the `\G` sequence, which is not one of the standard `\t`, `\n` escape sequences. So we need it as:

```python
r"""A string containing :math:`\Gamma`"""
```

Without this change, Python 3.12+ raises `SyntaxWarnings` about unknown escape sequences. I've built the docs and run pytest which I think does a good job of importing all the code and don't see any more syntax warnings.

Fixes #501  (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
