### PR TITLE
Updating docs to release 2.0.0

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Upload coverage reports to Codecov
       id: codecov
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.10)
+      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.13)
       uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,10 @@
 This document provides a brief overview of the main changes to `pyrealm` at each of the
 released versions. More detail can be found at the GitHub release page for each version.
 
-## 2.0.0 release candidates
+## 2.0.0
 
-A new major release is planned but will iterate through release candidates in order to
-make functionality available for testing while the new functionality and API changes are
-worked through. The changes below are provisional.
+Version 2.0.0 introduces major breaking changes in the structure of some functionality,
+notably the API of the `pmodel` module, as well as introducing new functionality.
 
 - The `PModel` and `SubdailyPModel` classes have been extensively restructured to align
   the attributes and methods and to remove repeated code. Many of these changes are
@@ -118,18 +117,24 @@ worked through. The changes below are provisional.
 - The first components in the experimental `demography` module, providing an integrated
   set of submodules that provide: plant functional types, size-structured cohorts, plant
   communities, a community canopy model and an implementation of the T Model for
-  allocation and growth. Release 2.0.0-rc.3 fixes some details of updating cohort counts
-  when adding or dropping cohorts from a community (#481) and moves calculation of per
-  stem GPP outside of StemAllocation rather than pinning it to use the big leaf
-  approximation (#480). Release 2.0.0-rc.4 replaces the canopy and light capture model,
-  which had been incorrectly implemented.
+  allocation and growth. Release `2.0.0-rc.3` fixed some details of updating cohort
+  counts when adding or dropping cohorts from a community (#481) and moves calculation
+  of per stem GPP outside of StemAllocation rather than pinning it to use the big leaf
+  approximation (#480). Release `2.0.0-rc.4` replaced the canopy and light capture
+  model, which had been incorrectly implemented.
+
+- An initial implementation of the "two leaf, two stream" model of light interception.
+  This is still in experimental form, but provides an extension to the default big-leaf
+  approximation used to model light interception for the P Model.
 
 - The first components of the experimental `phenology` module have been added. The main
-  functionalty as of 2.0.0-rc.4 is the `FaparLimitation` class that calculates annual
+  functionality in version `2.0.0` is the `FaparLimitation` class that calculates annual
   limits to $f_{APAR}$ and $LAI$ based on energy and water limitation of GPP. The module
   includes a new golden dataset in `pyrealm_build_data.phenology`. This module is
   supported by the new `core.time_series.AnnualValueCalculator` class, which is designed
   to calculate annual values over time series data with varying temporal resolution.
+  Later releases will extend this module to implement the calculation of daily
+  predictions of leaf area index and fAPAR from annual limitations and productivity.
 
 - An extension of the Subdaily P Model that allows the initial realised responses to be
   provided rather than assuming that they are equal to the initial optimal responses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ for more details.
 The `pyrealm` package uses the `poetry` tool for package management. Getting a simple
 development environment should involve:
 
-* Installing `python`: `pyrealm` requires `python >3.10` and we currently support
-  versions `python <=3.13`.
+* Installing `python`: `pyrealm` requires `python >3.10` and we currently run continuous
+  testing against versions `python >3.10, <=3.13`.
 * Installing `poetry`: although the `poetry` tool manages the versions of all the
   package requirements, the version of `poetry` itself is not managed. Developers should
   all ensure that they install the **same version of poetry** to avoid version

--- a/README.md
+++ b/README.md
@@ -39,31 +39,28 @@ The `pyrealm` package currently includes:
 For more details, see the package website:
 [https://pyrealm.readthedocs.io/](https://pyrealm.readthedocs.io/).
 
-## Version 2.0.0 development
+## Version overview
 
-New functionality being implemented after version 1.0.0 has lead to some immediate
-breaking changes in the API, for example in the handling of quantum yield settings in
-the class signatures for the `PModel` and `SubdailyPModel`. As the package uses
-[semantic versioning](https://semver.org/), these changes to the API require that new
-releases be made under a new major version.
+The `pyrealm` package uses [semantic versioning](https://semver.org/) and the list below
+summarise the major changes:
 
-We will be publishing a series of "release candidates" of the 2.0.0 package. These will
-be used to identify issues with the current API and try to stabilise a new API. The
-content of version 2.0.0 is not yet finalised, so these release candidates may also add
-new functionality.
+* Version `1.0.0`: initial implementation of the P Model and associated functionality
+* Version `2.0.0`: wide refactor of P Model code to a new API, extension of the package
+  functionality to include the SPLASH v1 model and experimental modules developing
+  functionality for plant demography and phenology.
 
-We recommend that you update to the most recent release candidate of version 2.0.0. The
-documentation now includes a [migration
+We **strongly** recommend that you update to version `2.0.0`. The documentation
+includes a [migration
 guide](https://pyrealm.readthedocs.io/en/develop/users/versions.html) to help update
-existing code.
+existing code using version `1.0.0`.
 
 ## Using `pyrealm`
 
-The `pyrealm` package requires Python 3 and the currently supported Python versions are:
-3.10, 3.11 and 3.12. We make released package versions available via
-[PyPi](https://pypi.org/project/pyrealm/) and also generate DOIs for each release via
-[Zenodo](https://doi.org/10.5281/zenodo.8366847). You can install the most recent
-release using `pip`:
+The `pyrealm` package requires Python 3.11 or greater and we currently test all
+`pyrealm` code using Python 3.11, 3.12 and 3.13. We make released package versions
+available via [PyPi](https://pypi.org/project/pyrealm/) and also generate DOIs for each
+release via [Zenodo](https://doi.org/10.5281/zenodo.8366847). You can install the most
+recent release using `pip`:
 
 ```sh
 pip install pyrealm

--- a/docs/source/_static/Splash.ipynb
+++ b/docs/source/_static/Splash.ipynb
@@ -186,12 +186,12 @@
     "the solar and evaporative calculations for the time series - none of these calculations\n",
     "rely on the soil moisture and so are calculated once when the `SplashModel` is created.\n",
     "\n",
-    "### Note\n",
-    "The `SplashModel` code currently requires that the latitude (`lat`) and elevation\n",
-    "(`elv`) data have the same shape as the sunshine fraction (`sf`), temperature (`tc`) and\n",
-    "precipitation (`pn`). These values are obviously constant through time - and latitude\n",
-    "may well be constant across the longitude dimension for gridded data - but, at the\n",
-    "moment, you need to broadcast these variables to match."
+    "The data for the sunshine fraction (`sf`), temperature (`tc`) and precipitation (`pn`)\n",
+    "are three dimensional arrays providing values along time, latitude and longitude axes.\n",
+    "The latitude (`lat`) values obviously only add coordinates along the latitude axis and\n",
+    "the elevation (`elv`) is constant through time. So before the model can be fitted, we\n",
+    "need to make these arrays compatible (see the [array inputs](../array_inputs.md)\n",
+    "documentation) by making them use the same dimensions.\n"
    ]
   },
   {
@@ -201,13 +201,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Convert latitude from (Y) to (1, Y, 1)\n",
+    "lat = data.lat.to_numpy()[np.newaxis, :, np.newaxis]\n",
+    "# Convert elevation from (Y, X) to (1, Y, X)\n",
+    "elv = data.elev.to_numpy()[np.newaxis, :, :]\n",
+    "\n",
+    "# Fit the model\n",
     "splash = SplashModel(\n",
-    "    lat=np.broadcast_to(data.lat.data[None, :, None], data.sf.data.shape),\n",
-    "    elv=np.broadcast_to(data.elev.data[None, :, :], data.sf.data.shape),\n",
-    "    dates=Calendar(data.time.data),\n",
-    "    sf=data.sf.data,\n",
-    "    tc=data.tmp.data,\n",
-    "    pn=data.pre.data,\n",
+    "    lat=lat,\n",
+    "    elv=elv,\n",
+    "    dates=Calendar(data.time.to_numpy()),\n",
+    "    sf=data.sf.to_numpy(),\n",
+    "    tc=data.tmp.to_numpy(),\n",
+    "    pn=data.pre.to_numpy(),\n",
     ")"
    ]
   },
@@ -375,7 +381,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/source/_static/TModel.ipynb
+++ b/docs/source/_static/TModel.ipynb
@@ -311,7 +311,7 @@
    "outputs": [],
    "source": [
     "# Calculate the stem GPP from potential GPP following the Li et al model\n",
-    "potential_gpp = np.repeat(5, dbh_col.size)[:, None]\n",
+    "potential_gpp = np.full((dbh_col.size, 1), fill_value=5)\n",
     "\n",
     "whole_crown_gpp = calculate_whole_crown_gpp(\n",
     "    potential_gpp=potential_gpp,\n",
@@ -379,7 +379,7 @@
    "outputs": [],
    "source": [
     "# Column array of identical DBH values\n",
-    "dbh_constant = np.repeat(0.2, 50)[:, None]\n",
+    "dbh_constant = np.full((50, 1), fill_value=0.2)\n",
     "\n",
     "# Get the allometric predictions for those stems\n",
     "constant_allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_constant)\n",

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -193,7 +193,7 @@ potential GPP:
 
 ```{code-cell} ipython3
 # Calculate the stem GPP from potential GPP following the Li et al model
-potential_gpp = np.repeat(5, dbh_col.size)[:, None]
+potential_gpp = np.full((dbh_col.size, 1), fill_value=5)
 
 whole_crown_gpp = calculate_whole_crown_gpp(
     potential_gpp=potential_gpp,
@@ -243,7 +243,7 @@ for constant allometries:
 
 ```{code-cell} ipython3
 # Column array of identical DBH values
-dbh_constant = np.repeat(0.2, 50)[:, None]
+dbh_constant = np.full((50, 1), fill_value=0.2)
 
 # Get the allometric predictions for those stems
 constant_allometries = StemAllometry(stem_traits=flora, at_dbh=dbh_constant)

--- a/docs/source/users/splash.md
+++ b/docs/source/users/splash.md
@@ -160,7 +160,7 @@ The data for the sunshine fraction (`sf`), temperature (`tc`) and precipitation 
 are three dimensional arrays providing values along time, latitude and longitude axes.
 The latitude (`lat`) values obviously only add coordinates along the latitude axis and
 the elevation (`elv`) is constant through time. So before the model can be fitted, we
-need to make these arrays compatible (see the [array inputs](../array_inputs.md)
+need to make these arrays compatible (see the [array inputs](../users/array_inputs.md)
 documentation) by making them use the same dimensions.
 
 ```{code-cell} ipython3

--- a/docs/source/users/splash.md
+++ b/docs/source/users/splash.md
@@ -6,19 +6,19 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: Python 3
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 language_info:
+  name: python
+  version: 3.12.3
+  mimetype: text/x-python
   codemirror_mode:
     name: ipython
     version: 3
-  file_extension: .py
-  mimetype: text/x-python
-  name: python
-  nbconvert_exporter: python
   pygments_lexer: ipython3
-  version: 3.11.9
+  nbconvert_exporter: python
+  file_extension: .py
 ---
 
 # The `splash` submodule
@@ -156,22 +156,27 @@ Before calculating water balances, you need to create a
 the solar and evaporative calculations for the time series - none of these calculations
 rely on the soil moisture and so are calculated once when the `SplashModel` is created.
 
-```{note}
-The `SplashModel` code currently requires that the latitude (`lat`) and elevation
-(`elv`) data have the same shape as the sunshine fraction (`sf`), temperature (`tc`) and
-precipitation (`pn`). These values are obviously constant through time - and latitude
-may well be constant across the longitude dimension for gridded data - but, at the
-moment, you need to broadcast these variables to match.
-```
+The data for the sunshine fraction (`sf`), temperature (`tc`) and precipitation (`pn`)
+are three dimensional arrays providing values along time, latitude and longitude axes.
+The latitude (`lat`) values obviously only add coordinates along the latitude axis and
+the elevation (`elv`) is constant through time. So before the model can be fitted, we
+need to make these arrays compatible (see the [array inputs](../array_inputs.md)
+documentation) by making them use the same dimensions.
 
 ```{code-cell} ipython3
+# Convert latitude from (Y) to (1, Y, 1)
+lat = data.lat.to_numpy()[np.newaxis, :, np.newaxis]
+# Convert elevation from (Y, X) to (1, Y, X)
+elv = data.elev.to_numpy()[np.newaxis, :, :]
+
+# Fit the model
 splash = SplashModel(
-    lat=np.broadcast_to(data.lat.data[None, :, None], data.sf.data.shape),
-    elv=np.broadcast_to(data.elev.data[None, :, :], data.sf.data.shape),
-    dates=Calendar(data.time.data),
-    sf=data.sf.data,
-    tc=data.tmp.data,
-    pn=data.pre.data,
+    lat=lat,
+    elv=elv,
+    dates=Calendar(data.time.to_numpy()),
+    sf=data.sf.to_numpy(),
+    tc=data.tmp.to_numpy(),
+    pn=data.pre.to_numpy(),
 )
 ```
 

--- a/docs/source/users/versions.md
+++ b/docs/source/users/versions.md
@@ -44,17 +44,8 @@ So, version 2.0.0 provides a complete reworking of the package, with a particula
 on better integrating the  {class}`~pyrealm.pmodel.pmodel.PModel` and
 {class}`~pyrealm.pmodel.pmodel.SubdailyPModel` classes. This has led to a large
 number of breaking changes in the API. As the package uses [semantic
-versioning](https://semver.org/), these changes to the API require that new releases be
-made under a new major version.
-
-```{warning}
-
-We will be publishing a series of "release candidates" of the 2.0.0 package. These will
-be used to identify issues with the current API and try to stabilise a new API. The
-content of version 2.0.0 is not yet finalised, so these release candidates may also add
-new functionality.
-
-```
+versioning](https://semver.org/), these changes to the API required that we move to
+`pyrealm 2.0.0`.
 
 The main user facing changes are shown below, but do also look at the [log of
 changes](#changes-log) for more detail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 description = "Python tools for modelling plant productivity and demography."
 license = "MIT"
 name = "pyrealm"
-version = "2.0.0-rc.5"
+version = "2.0.0"
 
 dependencies = [
   "dacite (>1.6.0)",

--- a/tests/profiling/splash/conftest.py
+++ b/tests/profiling/splash/conftest.py
@@ -47,8 +47,8 @@ def splash_profile_data(pytestconfig):
     pn = _scale_up(data.pre.to_numpy(), scaling_factor=scaling_factor)
 
     elv = np.tile(data.elev.to_numpy(), (1, scaling_factor))
-    elv = np.broadcast_to(elv[None, :, :], sf.shape)
-    lat = np.broadcast_to(data.lat.to_numpy()[None, :, None], sf.shape)
+    elv = elv[None, :, :]
+    lat = data.lat.to_numpy()[None, :, None]
 
     dates = Calendar(data.time.data)
 

--- a/tests/regression/splash/test_daily_solar.py
+++ b/tests/regression/splash/test_daily_solar.py
@@ -129,16 +129,16 @@ def test_solar_array_grid(grid_benchmarks):
 
     cal = Calendar(inputs.time.values.astype("datetime64[D]"))
 
-    # Duplicate lat and elev to same shape as sf and tc (TODO - avoid this!)
-    elev = np.broadcast_to(inputs.elev.data[None, :, :], inputs.sf.data.shape)
-    lat = np.broadcast_to(inputs.lat.data[None, :, None], inputs.sf.data.shape)
+    # Make lat and elev broadcastable to sf and tc
+    lat = inputs.lat.to_numpy()[None, :, None]
+    elev = inputs.elev.to_numpy()[None, :, :]
 
     solar = DailySolarFluxes(
         latitude=lat,
         elevation=elev,
         dates=cal,
-        sunshine_fraction=inputs["sf"].data,
-        temperature=inputs["tmp"].data,
+        sunshine_fraction=inputs["sf"].to_numpy(),
+        temperature=inputs["tmp"].to_numpy(),
     )
 
     # Test that the resulting solar calculations are the same.

--- a/tests/regression/splash/test_evap.py
+++ b/tests/regression/splash/test_evap.py
@@ -160,16 +160,16 @@ def test_evap_array_grid(splash_core_constants, grid_benchmarks, expected_attr):
 
     cal = Calendar(inputs.time.values.astype("datetime64[D]"))
 
-    # Duplicate lat and elev to same shape as sf and tc (TODO - avoid this!)
-    lat = np.broadcast_to(inputs.lat.data[None, :, None], inputs.sf.data.shape)
-    elev = np.broadcast_to(inputs.elev.data[None, :, :], inputs.sf.data.shape)
+    # Make lat and elev broadcastable to sf and tc
+    lat = inputs.lat.to_numpy()[None, :, None]
+    elev = inputs.elev.to_numpy()[None, :, :]
 
     solar = DailySolarFluxes(
         latitude=lat,
         elevation=elev,
         dates=cal,
-        sunshine_fraction=inputs["sf"].data,
-        temperature=inputs["tmp"].data,
+        sunshine_fraction=inputs["sf"].to_numpy(),
+        temperature=inputs["tmp"].to_numpy(),
         core_const=splash_core_constants,
     )
 

--- a/tests/regression/splash/test_splash.py
+++ b/tests/regression/splash/test_splash.py
@@ -8,8 +8,6 @@
   series.
 """
 
-from itertools import product
-
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -125,15 +123,15 @@ def test_run_spin_up_oned(splash_core_constants, one_d_benchmark):
     inputs, expected = one_d_benchmark
 
     # Need to reshape the inputs so they have a time and 1 observation axis and
-    # duplicate lat and elev to same shape as sf, tc, pc (TODO - avoid this!)
+    # duplicate lat and elev to same shape as sf, tc, pc
 
     splash = SplashModel(
-        lat=np.broadcast_to(inputs.lat.data, inputs.sf.shape),
-        elv=np.broadcast_to(inputs.elev.data, inputs.sf.shape),
-        dates=Calendar(inputs.time.data),
-        sf=inputs.sf.data,
-        tc=inputs.tmp.data,
-        pn=inputs.pre.data,
+        lat=inputs.lat.to_numpy()[None, :, None],
+        elv=inputs.elev.to_numpy()[None, :, :],
+        dates=Calendar(inputs.time.to_numpy()),
+        sf=inputs.sf.to_numpy(),
+        tc=inputs.tmp.to_numpy(),
+        pn=inputs.pre.to_numpy(),
         core_const=splash_core_constants,
     )
 
@@ -141,48 +139,6 @@ def test_run_spin_up_oned(splash_core_constants, one_d_benchmark):
 
     # Check against the spun up value from the original implementation
     assert_allclose(wn, expected["wn_spun_up"])
-
-
-def test_run_spin_up_iter(splash_core_constants, grid_benchmarks):
-    """Test the spin up process using the grid.
-
-    This test iterates over cells, following the cell by cell calculation in the
-    original implementation.
-
-    This is a slow test.
-    """
-
-    from pyrealm.core.calendar import Calendar
-    from pyrealm.splash.splash import SplashModel
-
-    inputs, expected = grid_benchmarks
-
-    cal = Calendar(inputs.time.data)
-
-    for lat, lon in product(inputs.lat.data, inputs.lon.data):
-        # Subset Dataset to cell - note use of singleton lists to preserve the resulting
-        # singleton lat and lon dimensions
-        cell_inputs = inputs.sel(lat=[lat], lon=[lon])
-        cell_expected = expected.sel(lat=[lat], lon=[lon])
-
-        # Test for sea cells (elevation is nan) and skip
-        if np.isnan(cell_inputs.elev.data[0]):
-            continue
-
-        splash = SplashModel(
-            lat=np.broadcast_to(cell_inputs.lat.data, cell_inputs.sf.shape),
-            elv=np.broadcast_to(cell_inputs.elev.data, cell_inputs.sf.shape),
-            dates=cal,
-            sf=cell_inputs.sf.data,
-            tc=cell_inputs.tmp.data,
-            pn=cell_inputs.pre.data,
-            core_const=splash_core_constants,
-        )
-
-        wn = splash.estimate_initial_soil_moisture()
-
-        # Check against the spun up value from the original implementation
-        assert_allclose(wn, cell_expected.wn_spun_up, rtol=1e-6)
 
 
 def test_run_spin_up_gridded(splash_core_constants, grid_benchmarks):
@@ -194,12 +150,12 @@ def test_run_spin_up_gridded(splash_core_constants, grid_benchmarks):
     inputs, expected = grid_benchmarks
 
     splash = SplashModel(
-        lat=np.broadcast_to(inputs.lat.data[None, :, None], inputs.sf.data.shape),
-        elv=np.broadcast_to(inputs.elev.data[None, :, :], inputs.sf.data.shape),
-        dates=Calendar(inputs.time.data),
-        sf=inputs.sf.data,
-        tc=inputs.tmp.data,
-        pn=inputs.pre.data,
+        lat=inputs.lat.to_numpy()[None, :, None],
+        elv=inputs.elev.to_numpy()[None, :, :],
+        dates=Calendar(inputs.time.to_numpy()),
+        sf=inputs.sf.to_numpy(),
+        tc=inputs.tmp.to_numpy(),
+        pn=inputs.pre.to_numpy(),
         core_const=splash_core_constants,
     )
 
@@ -226,13 +182,13 @@ def test_calculate_soil_moisture_oned(splash_core_constants, one_d_benchmark):
     # Need to reshape the inputs so they have a time and 1 observation axis and
     # duplicate lat and elev to same shape as sf, tc, pc (TODO - avoid this!)
 
-    splash = SplashModel(
-        lat=np.broadcast_to(inputs.lat.data, inputs.sf.shape),
-        elv=np.broadcast_to(inputs.elev.data, inputs.sf.shape),
-        dates=Calendar(inputs.time.data),
-        sf=inputs.sf.data,
-        tc=inputs.tmp.data,
-        pn=inputs.pre.data,
+    splash = splash = SplashModel(
+        lat=inputs.lat.to_numpy()[None, :, None],
+        elv=inputs.elev.to_numpy()[None, :, :],
+        dates=Calendar(inputs.time.to_numpy()),
+        sf=inputs.sf.to_numpy(),
+        tc=inputs.tmp.to_numpy(),
+        pn=inputs.pre.to_numpy(),
         core_const=splash_core_constants,
     )
 
@@ -263,12 +219,12 @@ def test_calculate_soil_moisture_grid(splash_core_constants, grid_benchmarks):
     # duplicate lat and elev to same shape as sf, tc, pc (TODO - avoid this!)
 
     splash = SplashModel(
-        lat=np.broadcast_to(inputs.lat.data[None, :, None], inputs.sf.data.shape),
-        elv=np.broadcast_to(inputs.elev.data[None, :, :], inputs.sf.data.shape),
-        dates=Calendar(inputs.time.data),
-        sf=inputs.sf.data,
-        tc=inputs.tmp.data,
-        pn=inputs.pre.data,
+        lat=inputs.lat.to_numpy()[None, :, None],
+        elv=inputs.elev.to_numpy()[None, :, :],
+        dates=Calendar(inputs.time.to_numpy()),
+        sf=inputs.sf.to_numpy(),
+        tc=inputs.tmp.to_numpy(),
+        pn=inputs.pre.to_numpy(),
         core_const=splash_core_constants,
     )
 

--- a/tests/unit/splash/test_splash_model.py
+++ b/tests/unit/splash/test_splash_model.py
@@ -20,7 +20,7 @@ def calendar(request, grid_benchmarks):
     """Provide the dates with a random start date."""
     from pyrealm.core.calendar import Calendar
 
-    dates = grid_benchmarks[0].time.data
+    dates = grid_benchmarks[0].time.to_numpy()
     start, end = request.param
     yield Calendar(dates[start:end])
 
@@ -44,7 +44,7 @@ def test_splash_model_init(splash_core_constants, grid_benchmarks, var, flag):
     )
 
     ds = grid_benchmarks[0].sel(time=slice("2000-01-01", "2000-04-01")).copy()
-    dates = ds.time.data
+    dates = ds.time.to_numpy()
 
     # ensure raising error if calendar size is more or less than timestamps
     if var == "dates":
@@ -56,7 +56,7 @@ def test_splash_model_init(splash_core_constants, grid_benchmarks, var, flag):
     # ensure warning if variable is out of bounds
     else:
         vmin, vmax = bounds[var]
-        arr = ds[var].data
+        arr = ds[var].to_numpy()
         if flag < 0:  # out of lower bound
             arr.flat[np.random.choice(arr.size)] = vmin - 1e-4
         else:  # out of upper bound
@@ -64,14 +64,19 @@ def test_splash_model_init(splash_core_constants, grid_benchmarks, var, flag):
         context = pytest.warns(UserWarning)
 
     with context:
+        # Convert latitude from (Y) to (1, Y, 1)
+        lat = ds.lat.to_numpy()[np.newaxis, :, np.newaxis]
+        # Convert elevation from (Y, X) to (1, Y, X)
+        elv = ds.elev.to_numpy()[np.newaxis, :, :]
+
+        # Fit the model
         SplashModel(
-            lat=np.broadcast_to(ds.lat.data[None, :, None], ds.sf.data.shape),
-            elv=np.broadcast_to(ds.elev.data[None, :, :], ds.sf.data.shape),
+            lat=lat,
+            elv=elv,
             dates=Calendar(dates),
-            sf=ds.sf.data,
-            tc=ds.tmp.data,
-            pn=ds.pre.data,
-            core_const=splash_core_constants,
+            sf=ds.sf.to_numpy(),
+            tc=ds.tmp.to_numpy(),
+            pn=ds.pre.to_numpy(),
         )
 
 
@@ -84,12 +89,12 @@ def splash_model(grid_benchmarks, splash_core_constants, calendar):
     ds = grid_benchmarks[0].sel(time=calendar.dates)
 
     splash = SplashModel(
-        lat=np.broadcast_to(ds.lat.data[None, :, None], ds.sf.data.shape),
-        elv=np.broadcast_to(ds.elev.data[None, :, :], ds.sf.data.shape),
+        lat=ds.lat.to_numpy()[None, :, None],
+        elv=ds.elev.to_numpy()[None, :, :],
         dates=calendar,
-        sf=ds.sf.data,
-        tc=ds.tmp.data,
-        pn=ds.pre.data,
+        sf=ds.sf.to_numpy(),
+        tc=ds.tmp.to_numpy(),
+        pn=ds.pre.to_numpy(),
         core_const=splash_core_constants,
     )
 


### PR DESCRIPTION
# Description

This PR is to update the docs to be ready for 2.0.0.

* Removing references to the "upcoming 2.0.0" release and removing the "2.0.0-rc" and "release candidates" terminology
* Updating supported python versions in a few places.
* Removing usage of user-broadcasting of arrays in docs (#542)
    * Switches some `np.repeat(v, N)[:, None]` for `np.full((N, 1), v)` - clearer.
* Removing broadcasting to same shape in testing.
* Removes an excessively paranoid test that ran particularly slowly: `test_run_spin_up_iter` was identical to `test_run_spin_up_grid` in what it tested but did so grid cell by grid cell. This test was largely used in developing `SplashModel` - the original implementation ran cell by cell, not in parallel - and doesn't really add anything to the test suite beyond `test_run_spin_up_grid` and slows it down.

Fixes #542

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
