### PR TITLE
Fixing behaviour of T Model with zero DBH values

### DIFF
--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -89,7 +89,7 @@ The {meth}`~pyrealm.demography.tmodel.StemAllometry` class provides the
 data for data exploration.
 
 ```{code-cell} ipython3
-single_allometry.to_pandas()
+single_allometry.to_pandas().transpose()
 ```
 
 However, the DBH values can also be a column array (an `N` x 1 array). In this case, the
@@ -98,8 +98,8 @@ predictions arranged with each PFT as a column and each DBH prediction as a row.
 makes them convenient to plot using `matplotlib`.
 
 ```{code-cell} ipython3
-# Column array of DBH values from 0 to 1.6 metres
-dbh_col = np.arange(0, 1.6, 0.01)[:, None]
+# Column array of DBH values from 0.01 to 1.6 metres
+dbh_col = np.arange(0.01, 1.6, 0.01)[:, None]
 # Get the predictions
 allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_col)
 ```
@@ -135,7 +135,7 @@ The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
 the values are stacked into columns along with a index showing the different cohorts.
 
 ```{code-cell} ipython3
-allometries.to_pandas()
+allometries.to_pandas().transpose()
 ```
 
 ## Productivity allocation
@@ -181,7 +181,7 @@ The {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
 export data for exploration.
 
 ```{code-cell} ipython3
-single_allocation.to_pandas()
+single_allocation.to_pandas().transpose()
 ```
 
 Using a column array of potential GPP values can be used to predict multiple estimates of
@@ -286,5 +286,5 @@ As before, the {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` metho
 the data for each stem:
 
 ```{code-cell} ipython3
-allocation.to_pandas()
+allocation.to_pandas().transpose()
 ```

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -129,7 +129,7 @@ from __future__ import annotations
 import json
 import sys
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -173,15 +173,16 @@ class Cohorts(PandasExporter, CohortMethods):
     count_attr: ClassVar[str] = "n_cohorts"
 
     # Instance attributes
-    dbh_values: NDArray[np.float64]
     n_individuals: NDArray[np.int_]
     pft_names: NDArray[np.str_]
     _cohort_id: NDArray[np.str_] = field(init=False)
+    _dbh_values: NDArray[np.float64] = field(init=False)
     n_cohorts: int = field(init=False)
+    dbh_values: InitVar[NDArray[np.float64]]
 
     __experimental__ = True
 
-    def __post_init__(self) -> None:
+    def __post_init__(self, dbh_values: NDArray[np.float64]) -> None:
         """Validation of cohorts data."""
 
         # TODO - validation - maybe make this optional to reduce workload within
@@ -191,7 +192,7 @@ class Cohorts(PandasExporter, CohortMethods):
 
         # Check cohort data types
         if not (
-            isinstance(self.dbh_values, np.ndarray)
+            isinstance(dbh_values, np.ndarray)
             and isinstance(self.n_individuals, np.ndarray)
             and isinstance(self.pft_names, np.ndarray)
         ):
@@ -199,11 +200,15 @@ class Cohorts(PandasExporter, CohortMethods):
 
         # Check the cohort inputs are of equal length
         try:
-            check_input_shapes(self.dbh_values, self.n_individuals, self.dbh_values)
+            check_input_shapes(self.pft_names, self.n_individuals, dbh_values)
         except ValueError:
             raise ValueError("Cohort arrays are of unequal length")
 
-        self.n_cohorts = self.dbh_values.size
+        if np.any(dbh_values < 0):
+            raise ValueError("Negative DBH values passed to Cohorts instance.")
+
+        self._dbh_values = dbh_values
+        self.n_cohorts = dbh_values.size
         self._cohort_id = np.array([str(uuid.uuid4()) for _ in range(self.n_cohorts)])
 
     @property
@@ -217,6 +222,22 @@ class Cohorts(PandasExporter, CohortMethods):
             raise ValueError("Cohort object with duplicated cohort ids")
 
         self._cohort_id = values
+
+    # Ignoring this redefinition - the name is used above as an init-only argument that
+    # is then redefined as a class property with a setter protecting from negative
+    # values.
+
+    @property  # type: ignore [no-redef]
+    def dbh_values(self) -> NDArray[np.float64]:
+        """The diameter at breast height of the cohorts (m)."""
+        return self._dbh_values
+
+    @dbh_values.setter
+    def dbh_values(self, values: NDArray[np.float64]) -> None:
+        if np.any(values < 0):
+            raise ValueError("Cannot set negative DBH values in Cohorts instance.")
+
+        self._dbh_values = values
 
 
 class CohortSchema(Schema):
@@ -477,7 +498,7 @@ class Community:
 
         # Populate the stem allometry
         self.stem_allometry = StemAllometry(
-            stem_traits=self.stem_traits, at_dbh=self.cohorts.dbh_values
+            stem_traits=self.stem_traits, at_dbh=self.cohorts._dbh_values
         )
 
     @classmethod
@@ -602,7 +623,7 @@ class Community:
         self.stem_traits.add_cohort_data(new_data=new_stem_traits)
 
         new_stem_allometry = StemAllometry(
-            stem_traits=new_stem_traits, at_dbh=new_data.dbh_values
+            stem_traits=new_stem_traits, at_dbh=new_data._dbh_values
         )
         self.stem_allometry.add_cohort_data(new_data=new_stem_allometry)
 

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -204,10 +204,10 @@ class Cohorts(PandasExporter, CohortMethods):
         except ValueError:
             raise ValueError("Cohort arrays are of unequal length")
 
-        if np.any(dbh_values < 0):
-            raise ValueError("Negative DBH values passed to Cohorts instance.")
+        # Set the DBH values to trigger validation
+        setattr(self, "dbh_values", dbh_values)
 
-        self._dbh_values = dbh_values
+        # Additional attributes
         self.n_cohorts = dbh_values.size
         self._cohort_id = np.array([str(uuid.uuid4()) for _ in range(self.n_cohorts)])
 
@@ -234,8 +234,9 @@ class Cohorts(PandasExporter, CohortMethods):
 
     @dbh_values.setter
     def dbh_values(self, values: NDArray[np.float64]) -> None:
-        if np.any(values < 0):
-            raise ValueError("Cannot set negative DBH values in Cohorts instance.")
+        """Setter function for DBH values, enforcing strictly positive values."""
+        if np.any(values <= 0):
+            raise ValueError("DBH values must be strictly positive")
 
         self._dbh_values = values
 

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -998,6 +998,10 @@ class StemAllometry(PandasExporter, CohortMethods):
                 trait_args={"h_max": stem_traits.h_max}, size_args={"at_dbh": at_dbh}
             )
 
+        # Fail if any DBH values are negative
+        if np.any(at_dbh < 0):
+            raise ValueError("Negative DBH values passed to StemAllometry")
+
         self.stem_height = calculate_heights(
             h_max=stem_traits.h_max, a_hd=stem_traits.a_hd, dbh=at_dbh, validate=False
         )

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -646,6 +646,12 @@ def calculate_net_primary_productivity(
         _validate_demography_array_arguments(
             trait_args={"yld": yld}, size_args=size_args
         )
+        # Allow reproductive tissue terms to be zero
+        size_args = {
+            k: v
+            for k, v in size_args.items()
+            if k not in ("reproductive_tissue_respiration")
+        }
         _enforce_positive_sizes(
             size_args=size_args, function_name="calculate_net_primary_productivity"
         )
@@ -756,13 +762,11 @@ def calculate_reproductive_tissue_turnover(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
-        size_args = {"m_rt": m_rt}
         _validate_demography_array_arguments(
-            trait_args={"tau_rt": tau_rt}, size_args=size_args
+            trait_args={"tau_rt": tau_rt}, size_args={"m_rt": m_rt}
         )
-        _enforce_positive_sizes(
-            size_args=size_args, function_name="calculate_reproductive_tissue_turnover"
-        )
+        if np.any(m_rt < 0):
+            raise ValueError("The reproductive tissue mass cannot be negative.")
 
     return _enforce_2D(m_rt * (1 / tau_rt))
 
@@ -919,6 +923,13 @@ def calculate_growth_increments(
             },
             size_args=size_args,
         )
+        # Allow reproductive tissue terms to be zero
+        size_args = {
+            k: v
+            for k, v in size_args.items()
+            if k
+            not in ("reproductive_tissue_turnover", "p_foliage_for_reproductive_tissue")
+        }
         _enforce_positive_sizes(
             size_args=size_args, function_name="calculate_growth_increments"
         )

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -1040,13 +1040,11 @@ class StemAllometry(PandasExporter, CohortMethods):
         # the at_dbh values are congruent with the stem_traits inputs. If they are, then
         # all the other allometry function inputs will be too.
         if validate:
+            size_args = {"at_dbh": at_dbh}
             _validate_demography_array_arguments(
-                trait_args={"h_max": stem_traits.h_max}, size_args={"at_dbh": at_dbh}
+                trait_args={"h_max": stem_traits.h_max}, size_args=size_args
             )
-
-        # Fail if any DBH values are negative
-        if np.any(at_dbh <= 0):
-            raise ValueError("DBH values must be strictly positive")
+            _enforce_positive_sizes(size_args=size_args, function_name="StemAllometry")
 
         self.stem_height = calculate_heights(
             h_max=stem_traits.h_max, a_hd=stem_traits.a_hd, dbh=at_dbh, validate=False

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -999,8 +999,10 @@ class StemAllometry(PandasExporter, CohortMethods):
             )
 
         # Fail if any DBH values are negative
-        if np.any(at_dbh < 0):
-            raise ValueError("Negative DBH values passed to StemAllometry")
+        if np.any(at_dbh <= 0):
+            raise ValueError(
+                "DBH values passed to StemAllometry must be strictly positive"
+            )
 
         self.stem_height = calculate_heights(
             h_max=stem_traits.h_max, a_hd=stem_traits.a_hd, dbh=at_dbh, validate=False

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -855,11 +855,11 @@ def calculate_growth_increments(
     * the crown area ratio (:math:`c`), and
     * the ratio of fine root mass to leaf area (:math:`\zeta`).
 
-    The value of :math`\Delta D` is unstable when :math:`D = 0` and hence :math:`H = 0`
+    The value of :math:`\Delta D` is unstable when :math:`D = 0` and hence :math:`H = 0`
     and the rates of change in stem and foliar mass are also zero. If :math:`P_{net} - T
-    = 0` then :math`\Delta D` is undefined, otherwise :math`\Delta D = \pm \inf`
+    = 0` then :math:`\Delta D` is undefined, otherwise :math:`\Delta D = \pm \inf`
     depending on whether then turnover costs exceed the available NPP. Under these
-    conditions, this function explicitly sets :math`\Delta D = 0`: **stems with zero
+    conditions, this function explicitly sets :math:`\Delta D = 0`: **stems with zero
     height cannot grow**.
 
     The resulting incremental changes in stem mass and foliar mass can then be

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -103,9 +103,7 @@ def calculate_dbh_from_height(
     # - H = h_max generates a divide by zero which returns inf with a warning. Here the
     #   answer should be h_max so that needs trapping.
 
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(RuntimeWarning, "divide by zero encountered in divide")
-        sup.filter(RuntimeWarning, "invalid value encountered in log")
+    with np.errstate(divide="ignore", invalid="ignore"):
         return _enforce_2D((h_max * np.log(h_max / (h_max - stem_height))) / a_hd)
 
 
@@ -162,6 +160,9 @@ def calculate_crown_fractions(
 
         f_{c} =\frac{H}{a D}
 
+    Note that when :math:`D = 0` - and hence also :math:`H = 0` - the crown fraction is
+    undefined.
+
     Args:
         a_hd: Initial slope of the height/diameter relationship of the PFT
         stem_height: Stem height of individuals
@@ -174,7 +175,12 @@ def calculate_crown_fractions(
             size_args={"dbh": dbh, "stem_height": stem_height},
         )
 
-    return _enforce_2D(stem_height / (a_hd * dbh))
+    # Calculate crown fraction, explicitly ignore divide by zero warnings when DBH is
+    # zero. Does not attempt to set an alternative value as there is no biological
+    # meaningful value and it is only used in further calculation in
+    # calculate_sapwood_mass, where DBH = 0 is handled.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return _enforce_2D(stem_height / (a_hd * dbh))
 
 
 def calculate_stem_masses(
@@ -251,12 +257,27 @@ def calculate_sapwood_masses(
 
     The sapwood mass (:math:`W_{\cdot s}`) is calculated from the individual crown area
     (:math:`A_{c}`), stem height (:math:`H`) and canopy fraction (:math:`f_{c}`) along
-    with the wood density (:math:`\rho_s`) and crown area ratio (:math:`c`) of the
-    plant functional type :cite:p:`{Equation 14, }Li:2014bc`.
+    with the wood density (:math:`\rho_s`) and crown area ratio (:math:`c`) of the plant
+    functional type. The calculation follows Equation 14 of :cite:`Li:2014bc`, except to
+    explicitly set :math:`W_{\cdot s} = 0` where :math:`D = 0` and hence :math:`H = 0`
+    and :math:`f_c` is undefined.
 
     .. math::
 
         W_{\cdot s} = \frac{A_c \rho_s H (1 - f_c / 2)}{c}
+
+
+      .. math::
+        :nowrap:
+
+        \[
+            W_{\cdot s} =
+                \begin{cases}
+                    \frac{A_c \rho_s H (1 - f_c / 2)}{c},  & H > 0 \\
+                    0, &  otherwise,
+                \end{cases}
+        \]
+
 
     Args:
         rho_s: Wood density of the PFT
@@ -277,7 +298,11 @@ def calculate_sapwood_masses(
         )
 
     return _enforce_2D(
-        crown_area * rho_s * stem_height * (1 - crown_fraction / 2) / ca_ratio
+        np.where(
+            stem_height == 0,
+            0,
+            crown_area * rho_s * stem_height * (1 - crown_fraction / 2) / ca_ratio,
+        )
     )
 
 
@@ -742,9 +767,9 @@ def calculate_growth_increments(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
     r"""Calculate growth increments.
 
-    Given an estimate of net primary productivity (:math:`P_{net}`), less associated  
-    turnover costs (:math:`T`), the remaining productivity can be allocated to growth
-    and hence estimate resulting increments :cite:`Li:2014bc` in:
+    Given an estimate of net primary productivity (NPP, :math:`P_{net}`), less
+    associated turnover costs (:math:`T`), the remaining productivity can be allocated
+    to growth and hence estimate resulting increments :cite:`Li:2014bc` in:
     
     * the stem diameter (:math:`\Delta D`),
     * the stem mass (:math:`\Delta W_s`), and 
@@ -785,6 +810,13 @@ def calculate_growth_increments(
     * the crown area ratio (:math:`c`), and
     * the ratio of fine root mass to leaf area (:math:`\zeta`).
 
+    The value of :math`\Delta D` is unstable when :math:`D = 0` and hence :math:`H = 0`
+    and the rates of change in stem and foliar mass are also zero. If :math:`P_{net} - T
+    = 0` then :math`\Delta D` is undefined, otherwise :math`\Delta D = \pm \inf`
+    depending on whether then turnover costs exceed the available NPP. Under these
+    conditions, this function explicitly sets :math`\Delta D = 0`: **stems with zero
+    height cannot grow**.
+
     The resulting incremental changes in stem mass and foliar mass can then be
     calculated as:
 
@@ -798,8 +830,15 @@ def calculate_growth_increments(
         \end{align*}
       \]
 
-    NOTE: Reproductive tissue is included as an optional additional cost of turnover.
-    If the default values are set to zero, it will not impact T Model calculations.
+    .. NOTE::
+
+        The original equations have been extended to include a term to model the costs
+        of maintaining reproductive tissue mass as a fraction of foliage mass. These
+        values can be set to zero to reproduce the predictions of the original T Model
+        calculations. 
+
+
+
 
     Args:
         rho_s: Wood density of the PFT
@@ -854,10 +893,16 @@ def calculate_growth_increments(
         * ((1 + p_foliage_for_reproductive_tissue) / sla + zeta)
     )
 
-    # Increment of diameter at breast height
-    delta_d = _enforce_2D(
-        (npp - turnover - reproductive_tissue_turnover) / (dWsdt + dWfdt)
-    )
+    # Increment of diameter at breast height, ignoring potential zero divides resulting
+    # from stems with zero DBH, which are then explicitly set to have Delta D of zero.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        delta_d = _enforce_2D(
+            np.where(
+                dbh == 0,
+                0,
+                (npp - turnover - reproductive_tissue_turnover) / (dWsdt + dWfdt),
+            )
+        )
 
     return (delta_d, dWsdt * delta_d, dWfdt * delta_d)
 

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -24,7 +24,7 @@ from pyrealm.demography.core import (
 from pyrealm.demography.flora import Flora, StemTraits
 
 
-def enforce_positive_sizes(size_args: dict[str, NDArray], function_name: str) -> None:
+def _enforce_positive_sizes(size_args: dict[str, NDArray], function_name: str) -> None:
     """Simple function to trap allometry inputs that are not strictly positive."""
 
     failing = [vname for vname, values in size_args.items() if np.any(values <= 0)]
@@ -65,6 +65,7 @@ def calculate_heights(
         _validate_demography_array_arguments(
             trait_args={"h_max": h_max, "a_hd": a_hd}, size_args=size_args
         )
+        _enforce_positive_sizes(size_args=size_args, function_name="calculate_heights")
 
     return _enforce_2D(h_max * (1 - np.exp(-a_hd * dbh / h_max)))
 
@@ -104,9 +105,12 @@ def calculate_dbh_from_height(
     """
 
     if validate:
+        size_args = {"stem_height": stem_height}
         _validate_demography_array_arguments(
-            trait_args={"h_max": h_max, "a_hd": a_hd},
-            size_args={"stem_height": stem_height},
+            trait_args={"h_max": h_max, "a_hd": a_hd}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_dbh_from_height"
         )
 
     # The equation here blows up in a couple of ways:
@@ -148,9 +152,13 @@ def calculate_crown_areas(
     """
 
     if validate:
+        size_args = {"dbh": dbh, "stem_height": stem_height}
+
         _validate_demography_array_arguments(
-            trait_args={"ca_ratio": ca_ratio, "a_hd": a_hd},
-            size_args={"dbh": dbh, "stem_height": stem_height},
+            trait_args={"ca_ratio": ca_ratio, "a_hd": a_hd}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_crown_areas"
         )
 
     return _enforce_2D(((np.pi * ca_ratio) / (4 * a_hd)) * dbh * stem_height)
@@ -165,16 +173,13 @@ def calculate_crown_fractions(
     r"""Calculate tree crown fraction under the T Model.
 
     The crown fraction (:math:`f_{c}`) is calculated from individual diameters at breast
-    height (:math:`D`) and stem height (:math:`H`), along with the initial slope of the
-    height / diameter relationship (:math:`a`) of the plant functional type
-    :cite:p:`{Equation 11, }Li:2014bc`:
+    height (:math:`D` for :math:`D > 0`) and stem height (:math:`H`), along with the
+    initial slope of the height / diameter relationship (:math:`a`) of the plant
+    functional type :cite:p:`{Equation 11, }Li:2014bc`:
 
     .. math::
 
         f_{c} =\frac{H}{a D}
-
-    Note that when :math:`D = 0` - and hence also :math:`H = 0` - the crown fraction is
-    undefined.
 
     Args:
         a_hd: Initial slope of the height/diameter relationship of the PFT
@@ -183,17 +188,16 @@ def calculate_crown_fractions(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"dbh": dbh, "stem_height": stem_height}
         _validate_demography_array_arguments(
-            trait_args={"a_hd": a_hd},
-            size_args={"dbh": dbh, "stem_height": stem_height},
+            trait_args={"a_hd": a_hd}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_crown_fractions"
         )
 
-    # Calculate crown fraction, explicitly ignore divide by zero warnings when DBH is
-    # zero. Does not attempt to set an alternative value as there is no biological
-    # meaningful value and it is only used in further calculation in
-    # calculate_sapwood_mass, where DBH = 0 is handled.
-    with np.errstate(divide="ignore", invalid="ignore"):
-        return _enforce_2D(stem_height / (a_hd * dbh))
+    # Calculate crown fraction
+    return _enforce_2D(stem_height / (a_hd * dbh))
 
 
 def calculate_stem_masses(
@@ -219,9 +223,12 @@ def calculate_stem_masses(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"dbh": dbh, "stem_height": stem_height}
         _validate_demography_array_arguments(
-            trait_args={"rho_s": rho_s},
-            size_args={"dbh": dbh, "stem_height": stem_height},
+            trait_args={"rho_s": rho_s}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_stem_masses"
         )
 
     return _enforce_2D((np.pi / 8) * rho_s * (dbh**2) * stem_height)
@@ -250,9 +257,12 @@ def calculate_foliage_masses(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"crown_area": crown_area}
         _validate_demography_array_arguments(
-            trait_args={"sla": sla, "lai": lai},
-            size_args={"crown_area": crown_area},
+            trait_args={"sla": sla, "lai": lai}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_foliage_masses"
         )
 
     return _enforce_2D(crown_area * lai * (1 / sla))
@@ -271,26 +281,12 @@ def calculate_sapwood_masses(
     The sapwood mass (:math:`W_{\cdot s}`) is calculated from the individual crown area
     (:math:`A_{c}`), stem height (:math:`H`) and canopy fraction (:math:`f_{c}`) along
     with the wood density (:math:`\rho_s`) and crown area ratio (:math:`c`) of the plant
-    functional type. The calculation follows Equation 14 of :cite:`Li:2014bc`, except to
-    explicitly set :math:`W_{\cdot s} = 0` where :math:`D = 0` and hence :math:`H = 0`
-    and :math:`f_c` is undefined.
+    functional type, following Equation 14 of :cite:`Li:2014bc`. The function is
+    undefined for negative or zero heights.
 
     .. math::
 
         W_{\cdot s} = \frac{A_c \rho_s H (1 - f_c / 2)}{c}
-
-
-      .. math::
-        :nowrap:
-
-        \[
-            W_{\cdot s} =
-                \begin{cases}
-                    \frac{A_c \rho_s H (1 - f_c / 2)}{c},  & H > 0 \\
-                    0, &  otherwise,
-                \end{cases}
-        \]
-
 
     Args:
         rho_s: Wood density of the PFT
@@ -301,21 +297,20 @@ def calculate_sapwood_masses(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {
+            "stem_height": stem_height,
+            "crown_area": crown_area,
+            "crown_fraction": crown_fraction,
+        }
         _validate_demography_array_arguments(
-            trait_args={"rho_s": rho_s, "ca_ratio": ca_ratio},
-            size_args={
-                "stem_height": stem_height,
-                "crown_area": crown_area,
-                "crown_fraction": crown_fraction,
-            },
+            trait_args={"rho_s": rho_s, "ca_ratio": ca_ratio}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_sapwood_masses"
         )
 
     return _enforce_2D(
-        np.where(
-            stem_height == 0,
-            0,
-            crown_area * rho_s * stem_height * (1 - crown_fraction / 2) / ca_ratio,
-        )
+        crown_area * rho_s * stem_height * (1 - crown_fraction / 2) / ca_ratio,
     )
 
 
@@ -346,9 +341,12 @@ def calculate_crown_z_max(
     """
 
     if validate:
+        size_args = {"stem_height": stem_height}
         _validate_demography_array_arguments(
-            trait_args={"z_max_prop": z_max_prop},
-            size_args={"stem_height": stem_height},
+            trait_args={"z_max_prop": z_max_prop}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_crown_z_max"
         )
 
     return _enforce_2D(stem_height * z_max_prop)
@@ -380,10 +378,11 @@ def calculate_crown_r0(
     """
 
     if validate:
+        size_args = {"crown_area": crown_area}
         _validate_demography_array_arguments(
-            trait_args={"q_m": q_m},
-            size_args={"crown_area": crown_area},
+            trait_args={"q_m": q_m}, size_args=size_args
         )
+        _enforce_positive_sizes(size_args=size_args, function_name="calculate_crown_r0")
 
     # Scaling factor to give expected A_c (crown area) at
     # z_m (height of maximum crown radius)
@@ -417,9 +416,12 @@ def calculate_whole_crown_gpp(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"potential_gpp": potential_gpp, "crown_area": crown_area}
         _validate_demography_array_arguments(
-            trait_args={"lai": lai, "par_ext": par_ext},
-            size_args={"potential_gpp": potential_gpp, "crown_area": crown_area},
+            trait_args={"lai": lai, "par_ext": par_ext}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_whole_crown_gpp"
         )
 
     return _enforce_2D(potential_gpp * crown_area * (1 - np.exp(-(par_ext * lai))))
@@ -445,9 +447,12 @@ def calculate_sapwood_respiration(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"sapwood_mass": sapwood_mass}
         _validate_demography_array_arguments(
-            trait_args={"resp_s": resp_s},
-            size_args={"sapwood_mass": sapwood_mass},
+            trait_args={"resp_s": resp_s}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_sapwood_respiration"
         )
 
     return _enforce_2D(sapwood_mass * resp_s)
@@ -475,9 +480,12 @@ def calculate_foliar_respiration(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"whole_crown_gpp": whole_crown_gpp}
         _validate_demography_array_arguments(
-            trait_args={"resp_f": resp_f},
-            size_args={"whole_crown_gpp": whole_crown_gpp},
+            trait_args={"resp_f": resp_f}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_foliar_respiration"
         )
 
     return _enforce_2D(whole_crown_gpp * resp_f)
@@ -506,9 +514,12 @@ def calculate_gpp_topslice(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"whole_crown_gpp": whole_crown_gpp}
         _validate_demography_array_arguments(
-            trait_args={"gpp_topslice": gpp_topslice},
-            size_args={"whole_crown_gpp": whole_crown_gpp},
+            trait_args={"gpp_topslice": gpp_topslice}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_gpp_topslice"
         )
 
     return _enforce_2D(whole_crown_gpp * gpp_topslice)
@@ -538,9 +549,13 @@ def calculate_reproductive_tissue_respiration(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"reproductive_tissue_mass": reproductive_tissue_mass}
         _validate_demography_array_arguments(
-            trait_args={"resp_rt": resp_rt},
-            size_args={"reproductive_tissue_mass": reproductive_tissue_mass},
+            trait_args={"resp_rt": resp_rt}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args,
+            function_name="calculate_reproductive_tissue_respiration",
         )
 
     return _enforce_2D(reproductive_tissue_mass * resp_rt)
@@ -571,13 +586,13 @@ def calculate_fine_root_respiration(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"foliage_mass": foliage_mass}
         _validate_demography_array_arguments(
-            trait_args={
-                "zeta": zeta,
-                "sla": sla,
-                "resp_r": resp_r,
-            },
-            size_args={"foliage_mass": foliage_mass},
+            trait_args={"zeta": zeta, "sla": sla, "resp_r": resp_r},
+            size_args=size_args,
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_fine_root_respiration"
         )
 
     return _enforce_2D(zeta * sla * foliage_mass * resp_r)
@@ -621,15 +636,18 @@ def calculate_net_primary_productivity(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {
+            "whole_crown_gpp": whole_crown_gpp,
+            "foliar_respiration": foliar_respiration,
+            "fine_root_respiration": fine_root_respiration,
+            "sapwood_respiration": sapwood_respiration,
+            "reproductive_tissue_respiration": reproductive_tissue_respiration,
+        }
         _validate_demography_array_arguments(
-            trait_args={"yld": yld},
-            size_args={
-                "whole_crown_gpp": whole_crown_gpp,
-                "foliar_respiration": foliar_respiration,
-                "fine_root_respiration": fine_root_respiration,
-                "sapwood_respiration": sapwood_respiration,
-                "reproductive_tissue_respiration": reproductive_tissue_respiration,
-            },
+            trait_args={"yld": yld}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_net_primary_productivity"
         )
 
     return _enforce_2D(
@@ -666,9 +684,13 @@ def calculate_foliage_turnover(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"foliage_mass": foliage_mass}
         _validate_demography_array_arguments(
             trait_args={"tau_f": tau_f},
-            size_args={"foliage_mass": foliage_mass},
+            size_args=size_args,
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_foliage_turnover"
         )
 
     return _enforce_2D(foliage_mass * (1 / tau_f))
@@ -701,9 +723,12 @@ def calculate_fine_root_turnover(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"foliage_mass": foliage_mass}
         _validate_demography_array_arguments(
-            trait_args={"sla": sla, "zeta": zeta, "tau_r": tau_r},
-            size_args={"foliage_mass": foliage_mass},
+            trait_args={"sla": sla, "zeta": zeta, "tau_r": tau_r}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_fine_root_turnover"
         )
 
     return _enforce_2D(foliage_mass * (sla * zeta / tau_r))
@@ -731,9 +756,12 @@ def calculate_reproductive_tissue_turnover(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {"m_rt": m_rt}
         _validate_demography_array_arguments(
-            trait_args={"tau_rt": tau_rt},
-            size_args={"m_rt": m_rt},
+            trait_args={"tau_rt": tau_rt}, size_args=size_args
+        )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_reproductive_tissue_turnover"
         )
 
     return _enforce_2D(m_rt * (1 / tau_rt))
@@ -871,6 +899,14 @@ def calculate_growth_increments(
         validate: Boolean flag to suppress argument validation
     """
     if validate:
+        size_args = {
+            "npp": npp,
+            "turnover": turnover,
+            "reproductive_tissue_turnover": reproductive_tissue_turnover,
+            "p_foliage_for_reproductive_tissue": p_foliage_for_reproductive_tissue,
+            "dbh": dbh,
+            "stem_height": stem_height,
+        }
         _validate_demography_array_arguments(
             trait_args={
                 "rho_s": rho_s,
@@ -881,15 +917,12 @@ def calculate_growth_increments(
                 "sla": sla,
                 "zeta": zeta,
             },
-            size_args={
-                "npp": npp,
-                "turnover": turnover,
-                "reproductive_tissue_turnover": reproductive_tissue_turnover,
-                "p_foliage_for_reproductive_tissue": p_foliage_for_reproductive_tissue,
-                "dbh": dbh,
-                "stem_height": stem_height,
-            },
+            size_args=size_args,
         )
+        _enforce_positive_sizes(
+            size_args=size_args, function_name="calculate_growth_increments"
+        )
+
     # Rates of change in stem and foliar
     dWsdt = (
         np.pi

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -553,10 +553,8 @@ def calculate_reproductive_tissue_respiration(
         _validate_demography_array_arguments(
             trait_args={"resp_rt": resp_rt}, size_args=size_args
         )
-        _enforce_positive_sizes(
-            size_args=size_args,
-            function_name="calculate_reproductive_tissue_respiration",
-        )
+        if np.any(reproductive_tissue_mass < 0):
+            raise ValueError("The reproductive tissue mass cannot be negative.")
 
     return _enforce_2D(reproductive_tissue_mass * resp_rt)
 
@@ -741,7 +739,7 @@ def calculate_fine_root_turnover(
 
 
 def calculate_reproductive_tissue_turnover(
-    m_rt: NDArray[np.float64],
+    reproductive_tissue_mass: NDArray[np.float64],
     tau_rt: NDArray[np.float64],
     validate: bool = True,
 ) -> NDArray[np.float64]:
@@ -749,26 +747,27 @@ def calculate_reproductive_tissue_turnover(
 
     This function calculates the costs associated with the turnover of reproductive
     tissue. This is calculated from the total reproductive tissue mass
-    (:math:`m_rt`), along with the turnover time of reproductive tissue
-    (:math:`\tau_rt`).
+    (:math:`m_{rt}`), along with the turnover time of reproductive tissue
+    (:math:`\tau_{rt}`).
 
     .. math::
 
-        T_rt = m_rt \left( \frac{1}{\tau_rt}\right)
+        T_{rt} = m_{rt} \left( \frac{1}{\tau_{rt}}\right)
 
     Args:
-        m_rt: The mass of reproductive tissue
+        reproductive_tissue_mass: The mass of reproductive tissue
         tau_rt: The turnover time of reproductive tissue
         validate: Boolean flag to suppress argument validation
     """
     if validate:
         _validate_demography_array_arguments(
-            trait_args={"tau_rt": tau_rt}, size_args={"m_rt": m_rt}
+            trait_args={"tau_rt": tau_rt},
+            size_args={"reproductive_tissue_mass": reproductive_tissue_mass},
         )
-        if np.any(m_rt < 0):
+        if np.any(reproductive_tissue_mass < 0):
             raise ValueError("The reproductive tissue mass cannot be negative.")
 
-    return _enforce_2D(m_rt * (1 / tau_rt))
+    return _enforce_2D(reproductive_tissue_mass * (1 / tau_rt))
 
 
 def calculate_reproductive_tissue_mass(
@@ -777,12 +776,12 @@ def calculate_reproductive_tissue_mass(
 ) -> NDArray[np.float64]:
     r"""Calculate reproductive tissue mass.
 
-    This function calculates the mass of reproductive tissue (:math:`m_rt`) as a fixed
+    This function calculates the mass of reproductive tissue (:math:`m_{rt}`) as a fixed
     proportion of the total foliage mass (:math:`W_f`) of individuals.
 
     .. math::
 
-        m_rt = p_{f_rt} W_f
+        m_{rt} = p_{f_{rt}} W_f
 
     Args:
         foliage_mass: The foliage mass
@@ -1295,7 +1294,7 @@ class StemAllocation(PandasExporter):
         )
 
         self.reproductive_tissue_turnover = calculate_reproductive_tissue_turnover(
-            m_rt=stem_allometry.reproductive_tissue_mass,
+            reproductive_tissue_mass=stem_allometry.reproductive_tissue_mass,
             tau_rt=stem_traits.tau_rt,
             validate=False,
         )

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -24,6 +24,18 @@ from pyrealm.demography.core import (
 from pyrealm.demography.flora import Flora, StemTraits
 
 
+def enforce_positive_sizes(size_args: dict[str, NDArray], function_name: str) -> None:
+    """Simple function to trap allometry inputs that are not strictly positive."""
+
+    failing = [vname for vname, values in size_args.items() if np.any(values <= 0)]
+
+    if failing:
+        raise ValueError(
+            f"Allometry values in {function_name} not strictly "
+            f"positive: {', '.join(failing)}"
+        )
+
+
 def calculate_heights(
     h_max: NDArray[np.float64],
     a_hd: NDArray[np.float64],
@@ -49,8 +61,9 @@ def calculate_heights(
     """
 
     if validate:
+        size_args = {"dbh": dbh}
         _validate_demography_array_arguments(
-            trait_args={"h_max": h_max, "a_hd": a_hd}, size_args={"dbh": dbh}
+            trait_args={"h_max": h_max, "a_hd": a_hd}, size_args=size_args
         )
 
     return _enforce_2D(h_max * (1 - np.exp(-a_hd * dbh / h_max)))
@@ -1000,9 +1013,7 @@ class StemAllometry(PandasExporter, CohortMethods):
 
         # Fail if any DBH values are negative
         if np.any(at_dbh <= 0):
-            raise ValueError(
-                "DBH values passed to StemAllometry must be strictly positive"
-            )
+            raise ValueError("DBH values must be strictly positive")
 
         self.stem_height = calculate_heights(
             h_max=stem_traits.h_max, a_hd=stem_traits.a_hd, dbh=at_dbh, validate=False

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -92,8 +92,18 @@ def check_expected(community, expected):
                 "dbh_values": np.array([0.2, -0.5]),
             },
             pytest.raises(ValueError),
-            "Negative DBH values passed to Cohorts instance.",
+            "DBH values must be strictly positive",
             id="negative dbh",
+        ),
+        pytest.param(
+            {
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, 0]),
+            },
+            pytest.raises(ValueError),
+            "DBH values must be strictly positive",
+            id="zero dbh",
         ),
         pytest.param(
             {

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -87,6 +87,16 @@ def check_expected(community, expected):
         ),
         pytest.param(
             {
+                "pft_names": np.array(["broadleaf", "conifer"]),
+                "n_individuals": np.array([6, 1]),
+                "dbh_values": np.array([0.2, -0.5]),
+            },
+            pytest.raises(ValueError),
+            "Negative DBH values passed to Cohorts instance.",
+            id="negative dbh",
+        ),
+        pytest.param(
+            {
                 "pft_names": False,
                 "n_individuals": np.array([6, 1]),
                 "dbh_values": np.array([0.2, 0.5]),
@@ -161,6 +171,28 @@ def test_Cohorts_duplicate_id_detection():
 
     with pytest.raises(ValueError):
         _ = cohorts.add_cohort_data(new_data=cohorts)
+
+
+def test_Cohorts_no_negative_dbh():
+    """Test setting negative DBH fails."""
+
+    from pyrealm.demography.community import Cohorts
+
+    # Create and instances to modify using methods
+    cohorts = Cohorts(
+        pft_names=np.array(["broadleaf", "conifer"]),
+        n_individuals=np.array([6, 1]),
+        dbh_values=np.array([0.2, 0.5]),
+    )
+
+    # This should be OK...
+    cohorts.dbh_values = np.array([0, 0])
+
+    # ... but this should fail
+    with pytest.raises(ValueError) as excep:
+        cohorts.dbh_values = np.array([-1, -1])
+
+    assert str(excep.value) == "Cannot set negative DBH values in Cohorts instance."
 
 
 def test_Cohorts_CohortMethods():

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -173,26 +173,64 @@ def test_Cohorts_duplicate_id_detection():
         _ = cohorts.add_cohort_data(new_data=cohorts)
 
 
-def test_Cohorts_no_negative_dbh():
-    """Test setting negative DBH fails."""
+@pytest.mark.parametrize(
+    argnames="values, outcome, message",
+    argvalues=(
+        pytest.param(np.array([1, 1]), does_not_raise(), None, id="positive"),
+        pytest.param(
+            np.array([1e-12, 1e-12]),
+            does_not_raise(),
+            None,
+            id="tiny but not zero",
+        ),
+        pytest.param(
+            np.array([1e-350, 1e-350]),
+            pytest.raises(ValueError),
+            "DBH values must be strictly positive",
+            id="functionally zero",
+        ),
+        pytest.param(
+            np.array([0, 0]),
+            pytest.raises(ValueError),
+            "DBH values must be strictly positive",
+            id="zero",
+        ),
+        pytest.param(
+            np.array([-1, -1]),
+            pytest.raises(ValueError),
+            "DBH values must be strictly positive",
+            id="negative",
+        ),
+    ),
+)
+def test_Cohorts_dbh_strictly_positive(values, outcome, message):
+    """Test setting negative or zero DBH fails."""
 
     from pyrealm.demography.community import Cohorts
 
-    # Create and instances to modify using methods
+    # Test __init__
+    with outcome as excep:
+        cohorts = Cohorts(
+            pft_names=np.array(["broadleaf", "conifer"]),
+            n_individuals=np.array([6, 1]),
+            dbh_values=values,
+        )
+
+    if excep:
+        assert str(excep.value) == message
+
+    # Test setter
     cohorts = Cohorts(
         pft_names=np.array(["broadleaf", "conifer"]),
         n_individuals=np.array([6, 1]),
-        dbh_values=np.array([0.2, 0.5]),
+        dbh_values=np.array([1, 1]),
     )
 
-    # This should be OK...
-    cohorts.dbh_values = np.array([0, 0])
+    with outcome as excep:
+        cohorts.dbh_values = values
 
-    # ... but this should fail
-    with pytest.raises(ValueError) as excep:
-        cohorts.dbh_values = np.array([-1, -1])
-
-    assert str(excep.value) == "Cannot set negative DBH values in Cohorts instance."
+    if excep:
+        assert str(excep.value) == message
 
 
 def test_Cohorts_CohortMethods():

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -1,5 +1,6 @@
 """test the functions in tmodel.py."""
 
+import warnings
 from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
@@ -950,3 +951,57 @@ def test_StemAllocation_validation(rtmodel_flora, whole_crown_gpp, outcome, exce
         return
 
     assert str(excep.value).startswith(excep_msg)
+
+
+def test_t_model_behaviour_zero_dbh(rtmodel_flora):
+    """Test the edge case of zero DBH.
+
+    This test is to check that the T Model calculations behave properly with DBH = 0:
+    * All allometries are zero, except crown fraction which is undefined.
+    * All allocation is zero, except for the input whole crown gpp and NPP, which is
+      simply GPP times the yield trait
+    """
+
+    from pyrealm.demography.tmodel import StemAllocation, StemAllometry
+
+    # With DBH=0 and GPP=0, the equations under these classes will get divide by zero
+    # and invalid values in calculations, but these should have been successfully muted
+    # for the specific equations where they occur.
+    #
+    # With the warnings setup to convert warnings to errors, this will lead to test
+    # failure if any warnings are raised. The message regex is to specifically avoid
+    # the pyrealm ExperimentalFeatureWarning causing a test failure.
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="^(Be aware that)")
+
+        # Calculate allometry for zero DBH stems of each PFT
+        allom = StemAllometry(stem_traits=rtmodel_flora, at_dbh=np.zeros((3, 3)))
+
+        # Calculate stem allocation forcing negative NPP, zero NPP and positive NPP for
+        # each PFT
+        gpp = np.tile(np.array([[-5], [0], [5]]), 3)
+
+        alloc = StemAllocation(
+            stem_traits=rtmodel_flora,
+            stem_allometry=allom,
+            whole_crown_gpp=gpp,
+        )
+
+        # Test the allometry values
+        for attr in allom.array_attrs:
+            vals = getattr(allom, attr)
+            if attr == "crown_fraction":
+                assert np.all(np.isnan(vals))
+            else:
+                assert_allclose(vals, np.zeros((3, 3)))
+
+        # Test the allocation values
+        for attr in alloc.array_attrs:
+            vals = getattr(alloc, attr)
+            if attr == "whole_crown_gpp":
+                assert_allclose(vals, gpp)
+            elif attr == "npp":
+                assert_allclose(vals, gpp * rtmodel_flora.yld)
+            else:
+                assert_allclose(vals, np.zeros((3, 3)))

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -1,6 +1,5 @@
 """test the functions in tmodel.py."""
 
-import warnings
 from contextlib import nullcontext as does_not_raise
 from inspect import signature
 from unittest.mock import patch
@@ -641,12 +640,15 @@ class TestTModel:
         )
 
         with outcome as excep:
+            # Note that foliar respiration was handled externally to the T Model
+            # calculations in the original R implementation. In pyrealm it is part of
+            # the PFT traits and the validation for allometry forces it to be non-zero,
+            # but here it is set very small to both pass input validation and to avoid
+            # altering the results given the precision of the tests.
             result = calculate_net_primary_productivity(
                 yld=rtmodel_flora.yld[pft_idx],
                 whole_crown_gpp=rtmodel_data["whole_crown_gpp"][data_idx],
-                foliar_respiration=np.array(
-                    [0]
-                ),  # Not included here in the R implementation
+                foliar_respiration=np.array([1e-10]),  # see above
                 fine_root_respiration=rtmodel_data["fine_root_respiration"][data_idx],
                 sapwood_respiration=rtmodel_data["sapwood_respiration"][data_idx],
                 reproductive_tissue_respiration=np.zeros(
@@ -759,23 +761,31 @@ class TestTModel:
     ),
 )
 @pytest.mark.parametrize(
-    argnames="fname, size_args",
+    argnames="fname, strict_size_args, non_strict_size_args",
     argvalues=(
-        ("calculate_heights", ("dbh",)),
-        ("calculate_dbh_from_height", ("stem_height",)),
-        ("calculate_crown_areas", ("dbh", "stem_height")),
-        ("calculate_crown_fractions", ("dbh", "stem_height")),
-        ("calculate_stem_masses", ("dbh", "stem_height")),
-        ("calculate_foliage_masses", ("crown_area",)),
-        ("calculate_sapwood_masses", ("stem_height", "crown_area", "crown_fraction")),
-        ("calculate_crown_z_max", ("stem_height",)),
-        ("calculate_crown_r0", ("crown_area",)),
-        ("calculate_whole_crown_gpp", ("potential_gpp", "crown_area")),
-        ("calculate_sapwood_respiration", ("sapwood_mass",)),
-        ("calculate_foliar_respiration", ("whole_crown_gpp",)),
-        ("calculate_gpp_topslice", ("whole_crown_gpp",)),
-        ("calculate_reproductive_tissue_respiration", ("reproductive_tissue_mass",)),
-        ("calculate_fine_root_respiration", ("foliage_mass",)),
+        ("calculate_heights", ("dbh",), tuple()),
+        ("calculate_dbh_from_height", ("stem_height",), tuple()),
+        ("calculate_crown_areas", ("dbh", "stem_height"), tuple()),
+        ("calculate_crown_fractions", ("dbh", "stem_height"), tuple()),
+        ("calculate_stem_masses", ("dbh", "stem_height"), tuple()),
+        ("calculate_foliage_masses", ("crown_area",), tuple()),
+        (
+            "calculate_sapwood_masses",
+            ("stem_height", "crown_area", "crown_fraction"),
+            tuple(),
+        ),
+        ("calculate_crown_z_max", ("stem_height",), tuple()),
+        ("calculate_crown_r0", ("crown_area",), tuple()),
+        ("calculate_whole_crown_gpp", ("potential_gpp", "crown_area"), tuple()),
+        ("calculate_sapwood_respiration", ("sapwood_mass",), tuple()),
+        ("calculate_foliar_respiration", ("whole_crown_gpp",), tuple()),
+        ("calculate_gpp_topslice", ("whole_crown_gpp",), tuple()),
+        (
+            "calculate_reproductive_tissue_respiration",
+            ("reproductive_tissue_mass",),
+            tuple(),
+        ),
+        ("calculate_fine_root_respiration", ("foliage_mass",), tuple()),
         (
             "calculate_net_primary_productivity",
             (
@@ -783,27 +793,28 @@ class TestTModel:
                 "foliar_respiration",
                 "fine_root_respiration",
                 "sapwood_respiration",
-                "reproductive_tissue_respiration",
             ),
+            ("reproductive_tissue_respiration",),
         ),
-        ("calculate_foliage_turnover", ("foliage_mass",)),
-        ("calculate_fine_root_turnover", ("foliage_mass",)),
-        ("calculate_reproductive_tissue_turnover", ("m_rt",)),
+        ("calculate_foliage_turnover", ("foliage_mass",), tuple()),
+        ("calculate_fine_root_turnover", ("foliage_mass",), tuple()),
         (
             "calculate_growth_increments",
             (
                 "npp",
                 "turnover",
-                "reproductive_tissue_turnover",
-                "p_foliage_for_reproductive_tissue",
                 "dbh",
                 "stem_height",
+            ),
+            (
+                "reproductive_tissue_turnover",
+                "p_foliage_for_reproductive_tissue",
             ),
         ),
     ),
 )
 def test_tmodel_enforce_positive_sizes(
-    rtmodel_flora, values, outcome, fname, size_args
+    rtmodel_flora, values, outcome, fname, strict_size_args, non_strict_size_args
 ):
     """Test the validation of positive size values in T model functions.
 
@@ -823,8 +834,8 @@ def test_tmodel_enforce_positive_sizes(
     # Reduce the trait arguments to those in the function signature
     func_args = {k: v for k, v in all_traits.items() if k in func_signature.parameters}
 
-    # Add the size arguments
-    for arg in size_args:
+    # Add all the size arguments to run the function
+    for arg in (*strict_size_args, *non_strict_size_args):
         func_args[arg] = values
 
     with outcome as excep:
@@ -832,8 +843,10 @@ def test_tmodel_enforce_positive_sizes(
         func(**func_args)
 
     if excep:
+        # The exception should only complain about the strict size args
         assert str(excep.value) == (
-            f"Allometry values in {fname} not strictly positive: {', '.join(size_args)}"
+            f"Allometry values in {fname} not strictly "
+            f"positive: {', '.join(strict_size_args)}"
         )
 
 
@@ -848,7 +861,7 @@ def test_calculate_dbh_from_height_edge_cases():
 
     pft_h_max_values = np.array([20, 30])
     pft_a_hd_values = np.array([116.0, 116.0])
-    stem_heights = np.array([[0], [10], [20], [30], [40]])
+    stem_heights = np.array([[10], [20], [30], [40]])
 
     dbh = calculate_dbh_from_height(
         h_max=pft_h_max_values,
@@ -856,14 +869,11 @@ def test_calculate_dbh_from_height_edge_cases():
         stem_height=stem_heights,
     )
 
-    # first row should be all zeros (zero height gives zero diameter)
-    assert np.all(dbh[0, :] == 0)
-
     # Infinite entries
-    assert np.all(np.isinf(dbh) == np.array([[0, 0], [0, 0], [1, 0], [0, 1], [0, 0]]))
+    assert np.all(np.isinf(dbh) == np.array([[0, 0], [1, 0], [0, 1], [0, 0]]))
 
     # Undefined entries
-    assert np.all(np.isnan(dbh) == np.array([[0, 0], [0, 0], [0, 0], [1, 0], [1, 1]]))
+    assert np.all(np.isnan(dbh) == np.array([[0, 0], [0, 0], [1, 0], [1, 1]]))
 
 
 @pytest.mark.parametrize(
@@ -1090,75 +1100,26 @@ def test_StemAllocation_validation(rtmodel_flora, whole_crown_gpp, outcome, exce
     assert str(excep.value).startswith(excep_msg)
 
 
-def test_t_model_behaviour_zero_dbh(rtmodel_flora):
-    """Test the edge case of zero DBH.
-
-    This test is to check that the T Model calculations behave properly with DBH = 0:
-    * All allometries are zero, except crown fraction which is undefined.
-    * All allocation is zero, except for the input whole crown gpp and NPP, which is
-      simply GPP times the yield trait
-    """
-
-    from pyrealm.demography.tmodel import StemAllocation, StemAllometry
-
-    # With DBH=0 and GPP=0, the equations under these classes will get divide by zero
-    # and invalid values in calculations, but these should have been successfully muted
-    # for the specific equations where they occur.
-    #
-    # With the warnings setup to convert warnings to errors, this will lead to test
-    # failure if any warnings are raised. The message regex is to specifically avoid
-    # the pyrealm ExperimentalFeatureWarning causing a test failure.
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings("error", message="^(Be aware that)")
-
-        # Calculate allometry for zero DBH stems of each PFT
-        allom = StemAllometry(stem_traits=rtmodel_flora, at_dbh=np.zeros((3, 3)))
-
-        # Calculate stem allocation forcing negative NPP, zero NPP and positive NPP for
-        # each PFT
-        gpp = np.tile(np.array([[-5], [0], [5]]), 3)
-
-        alloc = StemAllocation(
-            stem_traits=rtmodel_flora,
-            stem_allometry=allom,
-            whole_crown_gpp=gpp,
-        )
-
-        # Test the allometry values
-        for attr in allom.array_attrs:
-            vals = getattr(allom, attr)
-            if attr == "crown_fraction":
-                assert np.all(np.isnan(vals))
-            else:
-                assert_allclose(vals, np.zeros((3, 3)))
-
-        # Test the allocation values
-        for attr in alloc.array_attrs:
-            vals = getattr(alloc, attr)
-            if attr == "whole_crown_gpp":
-                assert_allclose(vals, gpp)
-            elif attr == "npp":
-                assert_allclose(vals, gpp * rtmodel_flora.yld)
-            else:
-                assert_allclose(vals, np.zeros((3, 3)))
-
-
 @pytest.mark.parametrize(
     argnames="dbh, outcome, msg",
     argvalues=(
         pytest.param(np.array([3, 3, 3]), does_not_raise(), None, id="positive"),
-        pytest.param(np.array([0, 0, 3]), does_not_raise(), None, id="zero"),
+        pytest.param(
+            np.array([0, 0, 3]),
+            pytest.raises(ValueError),
+            "Allometry values in StemAllometry not strictly positive: at_dbh",
+            id="zero",
+        ),
         pytest.param(
             np.array([-3, -2, 3]),
             pytest.raises(ValueError),
-            "Negative DBH values passed to StemAllometry",
-            id="positive",
+            "Allometry values in StemAllometry not strictly positive: at_dbh",
+            id="negative",
         ),
     ),
 )
-def test_stem_allocation_negative_dbh(rtmodel_flora, dbh, outcome, msg):
-    """Test that StemAllometry handles negative DBH."""
+def test_stem_allocation_strictly_positive_sizes(rtmodel_flora, dbh, outcome, msg):
+    """Test that StemAllometry handles zero and negative DBH."""
 
     from pyrealm.demography.tmodel import StemAllometry
 

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -121,7 +121,7 @@ def test_calculate_reproductive_tissue_turnover():
     from pyrealm.demography.tmodel import calculate_reproductive_tissue_turnover
 
     result = calculate_reproductive_tissue_turnover(
-        m_rt=np.array([10]),
+        reproductive_tissue_mass=np.array([10]),
         tau_rt=np.array([4]),
     )
 
@@ -780,11 +780,6 @@ class TestTModel:
         ("calculate_sapwood_respiration", ("sapwood_mass",), tuple()),
         ("calculate_foliar_respiration", ("whole_crown_gpp",), tuple()),
         ("calculate_gpp_topslice", ("whole_crown_gpp",), tuple()),
-        (
-            "calculate_reproductive_tissue_respiration",
-            ("reproductive_tissue_mass",),
-            tuple(),
-        ),
         ("calculate_fine_root_respiration", ("foliage_mass",), tuple()),
         (
             "calculate_net_primary_productivity",
@@ -818,7 +813,8 @@ def test_tmodel_enforce_positive_sizes(
 ):
     """Test the validation of positive size values in T model functions.
 
-    The function call is assembled programatically.
+    The function call is assembled programatically. It excludes testing of reproductive
+    tissue respiration and turnover because these do allow zero values.
     """
     from pyrealm.demography import tmodel
 

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -1005,3 +1005,29 @@ def test_t_model_behaviour_zero_dbh(rtmodel_flora):
                 assert_allclose(vals, gpp * rtmodel_flora.yld)
             else:
                 assert_allclose(vals, np.zeros((3, 3)))
+
+
+@pytest.mark.parametrize(
+    argnames="dbh, outcome, msg",
+    argvalues=(
+        pytest.param(np.array([3, 3, 3]), does_not_raise(), None, id="positive"),
+        pytest.param(np.array([0, 0, 3]), does_not_raise(), None, id="zero"),
+        pytest.param(
+            np.array([-3, -2, 3]),
+            pytest.raises(ValueError),
+            "Negative DBH values passed to StemAllometry",
+            id="positive",
+        ),
+    ),
+)
+def test_stem_allocation_negative_dbh(rtmodel_flora, dbh, outcome, msg):
+    """Test that StemAllometry handles negative DBH."""
+
+    from pyrealm.demography.tmodel import StemAllometry
+
+    with outcome as excep:
+        # Calculate allometry for zero DBH stems of each PFT
+        _ = StemAllometry(stem_traits=rtmodel_flora, at_dbh=dbh)
+        return
+
+    assert str(excep.value) == msg

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -2,6 +2,7 @@
 
 import warnings
 from contextlib import nullcontext as does_not_raise
+from inspect import signature
 from unittest.mock import patch
 
 import numpy as np
@@ -49,10 +50,10 @@ from numpy.testing import assert_allclose
 )
 def test_enforce_positive_sizes(size_args, outcome, message):
     """Test the enforce positive sizes function."""
-    from pyrealm.demography.tmodel import enforce_positive_sizes
+    from pyrealm.demography.tmodel import _enforce_positive_sizes
 
     with outcome as excep:
-        enforce_positive_sizes(size_args=size_args, function_name="NA")
+        _enforce_positive_sizes(size_args=size_args, function_name="NA")
 
     if excep:
         assert str(excep.value) == message
@@ -747,6 +748,93 @@ class TestTModel:
             return
 
         assert str(excep.value).startswith(excep_msg)
+
+
+@pytest.mark.parametrize(
+    argnames="values, outcome",
+    argvalues=(
+        pytest.param(np.array([1, 1, 1]), does_not_raise(), id="positive"),
+        pytest.param(np.array([0, 0, 0]), pytest.raises(ValueError), id="zero"),
+        pytest.param(np.array([-1, -1, -1]), pytest.raises(ValueError), id="negative"),
+    ),
+)
+@pytest.mark.parametrize(
+    argnames="fname, size_args",
+    argvalues=(
+        ("calculate_heights", ("dbh",)),
+        ("calculate_dbh_from_height", ("stem_height",)),
+        ("calculate_crown_areas", ("dbh", "stem_height")),
+        ("calculate_crown_fractions", ("dbh", "stem_height")),
+        ("calculate_stem_masses", ("dbh", "stem_height")),
+        ("calculate_foliage_masses", ("crown_area",)),
+        ("calculate_sapwood_masses", ("stem_height", "crown_area", "crown_fraction")),
+        ("calculate_crown_z_max", ("stem_height",)),
+        ("calculate_crown_r0", ("crown_area",)),
+        ("calculate_whole_crown_gpp", ("potential_gpp", "crown_area")),
+        ("calculate_sapwood_respiration", ("sapwood_mass",)),
+        ("calculate_foliar_respiration", ("whole_crown_gpp",)),
+        ("calculate_gpp_topslice", ("whole_crown_gpp",)),
+        ("calculate_reproductive_tissue_respiration", ("reproductive_tissue_mass",)),
+        ("calculate_fine_root_respiration", ("foliage_mass",)),
+        (
+            "calculate_net_primary_productivity",
+            (
+                "whole_crown_gpp",
+                "foliar_respiration",
+                "fine_root_respiration",
+                "sapwood_respiration",
+                "reproductive_tissue_respiration",
+            ),
+        ),
+        ("calculate_foliage_turnover", ("foliage_mass",)),
+        ("calculate_fine_root_turnover", ("foliage_mass",)),
+        ("calculate_reproductive_tissue_turnover", ("m_rt",)),
+        (
+            "calculate_growth_increments",
+            (
+                "npp",
+                "turnover",
+                "reproductive_tissue_turnover",
+                "p_foliage_for_reproductive_tissue",
+                "dbh",
+                "stem_height",
+            ),
+        ),
+    ),
+)
+def test_tmodel_enforce_positive_sizes(
+    rtmodel_flora, values, outcome, fname, size_args
+):
+    """Test the validation of positive size values in T model functions.
+
+    The function call is assembled programatically.
+    """
+    from pyrealm.demography import tmodel
+
+    # Get the function from the model
+    func = getattr(tmodel, fname)
+    func_signature = signature(func)
+
+    # Get a dictionary of traits as numpy array
+    all_traits = {
+        k: np.array(v) for k, v in rtmodel_flora.to_pandas().to_dict("list").items()
+    }
+
+    # Reduce the trait arguments to those in the function signature
+    func_args = {k: v for k, v in all_traits.items() if k in func_signature.parameters}
+
+    # Add the size arguments
+    for arg in size_args:
+        func_args[arg] = values
+
+    with outcome as excep:
+        # Call the function with the assembled arguments
+        func(**func_args)
+
+    if excep:
+        assert str(excep.value) == (
+            f"Allometry values in {fname} not strictly positive: {', '.join(size_args)}"
+        )
 
 
 def test_calculate_dbh_from_height_edge_cases():

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -10,6 +10,55 @@ from numpy.testing import assert_allclose
 
 
 @pytest.mark.parametrize(
+    argnames="size_args, outcome, message",
+    argvalues=(
+        pytest.param(
+            {"dbh": np.array([1, 1, 1])}, does_not_raise(), None, id="one var ok"
+        ),
+        pytest.param(
+            {"dbh": np.array([1, 1, 1]), "stem_height": np.array([1, 1, 1])},
+            does_not_raise(),
+            None,
+            id="two vars ok",
+        ),
+        pytest.param(
+            {"dbh": np.array([-1, -1, -1])},
+            pytest.raises(ValueError),
+            "Allometry values in NA not strictly positive: dbh",
+            id="negative",
+        ),
+        pytest.param(
+            {"dbh": np.array([0, 0, 0])},
+            pytest.raises(ValueError),
+            "Allometry values in NA not strictly positive: dbh",
+            id="zero",
+        ),
+        pytest.param(
+            {"dbh": np.array([-1, 0, 1]), "stem_height": np.array([-1, 0, 1])},
+            pytest.raises(ValueError),
+            "Allometry values in NA not strictly positive: dbh, stem_height",
+            id="two vars, both fail",
+        ),
+        pytest.param(
+            {"dbh": np.array([1, 1, 1]), "stem_height": np.array([-1, 0, 1])},
+            pytest.raises(ValueError),
+            "Allometry values in NA not strictly positive: stem_height",
+            id="two vars, one fails",
+        ),
+    ),
+)
+def test_enforce_positive_sizes(size_args, outcome, message):
+    """Test the enforce positive sizes function."""
+    from pyrealm.demography.tmodel import enforce_positive_sizes
+
+    with outcome as excep:
+        enforce_positive_sizes(size_args=size_args, function_name="NA")
+
+    if excep:
+        assert str(excep.value) == message
+
+
+@pytest.mark.parametrize(
     argnames="crown_areas, expected_r0",
     argvalues=(
         (np.array([20, 30]), np.array([[0.86887756, 1.29007041]])),


### PR DESCRIPTION
# Description

> [!Tip]
> OK - this is ready for review now.


Currently, if the DBH ($D$) of a stem is zero, then in the `StemAllometry` class:

* the crown fraction ($f_c$) is NaN, so...
* the sapwood mass (which uses $f_c$) is NaN 

And in the `StemAllocation` class:

* Consequently, sapwood respiration is NaN and as a result NPP and all the delta variables (diameter, mass, foliage) are NaN.

That leads to all sorts of unexpected behaviour. We _could_ make more sensible predictions when $D=0$ - which is what the first iteration of this PR did - but it basically doesn't make sense to make predictions when $D=0$.  That's actually a bit more work because we currently allow zero so this PR:

* Adds a new `_enforce_positive_sizes` helper function to `pyrealm.demography.tmodel` 
* Calls that function from within _nearly_ all of the validation sections of the T model functions. We don't call it on the reproductive mass functions because that is an experimental extension that we want to be able to set to zero.
* Add tests that zero and negative values are caught correctly.
* Updates tests to pass

The PR also: 

* Makes it a ValueError to create `StemAllometry` or `Cohorts` with negative DBH - this guarantees positive sizes and allows the per function validation to be skipped.
* Makes `Cohorts.dbh_values` a property raises ValueError when set with negative DBH values.



Fixes #524 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
