### PR TITLE
Add array inputs page to documentation

### DIFF
--- a/docs/source/_toc.yml
+++ b/docs/source/_toc.yml
@@ -5,6 +5,7 @@ subtrees:
 - caption: Users
   entries:
   - file: users/getting_started.md  
+  - file: users/array_inputs.md
   - file: users/pmodel/module_overview.md
     subtrees:
       - entries:

--- a/docs/source/users/array_inputs.md
+++ b/docs/source/users/array_inputs.md
@@ -23,25 +23,74 @@ language_info:
 
 # Using arrays in `pyrealm`
 
-Many functions in `pyrealm` accept array inputs. Unless stated in their descriptions
-these must be follow the rules below.
+Most of the functionality in `pyrealm` is designed to work with data arrays that can
+have multiple dimensions. The input data can be single scalar values - representing a
+point estimate - or multi-dimensional inputs - such as a time-series on a spatial grid.
+When inputs have multiple dimensions, these can be thought of as **axes**: a 3D array
+might have a time axis, an X axis and a Y axis. The **shape** of an array is then just
+the number of observations along each axis
 
-Array inputs can be either NumPy arrays or scalar values. Arrays of shape `(1,)` are
-also treated as scalar values. Multidimensional arrays are allowed, but they must have
-compatible shapes.
+If all of the inputs vary over all of the axes, then the input data all will need to
+have the same shape. However if one of the inputs is constant along one of the axes then
+that data can be repeated across the other axes. As an example, a function might need
+the following two inputs:
+
+* The temperature, which is a 5 x 5 spatial grid on a time series with five
+  observations and therefore has the shape `(5, 5, 5)`.
+* The elevation, which uses the same 5 x 5 spatial grid but is constant with time and so
+  has the shape `(5, 5)`
+
+Any calculation with these inputs has a problem: which two axes in the temperature data
+does the elevation map onto? In earlier versions of `pyrealm` (<=`1.0.0`), users were
+required to manually make all inputs the same shape by repeating data along axes.
+However, from `pyrealm 2.0.0`, users just need to make sure that inputs have compatible
+shapes, as described below.
+
+Note that **scalar inputs** (a single value) are a special case and are automatically
+assumed to be constant across all the other inputs
 
 ## Array shapes
 
-NumPy array inputs must be mutually broadcastable and have the same number of
-dimensions. For example, two arrays with shapes `(3, 5)` and `(1, 5)` are acceptable
-because the second array is assumed to be constant along the first dimension. However
-arrays with shapes `(3, 5)` and `(5,)` are incompatible because the number of dimensions
-is not the same.
+In `pyrealm`, we make use of the [array broadcasting
+rules](https://numpy.org/doc/stable/user/basics.broadcasting.html) of the `numpy`
+package. All array inputs to a `pyrealm` function then must be **mutually
+broadcastable**. It is worth reading that link but, in summary, the arrays must:
 
-In the following example most of the arguments to
-{class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` are 2-dimensional in time
-and position. But the pressure 1-dimensional --- constant in time. Therefore, the time
-axis is added before passing it to
+* have the same number of dimensions, and
+* have the same shape in each dimension or only a single observation in that dimension.
+
+Some examples:
+
+❌ Two arrays with shapes `(3, 5)` and `(5,)` are not compatible because the
+first array has two dimensions and the second only has a single dimension.
+
+❌ Two arrays with shapes `(3, 5)` and `(5, 3)` are not compatible. They are both
+two-dimensional but have different sizes along the two axes.
+
+✅ Two arrays with shapes `(3, 5)` and `(3, 5)` are compatible. They have the same
+number of dimensions and the same shape.
+
+✅ Two arrays with shapes `(3, 5)` and `(1, 5)` are also compatible. They are both 2
+dimensional and the first axis in the second array has a single observation and so can
+be broadcast across the three observations in the first array.
+
+✅ Using the earlier example with temperature and precipitation, if the order of the
+dimensions on the temperature array is `(x, y, time)`, then the shape of
+elevation should be set to be `(5, 5, 1)`. That final singleton dimension then give an
+unambiguous relationship between the two inputs.
+
+```{caution}
+If you are used to using [the R language](https://www.r-project.org/), note that `numpy`
+does not "recycle" values in the same way. R generally recycles shorter dimensions of
+any length to match longer dimensions but `numpy` does not do this: values are only
+"recycled" by broadcasting when there is a **single** observation on a dimension. If you
+wanted to repeat pairs of values along a dimension, then you will need to do so manually.
+```
+
+As an example of how to do this in practice, in the following example most of the
+arguments to {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` are
+2-dimensional in time and position. But the pressure 1-dimensional --- constant in time.
+Therefore, the time axis is added before passing it to
 {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`.
 
 ```{code-cell} ipython3
@@ -63,6 +112,10 @@ patm = np.full(n_position, 101325)
 
 # Declare a new axis to make it 2D with shape (1, n_position)
 patm = patm[np.newaxis, :]
+
+# Show the shapes for comparison
+print(temp.shape)
+print(patm.shape)
 
 # Call PModelEnvironment with all the inputs
 env = PModelEnvironment(tc=temp, co2=co2, patm=patm, vpd=vpd, fapar=fapar, ppfd=ppfd)

--- a/docs/source/users/array_inputs.md
+++ b/docs/source/users/array_inputs.md
@@ -28,17 +28,17 @@ have multiple dimensions. The input data can be single scalar values - represent
 point estimate - or multi-dimensional inputs - such as a time-series on a spatial grid.
 When inputs have multiple dimensions, these can be thought of as **axes**: a 3D array
 might have a time axis, an X axis and a Y axis. The **shape** of an array is then just
-the number of observations along each axis
+the number of observations along each axis.
 
 If all of the inputs vary over all of the axes, then the input data all will need to
 have the same shape. However if one of the inputs is constant along one of the axes then
-that data can be repeated across the other axes. As an example, a function might need
-the following two inputs:
+its shape only needs to match the other inputs along the axes that it varies over. As
+an example, a function might need the following two inputs:
 
 * The temperature, which is a 5 x 5 spatial grid on a time series with five
   observations and therefore has the shape `(5, 5, 5)`.
 * The elevation, which uses the same 5 x 5 spatial grid but is constant with time and so
-  has the shape `(5, 5)`
+  has the shape `(5, 5)`.
 
 Any calculation with these inputs has a problem: which two axes in the temperature data
 does the elevation map onto? In earlier versions of `pyrealm` (<=`1.0.0`), users were
@@ -47,14 +47,15 @@ However, from `pyrealm 2.0.0`, users just need to make sure that inputs have com
 shapes, as described below.
 
 Note that **scalar inputs** (a single value) are a special case and are automatically
-assumed to be constant across all the other inputs
+assumed to be constant across all the other inputs.
 
 ## Array shapes
 
 In `pyrealm`, we make use of the [array broadcasting
 rules](https://numpy.org/doc/stable/user/basics.broadcasting.html) of the `numpy`
-package. All array inputs to a `pyrealm` function then must be **mutually
-broadcastable**. It is worth reading that link but, in summary, the arrays must:
+package, with an additional restriction on the number of dimensions. It is worth reading
+that link but, in summary, all array inputs to a `pyrealm` function must be **mutually
+broadcastable** by satisfying the following rules:
 
 * have the same number of dimensions, and
 * have the same shape in each dimension or only a single observation in that dimension.
@@ -89,7 +90,7 @@ wanted to repeat pairs of values along a dimension, then you will need to do so 
 
 As an example of how to do this in practice, in the following example most of the
 arguments to {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` are
-2-dimensional in time and position. But the pressure 1-dimensional --- constant in time.
+2-dimensional in time and position. But the pressure is 1-dimensional --- constant in time.
 Therefore, the time axis is added before passing it to
 {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`.
 
@@ -114,8 +115,8 @@ patm = np.full(n_position, 101325)
 patm = patm[np.newaxis, :]
 
 # Show the shapes for comparison
-print(temp.shape)
-print(patm.shape)
+print("temp shape:", temp.shape)
+print("patm shape:", patm.shape)
 
 # Call PModelEnvironment with all the inputs
 env = PModelEnvironment(tc=temp, co2=co2, patm=patm, vpd=vpd, fapar=fapar, ppfd=ppfd)

--- a/docs/source/users/array_inputs.md
+++ b/docs/source/users/array_inputs.md
@@ -1,0 +1,69 @@
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+language_info:
+  codemirror_mode:
+    name: ipython
+    version: 3
+  file_extension: .py
+  mimetype: text/x-python
+  name: python
+  nbconvert_exporter: python
+  pygments_lexer: ipython3
+  version: 3.11.9
+---
+
+# Using arrays in `pyrealm`
+
+Many functions in `pyrealm` accept array inputs. Unless stated in their descriptions
+these must be follow the rules below.
+
+Array inputs can be either NumPy arrays or scalar values. Arrays of shape `(1,)` are
+also treated as scalar values. Multidimensional arrays are allowed, but they must have
+compatible shapes.
+
+## Array shapes
+
+NumPy array inputs must be mutually broadcastable and have the same number of
+dimensions. For example, two arrays with shapes `(3, 5)` and `(1, 5)` are acceptable
+because the second array is assumed to be constant along the first dimension. However
+arrays with shapes `(3, 5)` and `(5,)` are incompatible because the number of dimensions
+is not the same.
+
+In the following example most of the arguments to
+{class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` are 2-dimensional in time
+and position. But the pressure 1-dimensional --- constant in time. Therefore, the time
+axis is added before passing it to
+{class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment`.
+
+```{code-cell} ipython3
+import numpy as np
+from pyrealm.pmodel.pmodel_environment import PModelEnvironment
+
+n_time = 10
+n_position = 100
+
+# 2D arrays in time and position (a single dummy value is used)
+temp = np.full((n_time, n_position), 20)
+co2 = np.full((n_time, n_position), 400)
+vpd = np.full((n_time, n_position), 1000)
+fapar = np.full((n_time, n_position), 1)
+ppfd = np.full((n_time, n_position), 800)
+
+# 1D array in position - constant in time
+patm = np.full(n_position, 101325)
+
+# Declare a new axis to make it 2D with shape (1, n_position)
+patm = patm[np.newaxis, :]
+
+# Call PModelEnvironment with all the inputs
+env = PModelEnvironment(tc=temp, co2=co2, patm=patm, vpd=vpd, fapar=fapar, ppfd=ppfd)
+```

--- a/docs/source/users/getting_started.md
+++ b/docs/source/users/getting_started.md
@@ -57,32 +57,29 @@ shows you how to install `pip`.
 
 ## Installing `pyrealm`
 
-When the above prerequisites are fulfilled, you can simply install `pyrealm` by
-typing the command `pip install pyrealm` into the command line. This will, at
-this point in time, install pyrealm version 1.0.0. If a different version is
-required, this can be specified in the command, e.g.:
-`pip install pyrealm==2.0.0`.
+When the above prerequisites are fulfilled, you can simply install `pyrealm` by typing
+the command `pip install pyrealm` into the command line. This will, at this point in
+time, install pyrealm version 1.0.0. If a different version is required, this can be
+specified in the command, e.g.: `pip install pyrealm==2.0.0`.
 
-However, it is good practice to use a virtual environment for this, to not
-pollute your python environment with packages and versions you might not need
-for other work. Detailed information on how to do this can be found on the
-[Python Packaging User Guide](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
-In short, install `virtualenv`: `pip install virtualenv`, and
-then you can create a virtual environment typing `python3 -m venv .venv`
-(or `py -m venv .venv` on Windows) and activate it with
-`source .venv/bin/activate` (`.venv\Scripts\activate` on Windows). Then do
-`pip install pyrealm` and install everything else you might want to use. When
-you are done with your `pyrealm` work just type `deactivate`. You can
-re-activate and alter your environment anytime once it is set up.
+However, it is good practice to use a virtual environment for this, to not pollute your
+python environment with packages and versions you might not need for other work.
+Detailed information on how to do this can be found on the [Python Packaging User
+Guide](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/).
+In short, install `virtualenv`: `pip install virtualenv`, and then you can create a
+virtual environment typing `python3 -m venv .venv` (or `py -m venv .venv` on Windows)
+and activate it with `source .venv/bin/activate` (`.venv\Scripts\activate` on Windows).
+Then do `pip install pyrealm` and install everything else you might want to use. When
+you are done with your `pyrealm` work just type `deactivate`. You can re-activate and
+alter your environment anytime once it is set up.
 
 ## Running the worked examples
 
-The easiest way to get started with using `pyrealm` is going through the worked
-examples in this documentation.
-Each example can be run in a [jupyter notebook](https://jupyter.org/). For this,
-it can be opened using a jupyter hub cloud service such as
-[Google Colab](https://colab.research.google.com/) or a locally hosted jupyter
-hub. It is also straightforward to install and run it locally on your machine
+The easiest way to get started with using `pyrealm` is going through the worked examples
+in this documentation. Each example can be run in a [jupyter
+notebook](https://jupyter.org/). For this, it can be opened using a jupyter hub cloud
+service such as [Google Colab](https://colab.research.google.com/) or a locally hosted
+jupyter hub. It is also straightforward to install and run it locally on your machine
 following these steps:
 
 - Install [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) by running
@@ -93,16 +90,18 @@ jupyter notebooks are located.
 [JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/user/interface.html)
 for a detailed description of the user interface.
 
-There are a number of Python packages which are necessary for running the
-examples, namely `wget` to download example data (note that this is different
-in the jupyter notebooks from the worked examples in the documentation, which
-access the data directly from the github repository without downloading it
-separately), `matplotlib`, for plotting, `xarray` as a data structure for
-handling the data and `netCDF4` as file format in which the example data is
-stored.
+There are a number of Python packages which are necessary for running the examples,
+namely `wget` to download example data (note that this is different in the jupyter
+notebooks from the worked examples in the documentation, which access the data directly
+from the github repository without downloading it separately), `matplotlib`, for
+plotting, `xarray` as a data structure for handling the data and `netCDF4` as file
+format in which the example data is stored.
 
-The following code block (run from the `jupyter_notebooks` directory of
-  `pyrealm`) sets everything up for running the notebooks on Linux:
+The `pyrealm` package is also designed to work with multi-dimensional inputs to support
+efficient calculations - please review the overview of [array inputs](./array_inputs.md).
+
+The following code block (run from the `jupyter_notebooks` directory of `pyrealm`) sets
+  everything up for running the notebooks on Linux:
 
 ```bash
 pip install virtualenv
@@ -126,8 +125,7 @@ Good notebooks to get started with are
 
 ## `pyrealm` developers
 
-We welcome contributions to improving and extending the `pyrealm` package. The
-code for `pyrealm` can be found
-[on Github](https://github.com/ImperialCollegeLondon/pyrealm/). A guide how to
-develop for `pyrealm` can be found in the
-[`CONTRIBUTING.md` file](https://github.com/ImperialCollegeLondon/pyrealm/blob/develop/CONTRIBUTING.md).
+We welcome contributions to improving and extending the `pyrealm` package. The code for
+`pyrealm` can be found [on Github](https://github.com/ImperialCollegeLondon/pyrealm/). A
+guide how to develop for `pyrealm` can be found in the [`CONTRIBUTING.md`
+file](https://github.com/ImperialCollegeLondon/pyrealm/blob/develop/CONTRIBUTING.md).

--- a/docs/source/users/versions.md
+++ b/docs/source/users/versions.md
@@ -47,6 +47,11 @@ number of breaking changes in the API. As the package uses [semantic
 versioning](https://semver.org/), these changes to the API require that new releases be
 made under a new major version.
 
+One general change is that array inputs are no longer required to have identical shapes.
+This was often an issue when one input was constant over a particular axis - like
+elevation over a time series. Most functionality in `pyrealm` now requires only that
+the shapes of the inputs can be [broadcast to each other](./array_inputs.md).
+
 ```{warning}
 
 We will be publishing a series of "release candidates" of the 2.0.0 package. These will


### PR DESCRIPTION
# Description

Added a page to the users part of the documentation describing the expected format of array inputs.

Fixes #547 

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`
