### PR TITLE
Adding UUIDs to cohorts

### DIFF
--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -17,7 +17,7 @@ language_info:
   name: python
   nbconvert_exporter: python
   pygments_lexer: ipython3
-  version: 3.12.3
+  version: 3.11.9
 settings:
   output_matplotlib_strings: remove
 ---
@@ -110,11 +110,9 @@ individual stems, grouped into 3 cohorts with different stem sizes and crown sha
 
 ```{code-cell} ipython3
 # Define PFTs
-short_pft = PlantFunctionalType(
-    name="short", h_max=15, m=1.5, n=1.5, f_g=0, ca_ratio=380
-)
+short_pft = PlantFunctionalType(name="short", h_max=15, m=2, n=4, f_g=0, ca_ratio=380)
 tall_pft = PlantFunctionalType(
-    name="tall", h_max=30, m=1.5, n=2, par_ext=0.6, f_g=0, ca_ratio=500
+    name="tall", h_max=30, m=2, n=3, par_ext=0.6, f_g=0, ca_ratio=500
 )
 
 # Create the flora

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -93,9 +93,11 @@ Initialize a Community into an area of 1000 square meter with the given cohort d
 
 The data in the Community class is stored under three attributes, each of which stores
 an instance of a dataclass holding related parts of the community data. All have a
-``to_pandas`` method that can be used to visualise and explore the data:
+``to_pandas`` method that can be used to visualise and explore the data. Note that the
+`Cohorts` class automatically adds a unique internal ID to each cohort which is not
+shown here:
 
->>> community.cohorts.to_pandas()
+>>> community.cohorts.to_pandas().drop(columns="cohort_id")
    dbh_values  n_individuals        pft_names
 0       0.100            100   Evergreen Tree
 1       0.030            200  Deciduous Shrub
@@ -126,6 +128,7 @@ from __future__ import annotations
 
 import json
 import sys
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -155,12 +158,17 @@ class Cohorts(PandasExporter, CohortMethods):
     """A dataclass to hold data for a set of plant cohorts.
 
     The attributes should be numpy arrays of equal length, containing an entry for each
-    cohort in the data class.
+    cohort in the data class. The class automatically populates each cohort with a
+    unique id in the `cohort_id` property, using UUID4 values. The setter for this
+    property enforces unique values in this property. The most likely source of this
+    error would be if the
+    :meth:`CohortMethods.add_cohort_data<pyrealm.demography.core.CohortMethods.add_cohort_data>`
+    method was used to add a Cohorts instance to itself.
     """
 
     # A class variable setting the attribute names of traits.
     array_attrs: ClassVar[tuple[str, ...]] = tuple(
-        ["dbh_values", "n_individuals", "pft_names"]
+        ["dbh_values", "n_individuals", "pft_names", "cohort_id"]
     )
     count_attr: ClassVar[str] = "n_cohorts"
 
@@ -168,6 +176,7 @@ class Cohorts(PandasExporter, CohortMethods):
     dbh_values: NDArray[np.float64]
     n_individuals: NDArray[np.int_]
     pft_names: NDArray[np.str_]
+    _cohort_id: NDArray[np.str_] = field(init=False)
     n_cohorts: int = field(init=False)
 
     __experimental__ = True
@@ -194,7 +203,20 @@ class Cohorts(PandasExporter, CohortMethods):
         except ValueError:
             raise ValueError("Cohort arrays are of unequal length")
 
-        self.n_cohorts = len(self.dbh_values)
+        self.n_cohorts = self.dbh_values.size
+        self._cohort_id = np.array([str(uuid.uuid4()) for _ in range(self.n_cohorts)])
+
+    @property
+    def cohort_id(self) -> NDArray[np.str_]:
+        """Automatically populated with a UUID4 id for each cohort."""
+        return self._cohort_id
+
+    @cohort_id.setter
+    def cohort_id(self, values: NDArray[np.str_]) -> None:
+        if len(set(values)) < len(values):
+            raise ValueError("Cohort object with duplicated cohort ids")
+
+        self._cohort_id = values
 
 
 class CohortSchema(Schema):

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -11,12 +11,25 @@ from numpy.testing import assert_allclose
 
 
 @contextmanager
-def not_raises(exception):
-    """Simple context manager for checking a test does not raise."""
+def not_raises():
+    """Simple context manager for checking a statement does not raise."""
     try:
         yield
-    except exception:
-        raise pytest.fail(f"DID RAISE {exception}")
+    except Exception as excep:
+        raise excep
+
+
+def test_not_raises():
+    """Check of the not_raises context manager."""
+    with pytest.raises(ValueError):
+        raise ValueError()
+
+    with not_raises():
+        pass
+
+    with pytest.raises(ValueError):
+        with not_raises():
+            raise ValueError()
 
 
 @pytest.fixture
@@ -117,8 +130,11 @@ def test_Cohorts(args, outcome, excep_message):
         # Test IDs assigned
         cohort_ids = getattr(cohorts, "cohort_id", None)
         assert cohort_ids is not None
-        for id_value in cohort_ids:
-            assert not_raises(uuid.UUID(id_value))
+
+        # This could be tested implictly by just running the line, but this is to
+        # clarify that this conversion must complete successfully as part of the test.
+        with not_raises():
+            _ = [uuid.UUID(id_value) for id_value in cohort_ids]
 
         # test the to_pandas method
         df = cohorts.to_pandas()

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -152,7 +152,7 @@ def test_Cohorts_CohortMethods():
 
     from pyrealm.demography.community import Cohorts
 
-    # Create and instances to modify using methods
+    # Create instances to modify using methods
     cohorts = Cohorts(
         pft_names=np.array(["broadleaf", "conifer"]),
         n_individuals=np.array([6, 1]),

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -1,11 +1,22 @@
 """test the community object in community.py initialises as expected."""
 
+import uuid
+from contextlib import contextmanager
 from contextlib import nullcontext as does_not_raise
 
 import numpy as np
 import pytest
 from marshmallow.exceptions import ValidationError
 from numpy.testing import assert_allclose
+
+
+@contextmanager
+def not_raises(exception):
+    """Simple context manager for checking a test does not raise."""
+    try:
+        yield
+    except exception:
+        raise pytest.fail(f"DID RAISE {exception}")
 
 
 @pytest.fixture
@@ -89,7 +100,7 @@ def check_expected(community, expected):
             },
             pytest.raises(ValueError),
             "Cohort arrays are of unequal length",
-            id="not np array",
+            id="unequal length",
         ),
     ],
 )
@@ -99,8 +110,15 @@ def test_Cohorts(args, outcome, excep_message):
 
     with outcome as excep:
         cohorts = Cohorts(**args)
+
         # trivial test of success
         assert len(cohorts.dbh_values) == 2
+
+        # Test IDs assigned
+        cohort_ids = getattr(cohorts, "cohort_id", None)
+        assert cohort_ids is not None
+        for id_value in cohort_ids:
+            assert not_raises(uuid.UUID(id_value))
 
         # test the to_pandas method
         df = cohorts.to_pandas()
@@ -113,13 +131,35 @@ def test_Cohorts(args, outcome, excep_message):
     assert str(excep.value) == excep_message
 
 
+def test_Cohorts_duplicate_id_detection():
+    """Test the property checking for duplicate cohort ids."""
+
+    from pyrealm.demography.community import Cohorts
+
+    # Create and instances to modify using methods
+    cohorts = Cohorts(
+        pft_names=np.array(["broadleaf", "conifer"]),
+        n_individuals=np.array([6, 1]),
+        dbh_values=np.array([0.2, 0.5]),
+    )
+
+    with pytest.raises(ValueError):
+        _ = cohorts.add_cohort_data(new_data=cohorts)
+
+
 def test_Cohorts_CohortMethods():
     """Test the inherited CohortMethods methods."""
 
     from pyrealm.demography.community import Cohorts
 
-    # Create and instance to modify using methods
+    # Create and instances to modify using methods
     cohorts = Cohorts(
+        pft_names=np.array(["broadleaf", "conifer"]),
+        n_individuals=np.array([6, 1]),
+        dbh_values=np.array([0.2, 0.5]),
+    )
+
+    new_cohorts = Cohorts(
         pft_names=np.array(["broadleaf", "conifer"]),
         n_individuals=np.array([6, 1]),
         dbh_values=np.array([0.2, 0.5]),
@@ -132,7 +172,7 @@ def test_Cohorts_CohortMethods():
     assert str(excep.value) == "Cannot add cohort data from an dict instance to Cohorts"
 
     # Check success of adding and dropping data
-    cohorts.add_cohort_data(new_data=cohorts)
+    cohorts.add_cohort_data(new_data=new_cohorts)
     assert_allclose(cohorts.dbh_values, np.array([0.2, 0.5, 0.2, 0.5]))
     assert cohorts.n_cohorts == 4
 


### PR DESCRIPTION
# Description

This PR adds a new instance attribute to the `Cohorts` dataclass that is used to contain unique IDs for each cohort. The main rationale (as in the issue #521) is to provide a unique cohort tag if data is exported from `pyrealm` community objects.

* The UUID values are populated via the `__post_init__` method. 
* A `@property` and setter are defined to enforce unique IDs - not because of the minute chance of UUID collisions, but because users could potentially add existing cohort instances onto themselves, which would create a duplicate.
* The tests are extended to check UUIDs are being populated with UUID values and to check the duplicate detection works. One test that would have failed (because it added a `Cohorts` instance to itself) is also fixed.
* And `jupytext` stuck its oar in and made an unrelated format of a Markdown file.

Fixes #521

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
