### PR TITLE
Broken QA on `maintenance/1.x` branch

### DIFF
--- a/.github/workflows/pyrealm_ci.yaml
+++ b/.github/workflows/pyrealm_ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   test:
     needs: qa
@@ -38,7 +38,7 @@ jobs:
     - name: Install Poetry
       uses: abatilo/actions-poetry@v2.1.6
       with:
-        poetry-version: 1.2.2
+        poetry-version: 2.0.1
 
     - name: Install dependencies
       run: poetry install
@@ -66,7 +66,7 @@ jobs:
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.1.6
         with:
-          poetry-version: 1.2.2
+          poetry-version: 2.0.1
 
       - name: Install dependencies
         run: poetry install
@@ -78,7 +78,7 @@ jobs:
 
       - name: Archive built docs for error checking on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built-docs
           path: docs/build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ exclude = [
 ]
 ignore_missing_imports = false
 no_implicit_optional = true
-plugins = 'numpy.typing.mypy_plugin'
 strict_optional = true
 
 [tool.mypy-setup]

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -227,7 +227,7 @@ def calc_viscosity_h2o(
 
     # Calculate mu1 (Eq. 12 & Table 3, Huber et al., 2009):
     ctbar = (1.0 / tbar) - 1.0
-    mu1 = 0.0
+    mu1 = np.zeros_like(ctbar)
 
     # Iterate over the rows of the H_ij core_constants matrix
     for row_idx in np.arange(core_const.huber_H_ij.shape[1]):

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -852,8 +852,8 @@ def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
     from pyrealm.pmodel import PModel, PModelEnvironment
 
     env = PModelEnvironment(
-        tc=tc,
-        theta=theta,
+        tc=np.array([tc]),
+        theta=np.array([theta]),
         patm=np.array([101325]),
         vpd=np.array([100]),
         co2=np.array([400]),
@@ -869,8 +869,8 @@ def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
         const = PModelConst(beta_cost_ratio_prentice14=mod_theta.optchi.beta)
 
     env = PModelEnvironment(
-        tc=tc,
-        theta=theta,
+        tc=np.array([tc]),
+        theta=np.array([theta]),
         patm=np.array([101325]),
         vpd=np.array([100]),
         co2=np.array([400]),


### PR DESCRIPTION
# Description

This PR is to fix the QA issues that stopped the `1.0.1` release and check they pass on all platforms, ready to retry the release. There are a couple of typing fixes we might want to port to `develop` - not sure if the issues are still current through.

Also needed to update the QA workflows to use more modern `poetry` and actions.

Fixes #553

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
