### PR TITLE
Update NDArray typing

### DIFF
--- a/pyrealm/constants/core_const.py
+++ b/pyrealm/constants/core_const.py
@@ -142,7 +142,7 @@ class CoreConst(ConstantsClass):
     for 2000 CE :cite:t:`berger:1978a`."""
 
     # Hygro constants
-    magnus_coef: NDArray[np.float64] = field(
+    magnus_coef: NDArray[np.floating] = field(
         default_factory=lambda: np.array((611.2, 17.62, 243.12))
     )
     """Three coefficients of the Magnus equation for saturated vapour pressure,
@@ -160,7 +160,7 @@ class CoreConst(ConstantsClass):
     """Set the method used for calculating water density ('fisher' or 'chen')."""
 
     # Fisher Dial
-    fisher_dial_lambda: NDArray[np.float64] = field(
+    fisher_dial_lambda: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [1788.316, 21.55053, -0.4695911, 0.003096363, -7.341182e-06]
         )
@@ -168,7 +168,7 @@ class CoreConst(ConstantsClass):
     r"""Coefficients of the temperature dependent polynomial for :math:`\lambda`
      in the Tumlirz equation."""
 
-    fisher_dial_Po: NDArray[np.float64] = field(
+    fisher_dial_Po: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [5918.499, 58.05267, -1.1253317, 0.0066123869, -1.4661625e-05]
         )
@@ -176,7 +176,7 @@ class CoreConst(ConstantsClass):
     """Coefficients of the temperature dependent polynomial for :math:`P_0` in the
     Tumlirz equation."""
 
-    fisher_dial_Vinf: NDArray[np.float64] = field(
+    fisher_dial_Vinf: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [
                 0.6980547,
@@ -196,7 +196,7 @@ class CoreConst(ConstantsClass):
     in the Tumlirz equation."""
 
     # Chen water density
-    chen_po: NDArray[np.float64] = field(
+    chen_po: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [
                 0.99983952,
@@ -214,7 +214,7 @@ class CoreConst(ConstantsClass):
     r"""Coefficients of the polynomial relationship of water density with temperature at
     1 atm (:math:`P^0`, kg/m^3) from :cite:t:`chen:2008a`."""
 
-    chen_ko: NDArray[np.float64] = field(
+    chen_ko: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [19652.17, 148.1830, -2.29995, 0.01281, -4.91564e-5, 1.035530e-7]
         )
@@ -222,7 +222,7 @@ class CoreConst(ConstantsClass):
     r"""Polynomial relationship of bulk modulus of water with temperature at 1 atm
      (:math:`K^0`, kg/m^3) from :cite:t:`chen:2008a`."""
 
-    chen_ca: NDArray[np.float64] = field(
+    chen_ca: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [3.26138, 5.223e-4, 1.324e-4, -7.655e-7, 8.584e-10]
         )
@@ -230,7 +230,7 @@ class CoreConst(ConstantsClass):
     r"""Coefficients of the polynomial temperature dependent coefficient :math:`A` from
      :cite:t:`chen:2008a`."""
 
-    chen_cb: NDArray[np.float64] = field(
+    chen_cb: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [7.2061e-5, -5.8948e-6, 8.69900e-8, -1.0100e-9, 4.3220e-12]
         )
@@ -248,11 +248,11 @@ class CoreConst(ConstantsClass):
     huber_mu_ast: float = 1e-06
     r"""Huber reference pressure (:math:`\mu_{ast}` 1.0e-6, Pa s)"""
 
-    huber_H_i: NDArray[np.float64] = field(
+    huber_H_i: NDArray[np.floating] = field(
         default_factory=lambda: np.array([1.67752, 2.20462, 0.6366564, -0.241605])
     )
     """Temperature dependent parameterisation of Hi in Huber."""
-    huber_H_ij: NDArray[np.float64] = field(
+    huber_H_ij: NDArray[np.floating] = field(
         default_factory=lambda: np.array(
             [
                 [0.520094, 0.0850895, -1.08374, -0.289555, 0.0, 0.0],

--- a/pyrealm/constants/pmodel_const.py
+++ b/pyrealm/constants/pmodel_const.py
@@ -179,13 +179,13 @@ class PModelConst(ConstantsClass):
     * exponent of the threshold function (``psi_b``).
     """
 
-    beta_cost_ratio_c3: NDArray[np.float64] = field(
+    beta_cost_ratio_c3: NDArray[np.floating] = field(
         default_factory=lambda: np.array([146.0])
     )
     r"""Unit cost ratio for C3 plants (:math:`\beta`, 146.0) taken from
      :cite:t:`Stocker:2020dh`."""
 
-    beta_cost_ratio_c4: NDArray[np.float64] = field(
+    beta_cost_ratio_c4: NDArray[np.floating] = field(
         default_factory=lambda: np.array([146.0 / 9])
     )
     r"""Unit cost ratio for C4 plants (:math:`\beta`, 16.222).

--- a/pyrealm/core/bounds.py
+++ b/pyrealm/core/bounds.py
@@ -119,7 +119,9 @@ class BoundsChecker:
 
         self._data[bounds.var_name] = bounds
 
-    def check(self, var_name: str, values: NDArray) -> NDArray:
+    def check(
+        self, var_name: str, values: NDArray[np.floating]
+    ) -> NDArray[np.floating]:
         r"""Check inputs fall within bounds.
 
         This method checks whether the provided values fall within the bounds specified

--- a/pyrealm/core/hygro.py
+++ b/pyrealm/core/hygro.py
@@ -15,8 +15,8 @@ from pyrealm.core.utilities import evaluate_horner_polynomial
 
 
 def calc_vp_sat(
-    ta: NDArray[np.float64], core_const: CoreConst = CoreConst()
-) -> NDArray[np.float64]:
+    ta: NDArray[np.floating], core_const: CoreConst = CoreConst()
+) -> NDArray[np.floating]:
     r"""Calculate vapour pressure of saturated air.
 
     This function calculates the vapour pressure of saturated air in kPa at a given
@@ -60,10 +60,10 @@ def calc_vp_sat(
 
 
 def convert_vp_to_vpd(
-    vp: NDArray[np.float64],
-    ta: NDArray[np.float64],
+    vp: NDArray[np.floating],
+    ta: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert vapour pressure to vapour pressure deficit.
 
     Args:
@@ -92,11 +92,11 @@ def convert_vp_to_vpd(
 
 
 def convert_rh_to_vpd(
-    rh: NDArray[np.float64],
-    ta: NDArray[np.float64],
+    rh: NDArray[np.floating],
+    ta: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
     bounds_checker: BoundsChecker = BoundsChecker(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert relative humidity to vapour pressure deficit.
 
     Args:
@@ -134,10 +134,10 @@ def convert_rh_to_vpd(
 
 
 def convert_sh_to_vp(
-    sh: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    sh: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert specific humidity to vapour pressure.
 
     Args:
@@ -161,11 +161,11 @@ def convert_sh_to_vp(
 
 
 def convert_sh_to_vpd(
-    sh: NDArray[np.float64],
-    ta: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    sh: NDArray[np.floating],
+    ta: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert specific humidity to vapour pressure deficit.
 
     Args:
@@ -201,8 +201,8 @@ def convert_sh_to_vpd(
 
 
 def calc_saturation_vapour_pressure_slope(
-    tc: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    tc: NDArray[np.floating],
+) -> NDArray[np.floating]:
     """Calculate the slope of the saturation vapour pressure curve.
 
     Calculates the slope of the saturation pressure temperature curve, following
@@ -224,7 +224,7 @@ def calc_saturation_vapour_pressure_slope(
     )
 
 
-def calc_enthalpy_vaporisation(tc: NDArray[np.float64]) -> NDArray[np.float64]:
+def calc_enthalpy_vaporisation(tc: NDArray[np.floating]) -> NDArray[np.floating]:
     """Calculate the enthalpy of vaporization.
 
     Calculates the latent heat of vaporization of water as a function of
@@ -241,7 +241,7 @@ def calc_enthalpy_vaporisation(tc: NDArray[np.float64]) -> NDArray[np.float64]:
     return 1.91846e6 * ((tc + 273.15) / (tc + 273.15 - 33.91)) ** 2
 
 
-def calc_specific_heat(tc: NDArray[np.float64]) -> NDArray[np.float64]:
+def calc_specific_heat(tc: NDArray[np.floating]) -> NDArray[np.floating]:
     """Calculate the specific heat of air.
 
     Calculates the specific heat of air at a constant pressure (:math:`c_{pm}`, J/kg/K)
@@ -274,8 +274,10 @@ def calc_specific_heat(tc: NDArray[np.float64]) -> NDArray[np.float64]:
 
 
 def calc_psychrometric_constant(
-    tc: NDArray[np.float64], p: NDArray[np.float64], core_const: CoreConst = CoreConst()
-) -> NDArray[np.float64]:
+    tc: NDArray[np.floating],
+    p: NDArray[np.floating],
+    core_const: CoreConst = CoreConst(),
+) -> NDArray[np.floating]:
     r"""Calculate the psychrometric constant.
 
     Calculates the psychrometric constant (:math:`\lambda`, Pa/K) given the temperature

--- a/pyrealm/core/pressure.py
+++ b/pyrealm/core/pressure.py
@@ -9,8 +9,8 @@ from pyrealm.constants import CoreConst
 
 
 def calc_patm(
-    elv: NDArray[np.float64], core_const: CoreConst = CoreConst()
-) -> NDArray[np.float64]:
+    elv: NDArray[np.floating], core_const: CoreConst = CoreConst()
+) -> NDArray[np.floating]:
     r"""Calculate atmospheric pressure from elevation.
 
     Calculates atmospheric pressure as a function of elevation with reference to the

--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -21,8 +21,8 @@ from pyrealm.core.utilities import check_input_shapes
 
 
 def calculate_distance_factor(
-    nu: NDArray[np.float64], solar_eccentricity: float = CoreConst().solar_eccentricity
-) -> NDArray[np.float64]:
+    nu: NDArray[np.floating], solar_eccentricity: float = CoreConst().solar_eccentricity
+) -> NDArray[np.floating]:
     r"""Calculates distance factor.
 
     This function calculates the distance factor :math:`d_r` using the method of
@@ -55,9 +55,9 @@ def calculate_distance_factor(
 
 
 def calculate_solar_declination_angle(
-    lambda_: NDArray[np.float64],
+    lambda_: NDArray[np.floating],
     solar_obliquity: float = CoreConst().solar_obliquity,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the solar declination angle.
 
     This function calculates the solar declination angle (:math:`\delta`, degrees)
@@ -82,8 +82,8 @@ def calculate_solar_declination_angle(
 
 
 def calculate_ru_rv_intermediates(
-    declination: NDArray[np.float64], latitude: NDArray[np.float64]
-) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    declination: NDArray[np.floating], latitude: NDArray[np.floating]
+) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
     r"""Calculates intermediate values for use in solar radiation calcs.
 
     This function calculates :math:`r_u` and :math:`r_v` which are dimensionless
@@ -114,8 +114,8 @@ def calculate_ru_rv_intermediates(
 
 
 def calculate_sunset_hour_angle(
-    declination: NDArray[np.float64], latitude: NDArray[np.float64]
-) -> NDArray[np.float64]:
+    declination: NDArray[np.floating], latitude: NDArray[np.floating]
+) -> NDArray[np.floating]:
     r"""Calculate the sunset hour angle.
 
     This function calculates the sunset hour angle :math:`h_s` in degrees following Eq.
@@ -143,9 +143,9 @@ def calculate_sunset_hour_angle(
 
 
 def _calculate_sunset_hour_angle(
-    ru: NDArray[np.float64],
-    rv: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    ru: NDArray[np.floating],
+    rv: NDArray[np.floating],
+) -> NDArray[np.floating]:
     """Calculate sunset hour angle from intermediates.
 
     This function calculates the sunset hour angle using Eq3.22,
@@ -164,13 +164,13 @@ def _calculate_sunset_hour_angle(
 
 
 def calculate_daily_solar_radiation(
-    distance_factor: NDArray[np.float64],
-    sunset_hour_angle: NDArray[np.float64],
-    declination: NDArray[np.float64],
-    latitude: NDArray[np.float64],
+    distance_factor: NDArray[np.floating],
+    sunset_hour_angle: NDArray[np.floating],
+    declination: NDArray[np.floating],
+    latitude: NDArray[np.floating],
     day_seconds: float = CoreConst().day_seconds,
     solar_constant: float = CoreConst().solar_constant,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate daily extraterrestrial solar radiation.
 
     This function calculates the daily extraterrestrial solar radition (:math:`R_d`, J
@@ -214,13 +214,13 @@ def calculate_daily_solar_radiation(
 
 
 def _calculate_daily_solar_radiation(
-    ru: NDArray[np.float64],
-    rv: NDArray[np.float64],
-    distance_factor: NDArray[np.float64],
-    sunset_hour_angle: NDArray[np.float64],
+    ru: NDArray[np.floating],
+    rv: NDArray[np.floating],
+    distance_factor: NDArray[np.floating],
+    sunset_hour_angle: NDArray[np.floating],
     day_seconds: float = CoreConst().day_seconds,
     solar_constant: float = CoreConst().solar_constant,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate daily extraterrestrial solar radiation from intermediate values.
 
     This function calculates the daily extraterrestrial solar radition (:math:R_d`, J
@@ -254,10 +254,10 @@ def _calculate_daily_solar_radiation(
 
 
 def calculate_transmissivity(
-    sunshine_fraction: NDArray[np.float64],
-    elevation: NDArray[np.float64],
+    sunshine_fraction: NDArray[np.floating],
+    elevation: NDArray[np.floating],
     coef: tuple[float, ...] = CoreConst.transmissivity_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate atmospheric transmissivity.
 
     This function calculates atmospheric transmissivity (:math:`\tau`, unitless)
@@ -282,11 +282,11 @@ def calculate_transmissivity(
 
 
 def calculate_ppfd_from_tau_rd(
-    transmissivity: NDArray[np.float64],
-    daily_solar_radiation: NDArray[np.float64],
+    transmissivity: NDArray[np.floating],
+    daily_solar_radiation: NDArray[np.floating],
     visible_light_albedo: float = CoreConst().visible_light_albedo,
     swdown_to_ppfd_factor: float = CoreConst().swdown_to_ppfd_factor,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate photosynthetic photon flux density from intermediates.
 
     This function calculates photosynthetic photon flux density (PPFD, µmol m-2 s-1)
@@ -322,13 +322,13 @@ def calculate_ppfd_from_tau_rd(
 
 
 def calculate_ppfd(
-    sunshine_fraction: NDArray[np.float64],
-    elevation: NDArray[np.float64],
-    latitude: NDArray[np.float64],
+    sunshine_fraction: NDArray[np.floating],
+    elevation: NDArray[np.floating],
+    latitude: NDArray[np.floating],
     ordinal_date: NDArray[np.int_],
     n_days: NDArray[np.int_],
     const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculates photosynthetic photon flux density (PPFD).
 
     This function calculates photosynthetic photon flux density (PPFD, mol m-2) for a
@@ -411,10 +411,10 @@ def calculate_ppfd(
 
 
 def calculate_net_longwave_radiation(
-    sunshine_fraction: NDArray[np.float64],
-    temperature: NDArray[np.float64],
+    sunshine_fraction: NDArray[np.floating],
+    temperature: NDArray[np.floating],
     coef: tuple[float, float] = CoreConst().net_longwave_radiation_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate net longwave radiation.
 
     This function calculates the net longwave radiation (:math:`R_{nl}`, W m-2)
@@ -438,11 +438,11 @@ def calculate_net_longwave_radiation(
 
 
 def calculate_rw_intermediate(
-    transmissivity: NDArray[np.float64],
-    distance_factor: NDArray[np.float64],
+    transmissivity: NDArray[np.floating],
+    distance_factor: NDArray[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the rw intermediate variable.
 
     This function calculates the widely used variable substitute ``rw`` (:math:`r_w`, W
@@ -468,14 +468,14 @@ def calculate_rw_intermediate(
 
 
 def calculate_net_radiation_crossover_hour_angle(
-    net_longwave_radiation: NDArray[np.float64],
-    transmissivity: NDArray[np.float64],
-    distance_factor: NDArray[np.float64],
-    declination: NDArray[np.float64],
-    latitude: NDArray[np.float64],
+    net_longwave_radiation: NDArray[np.floating],
+    transmissivity: NDArray[np.floating],
+    distance_factor: NDArray[np.floating],
+    declination: NDArray[np.floating],
+    latitude: NDArray[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculates the net radiation crossover hour angle.
 
     This function calculates the net radiation crossover hour angle (:math:`h_n`,
@@ -521,11 +521,11 @@ def calculate_net_radiation_crossover_hour_angle(
 
 
 def _calculate_net_radiation_crossover_hour_angle(
-    net_longwave_radiation: NDArray[np.float64],
-    rw: NDArray[np.float64],
-    ru: NDArray[np.float64],
-    rv: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    net_longwave_radiation: NDArray[np.floating],
+    rw: NDArray[np.floating],
+    ru: NDArray[np.floating],
+    rv: NDArray[np.floating],
+) -> NDArray[np.floating]:
     """Calculate net radiation crossover hour angle using intermediate values.
 
     This function calculates the net radiation crossover hour angle (:math:`h_n`
@@ -548,16 +548,16 @@ def _calculate_net_radiation_crossover_hour_angle(
 
 
 def calculate_daytime_net_radiation(
-    net_longwave_radiation: NDArray[np.float64],
-    crossover_hour_angle: NDArray[np.float64],
-    declination: NDArray[np.float64],
-    latitude: NDArray[np.float64],
-    transmissivity: NDArray[np.float64],
-    distance_factor: NDArray[np.float64],
+    net_longwave_radiation: NDArray[np.floating],
+    crossover_hour_angle: NDArray[np.floating],
+    declination: NDArray[np.floating],
+    latitude: NDArray[np.floating],
+    transmissivity: NDArray[np.floating],
+    distance_factor: NDArray[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
     day_seconds: float = CoreConst().day_seconds,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate daily net radiation.
 
     Calculates the daily net radiation (:math:`R_{nd}`, J m-2) as:
@@ -607,13 +607,13 @@ def calculate_daytime_net_radiation(
 
 
 def _calculate_daytime_net_radiation(
-    rw: NDArray[np.float64],
-    rv: NDArray[np.float64],
-    ru: NDArray[np.float64],
-    crossover_hour_angle: NDArray[np.float64],
-    net_longwave_radiation: NDArray[np.float64],
+    rw: NDArray[np.floating],
+    rv: NDArray[np.floating],
+    ru: NDArray[np.floating],
+    crossover_hour_angle: NDArray[np.floating],
+    net_longwave_radiation: NDArray[np.floating],
     day_seconds: float = CoreConst().day_seconds,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculates daily net radiation using precalculated intermediates.
 
     This function calculates daytime net radiation (:math:`R_{nd}` :math:`J/m^2`), using
@@ -642,17 +642,17 @@ def _calculate_daytime_net_radiation(
 
 
 def calculate_nighttime_net_radiation(
-    net_longwave_radiation: NDArray[np.float64],
-    crossover_hour_angle: NDArray[np.float64],
-    sunset_hour_angle: NDArray[np.float64],
-    declination: NDArray[np.float64],
-    latitude: NDArray[np.float64],
-    transmissivity: NDArray[np.float64],
-    distance_factor: NDArray[np.float64],
+    net_longwave_radiation: NDArray[np.floating],
+    crossover_hour_angle: NDArray[np.floating],
+    sunset_hour_angle: NDArray[np.floating],
+    declination: NDArray[np.floating],
+    latitude: NDArray[np.floating],
+    transmissivity: NDArray[np.floating],
+    distance_factor: NDArray[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
     day_seconds: float = CoreConst().day_seconds,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculates nightime net radiation.
 
     This function calculates nighttime net radiation (:math:`R_{nn}`, J m-2) as:
@@ -707,14 +707,14 @@ def calculate_nighttime_net_radiation(
 
 
 def _calculate_nighttime_net_radiation(
-    rw: NDArray[np.float64],
-    rv: NDArray[np.float64],
-    ru: NDArray[np.float64],
-    sunset_hour_angle: NDArray[np.float64],
-    crossover_hour_angle: NDArray[np.float64],
-    net_longwave_radiation: NDArray[np.float64],
+    rw: NDArray[np.floating],
+    rv: NDArray[np.floating],
+    ru: NDArray[np.floating],
+    sunset_hour_angle: NDArray[np.floating],
+    crossover_hour_angle: NDArray[np.floating],
+    net_longwave_radiation: NDArray[np.floating],
     day_seconds: float = CoreConst().day_seconds,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculates nightime net radiation using precalculated intermediates.
 
     This function calculates nighttime net radiation (:math:`R_{nn}` :math:`J/m^2`), a
@@ -754,7 +754,7 @@ def calculate_heliocentric_longitudes(
     n_days: NDArray[np.int_],
     solar_eccentricity: float = CoreConst().solar_eccentricity,
     solar_perihelion: float = CoreConst().solar_perihelion,
-) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
     r"""Calculate heliocentric longitude and anomaly.
 
     This function calculates the heliocentric true anomaly (``nu``, :math:`\nu`,
@@ -830,10 +830,10 @@ def calculate_heliocentric_longitudes(
 
 
 def calculate_solar_elevation(
-    latitude: NDArray[np.float64],
-    declination: NDArray[np.float64],
-    hour_angle: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    latitude: NDArray[np.floating],
+    declination: NDArray[np.floating],
+    hour_angle: NDArray[np.floating],
+) -> NDArray[np.floating]:
     r"""Calculate the solar elevation angle.
 
     The solar elevation angle (:math:`\alpha`, radians) is the angle between the horizon
@@ -861,7 +861,7 @@ def calculate_solar_elevation(
 
 def calculate_solar_declination(
     ordinal_date: NDArray[np.int_],
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate solar declination angle.
 
     Calculates the solar declination angle (:math:`\delta`, radians) from the ordinal
@@ -882,8 +882,8 @@ def calculate_solar_declination(
 
 
 def calculate_local_hour_angle(
-    current_time: NDArray[np.float64], solar_noon: NDArray[np.float64]
-) -> NDArray[np.float64]:
+    current_time: NDArray[np.floating], solar_noon: NDArray[np.floating]
+) -> NDArray[np.floating]:
     r"""Calculate the local hour angle.
 
     The local hour angle (:math:`h`, radians) is a measure of time, expressed as an
@@ -907,10 +907,10 @@ def calculate_local_hour_angle(
 
 
 def calculate_solar_noon(
-    longitude: NDArray[np.float64],
-    equation_of_time: NDArray[np.float64],
-    standard_longitude: NDArray[np.float64] = np.array([0]),
-) -> NDArray[np.float64]:
+    longitude: NDArray[np.floating],
+    equation_of_time: NDArray[np.floating],
+    standard_longitude: NDArray[np.floating] = np.array([0]),
+) -> NDArray[np.floating]:
     r"""Calculate the solar noon  for a given location.
 
     The solar noon (:math:`t_0`, decimal hour) is the time of day when the sun is at its
@@ -939,9 +939,9 @@ def calculate_solar_noon(
 
 
 def calculate_equation_of_time(
-    day_angle: NDArray[np.float64],
+    day_angle: NDArray[np.floating],
     coef: tuple[float, ...] = CoreConst.equation_of_time_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the equation of time.
 
     Calculates values of the equation of time (:math:`E_t`, minutes) from the day angle
@@ -979,7 +979,7 @@ def calculate_equation_of_time(
     ) * f
 
 
-def calculate_day_angle(ordinal_date: NDArray[np.int_]) -> NDArray[np.float64]:
+def calculate_day_angle(ordinal_date: NDArray[np.int_]) -> NDArray[np.floating]:
     r"""Calculate the solar day angle.
 
     Calculates the solar day angle (:math:`\Gamma`, radians) for ordinal dates
@@ -1020,9 +1020,9 @@ class SolarPositions:
         array([0.60252])
     """
 
-    latitude: NDArray[np.float64]
+    latitude: NDArray[np.floating]
     """The latitude of the location in degrees."""
-    longitude: NDArray[np.float64]
+    longitude: NDArray[np.floating]
     """The longitude of the location in degrees."""
     datetime: NDArray[np.datetime64]
     """An array of np.datetime64 values corresponding to observations at the location
@@ -1030,28 +1030,28 @@ class SolarPositions:
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
     """A core constants instance."""
 
-    latitude_rad: NDArray[np.float64] = field(init=False)
+    latitude_rad: NDArray[np.floating] = field(init=False)
     """The latitude of the location in radians, calculated automatically."""
-    longitude_rad: NDArray[np.float64] = field(init=False)
+    longitude_rad: NDArray[np.floating] = field(init=False)
     """The longitude of the location in radians, calculated automatically."""
     ordinal_date: NDArray[np.int_] = field(init=False)
     """An array of ordinal dates calculated from the datetimes."""
-    decimal_time: NDArray[np.float64] = field(init=False)
+    decimal_time: NDArray[np.floating] = field(init=False)
     """An array of decimal hour values calculated from the datetimes."""
-    local_standard_meridian: NDArray[np.float64] = field(init=False)
+    local_standard_meridian: NDArray[np.floating] = field(init=False)
     """An array of local meridians given the longitude."""
 
-    day_angle: NDArray[np.float64] = field(init=False)
+    day_angle: NDArray[np.floating] = field(init=False)
     r"""The solar day angle of the observations (:math:`\Gamma`, radians)."""
-    equation_of_time: NDArray[np.float64] = field(init=False)
+    equation_of_time: NDArray[np.floating] = field(init=False)
     """The equation of time value for the observations (:math:`E_t`, minutes)."""
-    solar_noon: NDArray[np.float64] = field(init=False)
+    solar_noon: NDArray[np.floating] = field(init=False)
     """The solar noon for the observations (:math:`t_0`, decimal hour)."""
-    hour_angle: NDArray[np.float64] = field(init=False)
+    hour_angle: NDArray[np.floating] = field(init=False)
     """The local hour angle for the observations (:math:`h`, radians)."""
-    declination: NDArray[np.float64] = field(init=False)
+    declination: NDArray[np.floating] = field(init=False)
     r"""The declination for the observations ( (:math:`\delta`, radians)."""
-    solar_elevation: NDArray[np.float64] = field(init=False)
+    solar_elevation: NDArray[np.floating] = field(init=False)
     r"""The solar elevation for the observations (:math:`\alpha`, radians) ."""
 
     def __post_init__(self) -> None:
@@ -1098,7 +1098,7 @@ class SolarPositions:
             hour_angle=self.hour_angle,
         )
 
-    def get_local_standard_meridian(self) -> NDArray[np.float64]:
+    def get_local_standard_meridian(self) -> NDArray[np.floating]:
         """Calculate local meridian from longitude.
 
         This calculates the approximate local standard meridian given the longitude. The

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -77,12 +77,12 @@ class AnnualValueCalculator:
         self.duration_weights: list[NDArray[np.int_]] = []
         """A list of arrays giving the number of seconds that each observation
         within a year contributes to that year."""
-        self.fractional_weights: list[NDArray[np.float64]] = []
+        self.fractional_weights: list[NDArray[np.floating]] = []
         """A list of arrays giving the fraction of each observation within a year that
         falls in the year."""
         self.growing_season_by_year: list[NDArray[np.bool_]]
         """A list of arrays giving the growing season subarrays for each year."""
-        self.year_completeness: NDArray[np.float64]
+        self.year_completeness: NDArray[np.floating]
         """Provides the fractional coverage of observations for each year."""
         self.years: NDArray[np.datetime64]
         """The covered years as np.datetime64 at year precision."""
@@ -257,8 +257,8 @@ class AnnualValueCalculator:
         )
 
     def _split_values_by_year(
-        self, values: NDArray[np.float64]
-    ) -> list[NDArray[np.float64]]:
+        self, values: NDArray[np.floating]
+    ) -> list[NDArray[np.floating]]:
         """Validates and splits value arrays.
 
         Args:
@@ -279,7 +279,7 @@ class AnnualValueCalculator:
 
     def get_annual_means(
         self,
-        values: NDArray[np.float64],
+        values: NDArray[np.floating],
         within_growing_season: bool = False,
     ) -> NDArray[np.floating]:
         """Get annual means from an array of values.
@@ -346,7 +346,7 @@ class AnnualValueCalculator:
 
     def get_annual_totals(
         self,
-        values: NDArray[np.float64],
+        values: NDArray[np.floating],
         within_growing_season: bool = False,
     ) -> NDArray[np.floating]:
         """Get annual totals from an array of values.

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -129,7 +129,7 @@ class AnnualValueCalculator:
             if not np.all(duration_seconds > 0):
                 raise ValueError("The timing values are not strictly increasing")
 
-            intervals: NDArray = np.unique(duration_seconds)
+            intervals: NDArray[np.floating] = np.unique(duration_seconds)
 
             if len(intervals) == 1:
                 # Constant intervals

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -149,8 +149,8 @@ def summarize_attrs(
 
 
 def evaluate_horner_polynomial(
-    x: NDArray[np.float64], cf: Sequence | NDArray
-) -> NDArray[np.float64]:
+    x: NDArray[np.floating], cf: Sequence | NDArray
+) -> NDArray[np.floating]:
     r"""Evaluates a polynomial with coefficients `cf` at `x` using Horner's method.
 
     Horner's method is a fast way to evaluate polynomials, especially for large degrees,
@@ -179,11 +179,11 @@ def evaluate_horner_polynomial(
 
 
 def exponential_moving_average(
-    values: NDArray[np.float64],
-    initial_values: NDArray[np.float64] | None = None,
+    values: NDArray[np.floating],
+    initial_values: NDArray[np.floating] | None = None,
     alpha: float = 0.067,
     allow_holdover: bool = False,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Apply an exponential moving average to a variable.
 
     This function implements an exponential moving average for an input array, using

--- a/pyrealm/core/utilities.py
+++ b/pyrealm/core/utilities.py
@@ -149,7 +149,7 @@ def summarize_attrs(
 
 
 def evaluate_horner_polynomial(
-    x: NDArray[np.floating], cf: Sequence | NDArray
+    x: NDArray[np.floating], cf: Sequence | NDArray[np.floating]
 ) -> NDArray[np.floating]:
     r"""Evaluates a polynomial with coefficients `cf` at `x` using Horner's method.
 

--- a/pyrealm/core/water.py
+++ b/pyrealm/core/water.py
@@ -10,10 +10,10 @@ from pyrealm.core.utilities import check_input_shapes, evaluate_horner_polynomia
 
 
 def calc_density_h2o_chen(
-    tc: NDArray[np.float64],
-    p: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    p: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate the density of water using Chen et al 2008.
 
     This function calculates the density of water at a given temperature and pressure
@@ -65,10 +65,10 @@ def calc_density_h2o_chen(
 
 
 def calc_density_h2o_fisher(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate water density.
 
     Calculates the density of water as a function of temperature and atmospheric
@@ -124,11 +124,11 @@ def calc_density_h2o_fisher(
 
 
 def calc_density_h2o(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
     safe: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate water density.
 
     Calculates the density of water as a function of temperature and atmospheric
@@ -179,11 +179,11 @@ def calc_density_h2o(
 
 
 def calc_viscosity_h2o(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
     simple: bool = False,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the viscosity of water.
 
     Calculates the viscosity of water (:math:`\eta`) as a function of temperature and
@@ -247,11 +247,11 @@ def calc_viscosity_h2o(
 
 
 def calc_viscosity_h2o_matrix(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
     simple: bool = False,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the viscosity of water.
 
     Calculates the viscosity of water (:math:`\eta`) as a function of temperature and
@@ -309,11 +309,11 @@ def calc_viscosity_h2o_matrix(
 
 
 def convert_water_mm_to_moles(
-    water_mm: NDArray[np.float64],
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    water_mm: NDArray[np.floating],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert water in mm per square meter to moles.
 
     This function converts water volumes expressed as mm per m2 into a number of moles
@@ -348,11 +348,11 @@ def convert_water_mm_to_moles(
 
 
 def convert_water_moles_to_mm(
-    water_moles: NDArray[np.float64],
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    water_moles: NDArray[np.floating],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Convert water in moles to mm per square meter.
 
     This function converts water volumes expressed as moles into mm per m2. It accounts
@@ -385,8 +385,8 @@ def convert_water_moles_to_mm(
 
 
 def calculate_water_molar_volume(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     """Calculate the volume of a mole of water at a given temperature and pressure.

--- a/pyrealm/demography/canopy.py
+++ b/pyrealm/demography/canopy.py
@@ -21,16 +21,16 @@ from pyrealm.demography.crown import (
 
 def solve_canopy_area_filling_height(
     z: float,
-    stem_height: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
-    m: NDArray[np.float64],
-    n: NDArray[np.float64],
-    q_m: NDArray[np.float64],
-    z_max: NDArray[np.float64],
-    n_individuals: NDArray[np.float64],
+    stem_height: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    m: NDArray[np.floating],
+    n: NDArray[np.floating],
+    q_m: NDArray[np.floating],
+    z_max: NDArray[np.floating],
+    n_individuals: NDArray[np.floating],
     target_area: float = 0,
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Solver function for finding the height where a canopy occupies a given area.
 
     This function takes the number of individuals in each cohort along with the stem
@@ -98,7 +98,7 @@ def fit_perfect_plasticity_approximation(
     canopy_gap_fraction: float,
     max_stem_height: float,
     solver_tolerance: float,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Find canopy layer heights under the PPA model.
 
     Finds the closure heights of the canopy layers under the perfect plasticity
@@ -221,22 +221,22 @@ class CohortCanopyData(PandasExporter):
     )
 
     # Init vars
-    projected_leaf_area: InitVar[NDArray[np.float64]]
+    projected_leaf_area: InitVar[NDArray[np.floating]]
     """An array of the stem projected leaf area for each cohort at each of the required
     heights."""
     n_individuals: InitVar[NDArray[np.int_]]
     """The number of individuals for each cohort."""
-    lai: InitVar[NDArray[np.float64]]
+    lai: InitVar[NDArray[np.floating]]
     """The leaf area index of the plant functional type for each cohort."""
-    par_ext: InitVar[NDArray[np.float64]]
+    par_ext: InitVar[NDArray[np.floating]]
     """The extinction coefficient of the plant functional type for each cohort."""
     cell_area: InitVar[float]
     """The area available to the community."""
 
     # Computed variables
-    stem_leaf_area: NDArray[np.float64] = field(init=False)
+    stem_leaf_area: NDArray[np.floating] = field(init=False)
     """The leaf area of the crown model for each cohort by layer."""
-    cohort_absorption: NDArray[np.float64] = field(init=False)
+    cohort_absorption: NDArray[np.floating] = field(init=False)
     """The Beer-Lambert absorption fraction for each cohort."""
     fapar: NDArray[np.floating] = field(init=False)
     """The across layer fractions of absorbed radiation for each cohort by layer."""
@@ -249,10 +249,10 @@ class CohortCanopyData(PandasExporter):
 
     def __post_init__(
         self,
-        projected_leaf_area: NDArray[np.float64],
+        projected_leaf_area: NDArray[np.floating],
         n_individuals: NDArray[np.int_],
-        lai: NDArray[np.float64],
-        par_ext: NDArray[np.float64],
+        lai: NDArray[np.floating],
+        par_ext: NDArray[np.floating],
         cell_area: float,
     ) -> None:
         """Calculates cohort canopy attributes from the input data."""
@@ -264,7 +264,7 @@ class CohortCanopyData(PandasExporter):
         self.stem_leaf_area = np.diff(projected_leaf_area, axis=0, prepend=0)
 
         # Calculate Beer-Lambert light absorption coefficient for each cohort
-        self.cohort_absorption = 1 - np.exp(-par_ext * lai)
+        self.cohort_absorption = 1.0 - np.exp(-par_ext * lai)
 
         # Calculate the community wide properties across cohorts:
         # - average light transmission through each layer
@@ -319,34 +319,34 @@ class CommunityCanopyData(PandasExporter):
     )
 
     # Init vars
-    absorption: InitVar[NDArray[np.float64]]
+    absorption: InitVar[NDArray[np.floating]]
     """The Beer Lambert light absorption fraction for each cohort."""
-    leaf_area_index: InitVar[NDArray[np.float64]]
+    leaf_area_index: InitVar[NDArray[np.floating]]
     """The leaf area index for each cohort."""
-    cohort_leaf_area: InitVar[NDArray[np.float64]]
+    cohort_leaf_area: InitVar[NDArray[np.floating]]
     """The total leaf area per cohort for each layer."""
     cell_area: InitVar[float]
     """The total area within the community."""
 
     # Calculated variables
-    average_layer_absorption: NDArray[np.float64] = field(init=False)
+    average_layer_absorption: NDArray[np.floating] = field(init=False)
     """The average absorption within layers across the community."""
-    average_layer_fapar: NDArray[np.float64] = field(init=False)
+    average_layer_fapar: NDArray[np.floating] = field(init=False)
     """The average fAPAR of the community for each layer."""
-    average_layer_lai: NDArray[np.float64] = field(init=False)
+    average_layer_lai: NDArray[np.floating] = field(init=False)
     """The average leaf area index of the community within layers."""
-    transmission_profile: NDArray[np.float64] = field(init=False)
+    transmission_profile: NDArray[np.floating] = field(init=False)
     """The light transmission profile through the canopy by layer."""
-    transmission_to_ground: NDArray[np.float64] = field(init=False)
+    transmission_to_ground: NDArray[np.floating] = field(init=False)
     """The fraction of light reaching the ground below the canopy."""
 
     __experimental__ = True
 
     def __post_init__(
         self,
-        absorption: NDArray[np.float64],
-        leaf_area_index: NDArray[np.float64],
-        cohort_leaf_area: NDArray[np.float64],
+        absorption: NDArray[np.floating],
+        leaf_area_index: NDArray[np.floating],
+        cohort_leaf_area: NDArray[np.floating],
         cell_area: float,
     ) -> None:
         """Calculates community-wide canopy attributes from the input data."""
@@ -407,7 +407,7 @@ class Canopy:
     def __init__(
         self,
         community: Community,
-        layer_heights: NDArray[np.float64] | None = None,
+        layer_heights: NDArray[np.floating] | None = None,
         fit_ppa: bool = False,
         canopy_gap_fraction: float = 0,
         solver_tolerance: float = 0.001,
@@ -428,7 +428,7 @@ class Canopy:
         """Total number of canopy layers."""
         self.n_cohorts: int
         """Total number of cohorts in the canopy."""
-        self.heights: NDArray[np.float64]
+        self.heights: NDArray[np.floating]
         """The vertical heights at which the canopy structure is calculated."""
 
         self.crown_profile: CrownProfile

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -651,7 +651,7 @@ class Community:
     #     for cell_id in data_grouped_by_community.groups:
     #         community_dataframe = data_grouped_by_community.get_group(cell_id)
     #         dbh_values = community_dataframe["diameter_at_breast_height"].to_numpy(
-    #             dtype=np.float32
+    #             dtype=np.floating
     #         )
     #         number_of_individuals = community_dataframe[
     #             "number_of_individuals"

--- a/pyrealm/demography/community.py
+++ b/pyrealm/demography/community.py
@@ -170,13 +170,13 @@ class Cohorts(PandasExporter, CohortMethods):
     n_individuals: NDArray[np.int_]
     pft_names: NDArray[np.str_]
     _cohort_id: NDArray[np.str_] = field(init=False)
-    _dbh_values: NDArray[np.float64] = field(init=False)
+    _dbh_values: NDArray[np.floating] = field(init=False)
     n_cohorts: int = field(init=False)
-    dbh_values: InitVar[NDArray[np.float64]]
+    dbh_values: InitVar[NDArray[np.floating]]
 
     __experimental__ = True
 
-    def __post_init__(self, dbh_values: NDArray[np.float64]) -> None:
+    def __post_init__(self, dbh_values: NDArray[np.floating]) -> None:
         """Validation of cohorts data."""
 
         # TODO - validation - maybe make this optional to reduce workload within
@@ -222,12 +222,12 @@ class Cohorts(PandasExporter, CohortMethods):
     # values.
 
     @property  # type: ignore [no-redef]
-    def dbh_values(self) -> NDArray[np.float64]:
+    def dbh_values(self) -> NDArray[np.floating]:
         """The diameter at breast height of the cohorts (m)."""
         return self._dbh_values
 
     @dbh_values.setter
-    def dbh_values(self, values: NDArray[np.float64]) -> None:
+    def dbh_values(self, values: NDArray[np.floating]) -> None:
         """Setter function for DBH values, enforcing strictly positive values."""
         if np.any(values <= 0):
             raise ValueError("DBH values must be strictly positive")

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -141,9 +141,9 @@ class CohortMethods(ABC):
 
 
 def _validate_demography_array_arguments(
-    trait_args: dict[str, NDArray],
-    size_args: dict[str, NDArray] = {},
-    at_size_args: dict[str, NDArray] = {},
+    trait_args: dict[str, NDArray[np.floating]],
+    size_args: dict[str, NDArray[np.floating]] = {},
+    at_size_args: dict[str, NDArray[np.floating]] = {},
 ) -> None:
     """Shared validation for demography inputs.
 

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -385,7 +385,9 @@ def get_crown_xy(
     stem_offsets: NDArray[np.float32] | None = None,
     two_sided: bool = True,
     as_xy: bool = False,
-) -> list[tuple[NDArray, NDArray]] | list[NDArray]:
+) -> (
+    list[tuple[NDArray[np.floating], NDArray[np.floating]]] | list[NDArray[np.floating]]
+):
     """Extract plotting data from crown profiles.
 
     A CrownProfile instance contains crown radius and projected area data for a set of
@@ -434,8 +436,10 @@ def get_crown_xy(
         height_is_valid = np.logical_and(
             z <= stem_allometry.stem_height[:, stem_index], z >= 0
         )
-        valid_attr_values: NDArray = attr_values[height_is_valid, stem_index]
-        valid_heights: NDArray = z[height_is_valid]
+        valid_attr_values: NDArray[np.floating] = attr_values[
+            height_is_valid, stem_index
+        ]
+        valid_heights: NDArray[np.floating] = z[height_is_valid]
 
         if two_sided:
             # The values are extended to include the reverse profile as well as the zero

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -368,12 +368,12 @@ class CrownProfile(PandasExporter):
         )
 
     @property
-    def projected_crown_radius(self) -> NDArray[np.float32]:
+    def projected_crown_radius(self) -> NDArray[np.floating]:
         """An array of the projected crown radius of stems at z heights."""
         return np.sqrt(self.projected_crown_area / np.pi)
 
     @property
-    def projected_leaf_radius(self) -> NDArray[np.float32]:
+    def projected_leaf_radius(self) -> NDArray[np.floating]:
         """An array of the projected leaf radius of stems at z heights."""
         return np.sqrt(self.projected_leaf_area / np.pi)
 
@@ -382,7 +382,7 @@ def get_crown_xy(
     crown_profile: CrownProfile,
     stem_allometry: StemAllometry,
     attr: str,
-    stem_offsets: NDArray[np.float32] | None = None,
+    stem_offsets: NDArray[np.floating] | None = None,
     two_sided: bool = True,
     as_xy: bool = False,
 ) -> (

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -18,13 +18,13 @@ from pyrealm.demography.tmodel import StemAllometry
 
 
 def calculate_relative_crown_radius_at_z(
-    z: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    m: NDArray[np.float64],
-    n: NDArray[np.float64],
+    z: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    m: NDArray[np.floating],
+    n: NDArray[np.floating],
     validate: bool = True,
     clip: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate relative crown radius at a given height.
 
     The crown shape parameters ``m`` and ``n`` define the vertical distribution of
@@ -79,10 +79,10 @@ def calculate_relative_crown_radius_at_z(
 
 
 def calculate_crown_radius(
-    q_z: NDArray[np.float64],
-    r0: NDArray[np.float64],
+    q_z: NDArray[np.floating],
+    r0: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate crown radius from relative crown radius and crown r0.
 
     The relative crown radius (:math:`q(z)`) at a given height :math:`z` describes the
@@ -111,14 +111,14 @@ def calculate_crown_radius(
 
 
 def calculate_stem_projected_crown_area_at_z(
-    z: NDArray[np.float64],
-    q_z: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
-    q_m: NDArray[np.float64],
-    z_max: NDArray[np.float64],
+    z: NDArray[np.floating],
+    q_z: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    q_m: NDArray[np.floating],
+    z_max: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate stem projected crown area above a given height.
 
     This function calculates the projected crown area of a set of stems with given
@@ -164,15 +164,15 @@ def calculate_stem_projected_crown_area_at_z(
 
 
 def calculate_stem_projected_leaf_area_at_z(
-    z: NDArray[np.float64],
-    q_z: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
-    f_g: NDArray[np.float64],
-    q_m: NDArray[np.float64],
-    z_max: NDArray[np.float64],
+    z: NDArray[np.floating],
+    q_z: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    f_g: NDArray[np.floating],
+    q_m: NDArray[np.floating],
+    z_max: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     """Calculate projected leaf area above a given height.
 
     This function calculates the projected leaf area of a set of stems with given
@@ -275,18 +275,18 @@ class CrownProfile(PandasExporter):
     """A Flora or StemTraits instance providing plant functional trait data."""
     stem_allometry: InitVar[StemAllometry]
     """A StemAllometry instance setting the stem allometries for the crown profile."""
-    z: NDArray[np.float64]
+    z: NDArray[np.floating]
     """An array of vertical height values at which to calculate crown profiles."""
     validate: InitVar[bool] = True
     """Boolean flag to suppress argument validation."""
 
-    relative_crown_radius: NDArray[np.float64] = field(init=False)
+    relative_crown_radius: NDArray[np.floating] = field(init=False)
     """An array of the relative crown radius of stems at z heights"""
-    crown_radius: NDArray[np.float64] = field(init=False)
+    crown_radius: NDArray[np.floating] = field(init=False)
     """An array of the actual crown radius of stems at z heights"""
-    projected_crown_area: NDArray[np.float64] = field(init=False)
+    projected_crown_area: NDArray[np.floating] = field(init=False)
     """An array of the projected crown area of stems at z heights"""
-    projected_leaf_area: NDArray[np.float64] = field(init=False)
+    projected_leaf_area: NDArray[np.floating] = field(init=False)
     """An array of the projected leaf area of stems at z heights"""
 
     # Information attributes

--- a/pyrealm/demography/flora.py
+++ b/pyrealm/demography/flora.py
@@ -46,8 +46,8 @@ from pyrealm.demography.core import (
 
 
 def calculate_crown_q_m(
-    m: float | NDArray[np.float64], n: float | NDArray[np.float64]
-) -> float | NDArray[np.float64]:
+    m: float | NDArray[np.floating], n: float | NDArray[np.floating]
+) -> float | NDArray[np.floating]:
     """Calculate the crown scaling trait ``q_m``.
 
     The value of q_m is a constant crown scaling parameter derived from the ``m`` and
@@ -66,8 +66,8 @@ def calculate_crown_q_m(
 
 
 def calculate_crown_z_max_proportion(
-    m: float | NDArray[np.float64], n: float | NDArray[np.float64]
-) -> float | NDArray[np.float64]:
+    m: float | NDArray[np.floating], n: float | NDArray[np.floating]
+) -> float | NDArray[np.floating]:
     r"""Calculate the z_m trait.
 
     The z_m proportion (:math:`p_{zm}`) is the constant proportion of stem height at
@@ -281,49 +281,49 @@ class Flora(PandasExporter):
     # - trait arrays
     name: NDArray[np.str_] = field(init=False)
     r"""The name of the plant functional type."""
-    a_hd: NDArray[np.float64] = field(init=False)
+    a_hd: NDArray[np.floating] = field(init=False)
     r"""Initial slope of height-diameter relationship (:math:`a`, -)"""
-    ca_ratio: NDArray[np.float64] = field(init=False)
+    ca_ratio: NDArray[np.floating] = field(init=False)
     r"""Initial ratio of crown area to stem cross-sectional area
     (:math:`c`, -)"""
-    h_max: NDArray[np.float64] = field(init=False)
+    h_max: NDArray[np.floating] = field(init=False)
     r"""Maximum tree height (:math:`H_m`, m)"""
-    rho_s: NDArray[np.float64] = field(init=False)
+    rho_s: NDArray[np.floating] = field(init=False)
     r"""Sapwood density (:math:`\rho_s`, kg Cm-3)"""
-    lai: NDArray[np.float64] = field(init=False)
+    lai: NDArray[np.floating] = field(init=False)
     """Leaf area index within the crown (:math:`L`,  -)"""
-    sla: NDArray[np.float64] = field(init=False)
+    sla: NDArray[np.floating] = field(init=False)
     r"""Specific leaf area (:math:`\sigma`,  m2 kg-1 C)"""
-    tau_f: NDArray[np.float64] = field(init=False)
+    tau_f: NDArray[np.floating] = field(init=False)
     r"""Foliage turnover time (:math:`\tau_f`,years)"""
-    tau_r: NDArray[np.float64] = field(init=False)
+    tau_r: NDArray[np.floating] = field(init=False)
     r"""Fine-root turnover time (:math:`\tau_r`,  years)"""
-    tau_rt: NDArray[np.float64] = field(init=False)
+    tau_rt: NDArray[np.floating] = field(init=False)
     r"""Reproductive tissue turnover time (:math:`\tau_rt`,years)"""
-    par_ext: NDArray[np.float64] = field(init=False)
+    par_ext: NDArray[np.floating] = field(init=False)
     r"""Extinction coefficient of photosynthetically active radiation (PAR) (:math:`k`,
      -)"""
-    yld: NDArray[np.float64] = field(init=False)
+    yld: NDArray[np.floating] = field(init=False)
     r"""Yield factor (:math:`y`,  -)"""
-    zeta: NDArray[np.float64] = field(init=False)
+    zeta: NDArray[np.floating] = field(init=False)
     r"""Ratio of fine-root mass to foliage area (:math:`\zeta`, kg C m-2)"""
-    resp_r: NDArray[np.float64] = field(init=False)
+    resp_r: NDArray[np.floating] = field(init=False)
     r"""Fine-root specific respiration rate (:math:`r_r`, year-1)"""
-    resp_s: NDArray[np.float64] = field(init=False)
+    resp_s: NDArray[np.floating] = field(init=False)
     r"""Sapwood-specific respiration rate (:math:`r_s`,  year-1)"""
-    resp_f: NDArray[np.float64] = field(init=False)
+    resp_f: NDArray[np.floating] = field(init=False)
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
-    resp_rt: NDArray[np.float64] = field(init=False)
+    resp_rt: NDArray[np.floating] = field(init=False)
     r"""Reproductive tissue respiration rate (:math:`r_{rt}`,  -)"""
-    m: NDArray[np.float64] = field(init=False)
+    m: NDArray[np.floating] = field(init=False)
     r"""Crown shape parameter (:math:`m`, -)"""
-    n: NDArray[np.float64] = field(init=False)
+    n: NDArray[np.floating] = field(init=False)
     r"""Crown shape parameter (:math:`n`, -)"""
-    f_g: NDArray[np.float64] = field(init=False)
+    f_g: NDArray[np.floating] = field(init=False)
     r"""Crown gap fraction (:math:`f_g`, -)"""
-    q_m: NDArray[np.float64] = field(init=False)
+    q_m: NDArray[np.floating] = field(init=False)
     """Scaling factor to derive maximum crown radius from crown area."""
-    z_max_prop: NDArray[np.float64] = field(init=False)
+    z_max_prop: NDArray[np.floating] = field(init=False)
     """Proportion of stem height at which maximum crown radius is found."""
 
     # - other instance attributes
@@ -336,9 +336,9 @@ class Flora(PandasExporter):
     _n_stems: int = field(init=False)
     """Private attribute for compatibility with StemTraits API."""
 
-    p_foliage_for_reproductive_tissue: NDArray[np.float64] = field(init=False)
+    p_foliage_for_reproductive_tissue: NDArray[np.floating] = field(init=False)
     """Proportion of foliage used to calculate reproductive tissue."""
-    gpp_topslice: NDArray[np.float64] = field(init=False)
+    gpp_topslice: NDArray[np.floating] = field(init=False)
     """Proportion of GPP to topslice before allocation."""
 
     def __post_init__(self, pfts: Sequence[PlantFunctionalTypeStrict]) -> None:
@@ -490,54 +490,54 @@ class StemTraits(PandasExporter, CohortMethods):
     # Instance trait attributes
     name: NDArray[np.str_]
     r"""The name of the plant functional type."""
-    a_hd: NDArray[np.float64]
+    a_hd: NDArray[np.floating]
     r"""Initial slope of height-diameter relationship (:math:`a`, -)"""
-    ca_ratio: NDArray[np.float64]
+    ca_ratio: NDArray[np.floating]
     r"""Initial ratio of crown area to stem cross-sectional area
     (:math:`c`, -)"""
-    h_max: NDArray[np.float64]
+    h_max: NDArray[np.floating]
     r"""Maximum tree height (:math:`H_m`, m)"""
-    rho_s: NDArray[np.float64]
+    rho_s: NDArray[np.floating]
     r"""Sapwood density (:math:`\rho_s`, kg Cm-3)"""
-    lai: NDArray[np.float64]
+    lai: NDArray[np.floating]
     """Leaf area index within the crown (:math:`L`,  -)"""
-    sla: NDArray[np.float64]
+    sla: NDArray[np.floating]
     r"""Specific leaf area (:math:`\sigma`,  m2 kg-1 C)"""
-    tau_f: NDArray[np.float64]
+    tau_f: NDArray[np.floating]
     r"""Foliage turnover time (:math:`\tau_f`,years)"""
-    tau_rt: NDArray[np.float64]
+    tau_rt: NDArray[np.floating]
     r"""Reproductive tissue turnover time (:math:`\tau_rt`,years)"""
-    tau_r: NDArray[np.float64]
+    tau_r: NDArray[np.floating]
     r"""Fine-root turnover time (:math:`\tau_r`,  years)"""
-    par_ext: NDArray[np.float64]
+    par_ext: NDArray[np.floating]
     r"""Extinction coefficient of photosynthetically active radiation (PAR) (:math:`k`,
      -)"""
-    yld: NDArray[np.float64]
+    yld: NDArray[np.floating]
     r"""Yield factor (:math:`y`,  -)"""
-    zeta: NDArray[np.float64]
+    zeta: NDArray[np.floating]
     r"""Ratio of fine-root mass to foliage area (:math:`\zeta`, kg C m-2)"""
-    resp_r: NDArray[np.float64]
+    resp_r: NDArray[np.floating]
     r"""Fine-root specific respiration rate (:math:`r_r`, year-1)"""
-    resp_s: NDArray[np.float64]
+    resp_s: NDArray[np.floating]
     r"""Sapwood-specific respiration rate (:math:`r_s`,  year-1)"""
-    resp_f: NDArray[np.float64]
+    resp_f: NDArray[np.floating]
     r"""Foliage maintenance respiration fraction (:math:`r_f`,  -)"""
-    resp_rt: NDArray[np.float64]
+    resp_rt: NDArray[np.floating]
     r"""Reproductive tissue respiration rate (:math:`r_{rt}`,  -)"""
-    m: NDArray[np.float64]
+    m: NDArray[np.floating]
     r"""Crown shape parameter (:math:`m`, -)"""
-    n: NDArray[np.float64]
+    n: NDArray[np.floating]
     r"""Crown shape parameter (:math:`n`, -)"""
-    f_g: NDArray[np.float64]
+    f_g: NDArray[np.floating]
     r"""Crown gap fraction (:math:`f_g`, -)"""
-    q_m: NDArray[np.float64]
+    q_m: NDArray[np.floating]
     """Scaling factor to derive maximum crown radius from crown area."""
-    z_max_prop: NDArray[np.float64]
+    z_max_prop: NDArray[np.floating]
     """Proportion of stem height at which maximum crown radius is found."""
 
-    p_foliage_for_reproductive_tissue: NDArray[np.float64]
+    p_foliage_for_reproductive_tissue: NDArray[np.floating]
     """Proportion of foliage used to calculate reproductive tissue."""
-    gpp_topslice: NDArray[np.float64]
+    gpp_topslice: NDArray[np.floating]
     """Proportion of GPP to topslice before allocation."""
 
     validate: bool = True

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -37,11 +37,11 @@ def _enforce_positive_sizes(size_args: dict[str, NDArray], function_name: str) -
 
 
 def calculate_heights(
-    h_max: NDArray[np.float64],
-    a_hd: NDArray[np.float64],
-    dbh: NDArray[np.float64],
+    h_max: NDArray[np.floating],
+    a_hd: NDArray[np.floating],
+    dbh: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate tree height under the T Model.
 
     The height of trees (:math:`H`) are calculated from individual diameters at breast
@@ -71,11 +71,11 @@ def calculate_heights(
 
 
 def calculate_dbh_from_height(
-    h_max: NDArray[np.float64],
-    a_hd: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
+    h_max: NDArray[np.floating],
+    a_hd: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate diameter at breast height from stem height under the T Model.
 
     This function inverts the normal calculation of stem height (:math:`H`) from
@@ -125,12 +125,12 @@ def calculate_dbh_from_height(
 
 
 def calculate_crown_areas(
-    ca_ratio: NDArray[np.float64],
-    a_hd: NDArray[np.float64],
-    dbh: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
+    ca_ratio: NDArray[np.floating],
+    a_hd: NDArray[np.floating],
+    dbh: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate tree crown area under the T Model.
 
     The tree crown area (:math:`A_{c}`) is calculated from individual diameters at
@@ -165,11 +165,11 @@ def calculate_crown_areas(
 
 
 def calculate_crown_fractions(
-    a_hd: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    dbh: NDArray[np.float64],
+    a_hd: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    dbh: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate tree crown fraction under the T Model.
 
     The crown fraction (:math:`f_{c}`) is calculated from individual diameters at breast
@@ -201,11 +201,11 @@ def calculate_crown_fractions(
 
 
 def calculate_stem_masses(
-    rho_s: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    dbh: NDArray[np.float64],
+    rho_s: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    dbh: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate stem mass under the T Model.
 
     The stem mass (:math:`W_{s}`) is calculated from individual diameters at breast
@@ -235,11 +235,11 @@ def calculate_stem_masses(
 
 
 def calculate_foliage_masses(
-    sla: NDArray[np.float64],
-    lai: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
+    sla: NDArray[np.floating],
+    lai: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate foliage mass under the T Model.
 
     The foliage mass (:math:`W_{f}`) is calculated from the crown area (:math:`A_{c}`),
@@ -269,13 +269,13 @@ def calculate_foliage_masses(
 
 
 def calculate_sapwood_masses(
-    rho_s: NDArray[np.float64],
-    ca_ratio: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
-    crown_fraction: NDArray[np.float64],
+    rho_s: NDArray[np.floating],
+    ca_ratio: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    crown_fraction: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate sapwood mass under the T Model.
 
     The sapwood mass (:math:`W_{\cdot s}`) is calculated from the individual crown area
@@ -315,10 +315,10 @@ def calculate_sapwood_masses(
 
 
 def calculate_crown_z_max(
-    z_max_prop: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
+    z_max_prop: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate height of maximum crown radius.
 
     The height of the maximum crown radius (:math:`z_m`) is derived from the crown
@@ -353,10 +353,10 @@ def calculate_crown_z_max(
 
 
 def calculate_crown_r0(
-    q_m: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
+    q_m: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate scaling factor for width of maximum crown radius.
 
     This scaling factor (:math:`r_0`) is derived from the crown shape parameters
@@ -390,12 +390,12 @@ def calculate_crown_r0(
 
 
 def calculate_whole_crown_gpp(
-    potential_gpp: NDArray[np.float64],
-    crown_area: NDArray[np.float64],
-    par_ext: NDArray[np.float64],
-    lai: NDArray[np.float64],
+    potential_gpp: NDArray[np.floating],
+    crown_area: NDArray[np.floating],
+    par_ext: NDArray[np.floating],
+    lai: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate whole crown gross primary productivity.
 
     This function calculates individual gross primary productivity (GPP) across the
@@ -428,10 +428,10 @@ def calculate_whole_crown_gpp(
 
 
 def calculate_sapwood_respiration(
-    resp_s: NDArray[np.float64],
-    sapwood_mass: NDArray[np.float64],
+    resp_s: NDArray[np.floating],
+    sapwood_mass: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate sapwood respiration.
 
     Calculates the total sapwood respiration (:math:`R_{\cdot s}`) given the individual
@@ -459,10 +459,10 @@ def calculate_sapwood_respiration(
 
 
 def calculate_foliar_respiration(
-    resp_f: NDArray[np.float64],
-    whole_crown_gpp: NDArray[np.float64],
+    resp_f: NDArray[np.floating],
+    whole_crown_gpp: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate foliar respiration.
 
     Calculates the total foliar respiration (:math:`R_{f}`) given the individual crown
@@ -492,10 +492,10 @@ def calculate_foliar_respiration(
 
 
 def calculate_gpp_topslice(
-    gpp_topslice: NDArray[np.float64],
-    whole_crown_gpp: NDArray[np.float64],
+    gpp_topslice: NDArray[np.floating],
+    whole_crown_gpp: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate gpp topslice.
 
     Calculates a fixed proportion of the total GPP for the crown that is removed before
@@ -526,10 +526,10 @@ def calculate_gpp_topslice(
 
 
 def calculate_reproductive_tissue_respiration(
-    resp_rt: NDArray[np.float64],
-    reproductive_tissue_mass: NDArray[np.float64],
+    resp_rt: NDArray[np.floating],
+    reproductive_tissue_mass: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate reproductive tissue respiration.
 
     Calculates the total reproductive tissue respiration (:math:`R_{rt}`) given the
@@ -560,12 +560,12 @@ def calculate_reproductive_tissue_respiration(
 
 
 def calculate_fine_root_respiration(
-    zeta: NDArray[np.float64],
-    sla: NDArray[np.float64],
-    resp_r: NDArray[np.float64],
-    foliage_mass: NDArray[np.float64],
+    zeta: NDArray[np.floating],
+    sla: NDArray[np.floating],
+    resp_r: NDArray[np.floating],
+    foliage_mass: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate fine root respiration.
 
     Calculates the total fine root respiration (:math:`R_{r}`) given the individual
@@ -597,14 +597,14 @@ def calculate_fine_root_respiration(
 
 
 def calculate_net_primary_productivity(
-    yld: NDArray[np.float64],
-    whole_crown_gpp: NDArray[np.float64],
-    foliar_respiration: NDArray[np.float64],
-    fine_root_respiration: NDArray[np.float64],
-    sapwood_respiration: NDArray[np.float64],
-    reproductive_tissue_respiration: NDArray[np.float64],
+    yld: NDArray[np.floating],
+    whole_crown_gpp: NDArray[np.floating],
+    foliar_respiration: NDArray[np.floating],
+    fine_root_respiration: NDArray[np.floating],
+    sapwood_respiration: NDArray[np.floating],
+    reproductive_tissue_respiration: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate net primary productivity.
 
     The net primary productivity (NPP, :math:`P_{net}`) is calculated as a plant
@@ -667,10 +667,10 @@ def calculate_net_primary_productivity(
 
 
 def calculate_foliage_turnover(
-    tau_f: NDArray[np.float64],
-    foliage_mass: NDArray[np.float64],
+    tau_f: NDArray[np.floating],
+    foliage_mass: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate turnover costs for foliage.
 
     This function calculates the costs associated with the turnover of foliage. This is
@@ -701,12 +701,12 @@ def calculate_foliage_turnover(
 
 
 def calculate_fine_root_turnover(
-    sla: NDArray[np.float64],
-    zeta: NDArray[np.float64],
-    tau_r: NDArray[np.float64],
-    foliage_mass: NDArray[np.float64],
+    sla: NDArray[np.floating],
+    zeta: NDArray[np.floating],
+    tau_r: NDArray[np.floating],
+    foliage_mass: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate turnover costs.
 
     This function calculates the costs associated with the turnover of fine roots. This
@@ -739,10 +739,10 @@ def calculate_fine_root_turnover(
 
 
 def calculate_reproductive_tissue_turnover(
-    reproductive_tissue_mass: NDArray[np.float64],
-    tau_rt: NDArray[np.float64],
+    reproductive_tissue_mass: NDArray[np.floating],
+    tau_rt: NDArray[np.floating],
     validate: bool = True,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate reproductive tissue turnover costs.
 
     This function calculates the costs associated with the turnover of reproductive
@@ -771,9 +771,9 @@ def calculate_reproductive_tissue_turnover(
 
 
 def calculate_reproductive_tissue_mass(
-    foliage_mass: NDArray[np.float64],
-    p_foliage_for_reproductive_tissue: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    foliage_mass: NDArray[np.floating],
+    p_foliage_for_reproductive_tissue: NDArray[np.floating],
+) -> NDArray[np.floating]:
     r"""Calculate reproductive tissue mass.
 
     This function calculates the mass of reproductive tissue (:math:`m_{rt}`) as a fixed
@@ -794,21 +794,21 @@ def calculate_reproductive_tissue_mass(
 
 
 def calculate_growth_increments(
-    rho_s: NDArray[np.float64],
-    a_hd: NDArray[np.float64],
-    h_max: NDArray[np.float64],
-    lai: NDArray[np.float64],
-    ca_ratio: NDArray[np.float64],
-    sla: NDArray[np.float64],
-    zeta: NDArray[np.float64],
-    npp: NDArray[np.float64],
-    turnover: NDArray[np.float64],
-    reproductive_tissue_turnover: NDArray[np.float64],
-    p_foliage_for_reproductive_tissue: NDArray[np.float64],
-    dbh: NDArray[np.float64],
-    stem_height: NDArray[np.float64],
+    rho_s: NDArray[np.floating],
+    a_hd: NDArray[np.floating],
+    h_max: NDArray[np.floating],
+    lai: NDArray[np.floating],
+    ca_ratio: NDArray[np.floating],
+    sla: NDArray[np.floating],
+    zeta: NDArray[np.floating],
+    npp: NDArray[np.floating],
+    turnover: NDArray[np.floating],
+    reproductive_tissue_turnover: NDArray[np.floating],
+    p_foliage_for_reproductive_tissue: NDArray[np.floating],
+    dbh: NDArray[np.floating],
+    stem_height: NDArray[np.floating],
     validate: bool = True,
-) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
     r"""Calculate growth increments.
 
     Given an estimate of net primary productivity (NPP, :math:`P_{net}`), less
@@ -1000,32 +1000,32 @@ class StemAllometry(PandasExporter, CohortMethods):
     """ An instance of :class:`~pyrealm.demography.flora.Flora` or 
     :class:`~pyrealm.demography.flora.StemTraits`, providing plant functional trait data
     for a set of stems."""
-    at_dbh: InitVar[NDArray[np.float64]]
+    at_dbh: InitVar[NDArray[np.floating]]
     """An array of diameter at breast height values at which to predict stem allometry 
     values."""
     validate: InitVar[bool] = True
     """Boolean flag to suppress argument validation."""
 
     # Post init allometry attributes
-    dbh: NDArray[np.float64] = field(init=False)
+    dbh: NDArray[np.floating] = field(init=False)
     """Diameter at breast height (m)"""
-    stem_height: NDArray[np.float64] = field(init=False)
+    stem_height: NDArray[np.floating] = field(init=False)
     """Stem height (m)"""
-    crown_area: NDArray[np.float64] = field(init=False)
+    crown_area: NDArray[np.floating] = field(init=False)
     """Crown area (m2)"""
-    crown_fraction: NDArray[np.float64] = field(init=False)
+    crown_fraction: NDArray[np.floating] = field(init=False)
     """Vertical fraction of the stem covered by the crown (-)"""
-    stem_mass: NDArray[np.float64] = field(init=False)
+    stem_mass: NDArray[np.floating] = field(init=False)
     """Stem mass (kg)"""
-    foliage_mass: NDArray[np.float64] = field(init=False)
+    foliage_mass: NDArray[np.floating] = field(init=False)
     """Foliage mass (kg)"""
-    reproductive_tissue_mass: NDArray[np.float64] = field(init=False)
+    reproductive_tissue_mass: NDArray[np.floating] = field(init=False)
     """Reproductive tissue mass (kg)"""
-    sapwood_mass: NDArray[np.float64] = field(init=False)
+    sapwood_mass: NDArray[np.floating] = field(init=False)
     """Sapwood mass (kg)"""
-    crown_r0: NDArray[np.float64] = field(init=False)
+    crown_r0: NDArray[np.floating] = field(init=False)
     """Crown radius scaling factor (-)"""
-    crown_z_max: NDArray[np.float64] = field(init=False)
+    crown_z_max: NDArray[np.floating] = field(init=False)
     """Height of maximum crown radius (m)"""
 
     # Information attributes
@@ -1039,7 +1039,7 @@ class StemAllometry(PandasExporter, CohortMethods):
     def __post_init__(
         self,
         stem_traits: Flora | StemTraits,
-        at_dbh: NDArray[np.float64],
+        at_dbh: NDArray[np.floating],
         validate: bool,
     ) -> None:
         """Populate the stem allometry attributes from the traits and size data."""
@@ -1169,38 +1169,38 @@ class StemAllocation(PandasExporter):
     stem_allometry: InitVar[StemAllometry]
     """An instance of :class:`~pyrealm.demography.tmodel.StemAllometry`
     providing the stem size data for which to calculate allocation."""
-    whole_crown_gpp: NDArray[np.float64]
+    whole_crown_gpp: NDArray[np.floating]
     """An array of gross primary productivity values (kg C) across the whole of the
     crown of each stem to be allocated to respiration, turnover and growth."""
     validate: InitVar[bool] = True
     """ Boolean flag to suppress argument validation."""
 
     # Post init allometry attributes
-    topslice_whole_crown_gpp: NDArray[np.float64] = field(init=False)
+    topslice_whole_crown_gpp: NDArray[np.floating] = field(init=False)
     """The available stem GPP after any topslicing (g C)"""
-    sapwood_respiration: NDArray[np.float64] = field(init=False)
+    sapwood_respiration: NDArray[np.floating] = field(init=False)
     """Allocation to sapwood respiration (g C)"""
-    foliar_respiration: NDArray[np.float64] = field(init=False)
+    foliar_respiration: NDArray[np.floating] = field(init=False)
     """Allocation to foliar respiration (g C)"""
-    reproductive_tissue_respiration: NDArray[np.float64] = field(init=False)
+    reproductive_tissue_respiration: NDArray[np.floating] = field(init=False)
     """Allocation to reproductive tissue respiration (g C)"""
-    fine_root_respiration: NDArray[np.float64] = field(init=False)
+    fine_root_respiration: NDArray[np.floating] = field(init=False)
     """Allocation to fine root respiration (g C)"""
-    gpp_topslice: NDArray[np.float64] = field(init=False)
+    gpp_topslice: NDArray[np.floating] = field(init=False)
     """GPP removed before allocation for various biological functions (g C)"""
-    npp: NDArray[np.float64] = field(init=False)
+    npp: NDArray[np.floating] = field(init=False)
     """Net primary productivity (g C)"""
-    leaf_turnover: NDArray[np.float64] = field(init=False)
+    leaf_turnover: NDArray[np.floating] = field(init=False)
     """Allocation to leaf turnover (g C)"""
-    fine_root_turnover: NDArray[np.float64] = field(init=False)
+    fine_root_turnover: NDArray[np.floating] = field(init=False)
     """Allocation to fine root turnover"""
-    reproductive_tissue_turnover: NDArray[np.float64] = field(init=False)
+    reproductive_tissue_turnover: NDArray[np.floating] = field(init=False)
     """Allocation to reproductive tissue turnover (g C)"""
-    delta_dbh: NDArray[np.float64] = field(init=False)
+    delta_dbh: NDArray[np.floating] = field(init=False)
     """Predicted increase in stem diameter from growth allocation (m)"""
-    delta_stem_mass: NDArray[np.float64] = field(init=False)
+    delta_stem_mass: NDArray[np.floating] = field(init=False)
     """Predicted increase in stem mass from growth allocation (g C)"""
-    delta_foliage_mass: NDArray[np.float64] = field(init=False)
+    delta_foliage_mass: NDArray[np.floating] = field(init=False)
     """Predicted increase in foliar mass from growth allocation (g C)"""
 
     # Information attributes

--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -24,7 +24,9 @@ from pyrealm.demography.core import (
 from pyrealm.demography.flora import Flora, StemTraits
 
 
-def _enforce_positive_sizes(size_args: dict[str, NDArray], function_name: str) -> None:
+def _enforce_positive_sizes(
+    size_args: dict[str, NDArray[np.floating]], function_name: str
+) -> None:
     """Simple function to trap allometry inputs that are not strictly positive."""
 
     failing = [vname for vname, values in size_args.items() if np.any(values <= 0)]

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -94,13 +94,13 @@ class FaparLimitation:
 
     def __init__(
         self,
-        annual_total_potential_gpp: NDArray[np.float64],
-        annual_mean_ca: NDArray[np.float64],
-        annual_mean_chi: NDArray[np.float64],
-        annual_mean_vpd: NDArray[np.float64],
-        annual_total_precip: NDArray[np.float64],
-        annual_growing_season_length: NDArray[np.float64],
-        aridity_index: NDArray[np.float64],
+        annual_total_potential_gpp: NDArray[np.floating],
+        annual_mean_ca: NDArray[np.floating],
+        annual_mean_chi: NDArray[np.floating],
+        annual_mean_vpd: NDArray[np.floating],
+        annual_total_precip: NDArray[np.floating],
+        annual_growing_season_length: NDArray[np.floating],
+        aridity_index: NDArray[np.floating],
         phenology_const: PhenologyConst = PhenologyConst(),
     ) -> None:
         # Experimental class
@@ -178,10 +178,10 @@ class FaparLimitation:
         cls,
         pmodel: PModelABC,
         growing_season: NDArray[np.bool],
-        precip: NDArray[np.float64],
-        aridity_index: NDArray[np.float64],
+        precip: NDArray[np.floating],
+        aridity_index: NDArray[np.floating],
         datetimes: NDArray[np.datetime64] | None = None,
-        gpp_penalty_factor: NDArray[np.float64] | None = None,
+        gpp_penalty_factor: NDArray[np.floating] | None = None,
         phenology_const: PhenologyConst = PhenologyConst(),
     ) -> Self:
         r"""Create a FaparLimitation instance from a P Model and other inputs.

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -416,7 +416,7 @@ class AcclimationModel:
                 "are used for acclimation"
             )
 
-    def _pad_values(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+    def _pad_values(self, values: NDArray[np.floating]) -> NDArray[np.floating]:
         """Pad values array to full days.
 
         This method takes an array representing daily values and pads the first and
@@ -438,7 +438,7 @@ class AcclimationModel:
 
         return np.pad(values, padding_dims, constant_values=(np.nan, np.nan))
 
-    def get_window_values(self, values: NDArray[np.float64]) -> NDArray[np.float64]:
+    def get_window_values(self, values: NDArray[np.floating]) -> NDArray[np.floating]:
         """Extract acclimation window values for a variable.
 
         This method takes an array of values which has the same shape along the first
@@ -476,8 +476,8 @@ class AcclimationModel:
 
     def get_daily_means(
         self,
-        values: NDArray[np.float64],
-    ) -> NDArray[np.float64]:
+        values: NDArray[np.floating],
+    ) -> NDArray[np.floating]:
         """Get the daily means of a variable during the acclimation window.
 
         This method extracts values from a given variable during a defined acclimation
@@ -513,9 +513,9 @@ class AcclimationModel:
 
     def apply_acclimation(
         self,
-        values: NDArray[np.float64],
-        initial_values: NDArray[np.float64] | None = None,
-    ) -> NDArray[np.float64]:
+        values: NDArray[np.floating],
+        initial_values: NDArray[np.floating] | None = None,
+    ) -> NDArray[np.floating]:
         r"""Apply acclimation to optimal values.
 
         Three key photosynthetic parameters (:math:`\xi`, :math:`V_{cmax25}` and
@@ -562,9 +562,9 @@ class AcclimationModel:
 
     def fill_daily_to_subdaily(
         self,
-        values: NDArray[np.float64],
-        previous_values: NDArray[np.float64] | None = None,
-    ) -> NDArray[np.float64]:
+        values: NDArray[np.floating],
+        previous_values: NDArray[np.floating] | None = None,
+    ) -> NDArray[np.floating]:
         """Resample daily variables onto the subdaily time scale.
 
         This method takes an array representing daily values and interpolates those
@@ -634,12 +634,12 @@ class AcclimationModel:
 
     def _get_subdaily_interpolation_xy(
         self,
-        values: NDArray[np.float64],
-        previous_values: NDArray[np.float64] | None = None,
+        values: NDArray[np.floating],
+        previous_values: NDArray[np.floating] | None = None,
     ) -> tuple[
         NDArray[np.datetime64],
-        NDArray[np.float64],
-        tuple[NDArray[np.float64] | None, NDArray[np.float64] | None],
+        NDArray[np.floating],
+        tuple[NDArray[np.floating] | None, NDArray[np.floating] | None],
     ]:
         """Generate the interpolation data used to fill subdaily values.
 

--- a/pyrealm/pmodel/arrhenius.py
+++ b/pyrealm/pmodel/arrhenius.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.core.experimental import warn_experimental
@@ -84,10 +85,10 @@ class ArrheniusFactorABC(ABC):
         self._check_required_env_variables()
 
     @abstractmethod
-    def _calculation_method(self, coefficients: dict) -> NDArray:
+    def _calculation_method(self, coefficients: dict) -> NDArray[np.floating]:
         pass
 
-    def calculate_arrhenius_factor(self, coefficients: dict) -> NDArray:
+    def calculate_arrhenius_factor(self, coefficients: dict) -> NDArray[np.floating]:
         """Calculate the Arrhenius factor.
 
         This method calculates the Arrhenius factor for the model environment, given a
@@ -177,7 +178,7 @@ class SimpleArrhenius(
         array([0.63795])
     """
 
-    def _calculation_method(self, coefficients: dict) -> NDArray:
+    def _calculation_method(self, coefficients: dict) -> NDArray[np.floating]:
         return calculate_simple_arrhenius_factor(
             tk=self.env.tk,
             tk_ref=self.env.pmodel_const.tk_ref,
@@ -230,7 +231,7 @@ class KattgeKnorrArrhenius(
 
     __experimental__ = True
 
-    def _calculation_method(self, coefficients: dict) -> NDArray:
+    def _calculation_method(self, coefficients: dict) -> NDArray[np.floating]:
         warn_experimental("KattgeKnorrArrhenius")
 
         return calculate_kattge_knorr_arrhenius_factor(

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -13,10 +13,10 @@ from pyrealm.core.utilities import check_input_shapes, summarize_attrs
 
 
 def convert_gpp_advantage_to_c4_fraction(
-    gpp_adv_c4: NDArray[np.float64],
-    treecover: NDArray[np.float64],
+    gpp_adv_c4: NDArray[np.floating],
+    treecover: NDArray[np.floating],
     c3c4_const: C3C4Const = C3C4Const(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Convert C4 GPP advantage to C4 fraction.
 
     This function calculates an initial estimate of the fraction of C4 plants based on
@@ -63,8 +63,8 @@ def convert_gpp_advantage_to_c4_fraction(
 
 
 def calculate_tree_proportion(
-    gppc3: NDArray[np.float64], c3c4_const: C3C4Const = C3C4Const()
-) -> NDArray[np.float64]:
+    gppc3: NDArray[np.floating], c3c4_const: C3C4Const = C3C4Const()
+) -> NDArray[np.floating]:
     r"""Calculate the proportion of GPP from C3 trees.
 
     This function estimates the proportion of C3 trees in the community, which can then
@@ -186,9 +186,9 @@ class C3C4Competition:
 
     def __init__(
         self,
-        gpp_c3: NDArray[np.float64],
-        gpp_c4: NDArray[np.float64],
-        treecover: NDArray[np.float64],
+        gpp_c3: NDArray[np.floating],
+        gpp_c4: NDArray[np.floating],
+        treecover: NDArray[np.floating],
         below_t_min: NDArray[np.bool],
         cropland: NDArray[np.bool],
         c3c4_const: C3C4Const = C3C4Const(),
@@ -205,7 +205,7 @@ class C3C4Competition:
         # annual total GPP estimates for C3 and C4 plants. This uses use
         # np.full to handle division by zero without raising warnings
         gpp_adv_c4 = np.full(self.shape, np.nan)
-        self.gpp_adv_c4: NDArray[np.float64] = np.divide(
+        self.gpp_adv_c4: NDArray[np.floating] = np.divide(
             gpp_c4 - gpp_c3, gpp_c3, out=gpp_adv_c4, where=gpp_c3 > 0
         )
         """The proportional advantage in GPP of C4 over C3 plants"""
@@ -233,22 +233,22 @@ class C3C4Competition:
         cropland = np.broadcast_to(cropland, self.shape)
         frac_c4[cropland] = np.nan  # type: ignore
 
-        self.frac_c4: NDArray[np.float64] = frac_c4
+        self.frac_c4: NDArray[np.floating] = frac_c4
         """The estimated fraction of C4 plants."""
 
-        self.gpp_c3_contrib: NDArray[np.float64] = gpp_c3 * (1 - self.frac_c4)
+        self.gpp_c3_contrib: NDArray[np.floating] = gpp_c3 * (1 - self.frac_c4)
         """The estimated contribution of C3 plants to GPP (gC m-2 yr-1)"""
         self.gpp_c4_contrib = gpp_c4 * self.frac_c4
         """The estimated contribution of C4 plants to GPP (gC m-2 yr-1)"""
 
         # Define attributes used elsewhere
-        self.Delta13C_C3: NDArray[np.float64]
+        self.Delta13C_C3: NDArray[np.floating]
         r"""Contribution from C3 plants to (:math:`\Delta\ce{^13C}`, permil)."""
-        self.Delta13C_C4: NDArray[np.float64]
+        self.Delta13C_C4: NDArray[np.floating]
         r"""Contribution from C4 plants to (:math:`\Delta\ce{^13C}`, permil)."""
-        self.d13C_C3: NDArray[np.float64]
+        self.d13C_C3: NDArray[np.floating]
         r"""Contribution from C3 plants to (:math:`d\ce{^13C}`, permil)."""
-        self.d13C_C4: NDArray[np.float64]
+        self.d13C_C4: NDArray[np.floating]
         r"""Contribution from C3 plants to (:math:`d\ce{^13C}`, permil)."""
 
     def __repr__(self) -> str:
@@ -257,9 +257,9 @@ class C3C4Competition:
 
     def estimate_isotopic_discrimination(
         self,
-        d13CO2: NDArray[np.float64],
-        Delta13C_C3_alone: NDArray[np.float64],
-        Delta13C_C4_alone: NDArray[np.float64],
+        d13CO2: NDArray[np.floating],
+        Delta13C_C3_alone: NDArray[np.floating],
+        Delta13C_C4_alone: NDArray[np.floating],
     ) -> None:
         r"""Estimate CO2 isotopic discrimination values.
 

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -12,11 +12,11 @@ from pyrealm.core.water import calc_viscosity_h2o
 
 
 def calculate_simple_arrhenius_factor(
-    tk: NDArray[np.float64],
+    tk: NDArray[np.floating],
     tk_ref: float,
     ha: float,
     k_R: float = CoreConst().k_R,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate an Arrhenius scaling factor using activation energy.
 
     Calculates the temperature-scaling factor :math:`f` for enzyme kinetics following
@@ -65,12 +65,12 @@ def calculate_simple_arrhenius_factor(
 
 
 def calculate_kattge_knorr_arrhenius_factor(
-    tk_leaf: NDArray[np.float64],
+    tk_leaf: NDArray[np.floating],
     tk_ref: float,
-    tc_growth: NDArray[np.float64],
+    tc_growth: NDArray[np.floating],
     coef: dict[str, float],
     k_R: float = CoreConst().k_R,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate an Arrhenius factor following :cite:t:`Kattge:2007db`.
 
     This implements a "peaked" version of the Arrhenius relationship, describing a
@@ -157,10 +157,10 @@ def calculate_kattge_knorr_arrhenius_factor(
 
 
 def calc_ftemp_inst_rd(
-    tc: NDArray[np.float64],
+    tc: NDArray[np.floating],
     tc_ref: float = PModelConst().tc_ref,
     coef: tuple[float, float] = PModelConst().heskel_rd,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate temperature scaling of dark respiration.
 
     Calculates the temperature-scaling factor for dark respiration at a given
@@ -197,13 +197,13 @@ def calc_ftemp_inst_rd(
 
 
 def calc_gammastar(
-    tk: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tk: NDArray[np.floating],
+    patm: NDArray[np.floating],
     tk_ref: float = PModelConst().tk_ref,
     k_Po: float = CoreConst().k_Po,
     k_R: float = CoreConst().k_R,
     coef: dict[str, float] = PModelConst().bernacchi_gs,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the photorespiratory CO2 compensation point.
 
     Calculates the photorespiratory **CO2 compensation point** in absence of dark
@@ -254,10 +254,10 @@ def calc_gammastar(
 
 
 def calc_ns_star(
-    tc: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tc: NDArray[np.floating],
+    patm: NDArray[np.floating],
     core_const: CoreConst = CoreConst(),
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the relative viscosity of water.
 
     Calculates the relative viscosity of water (:math:`\eta^*`), given the standard
@@ -298,13 +298,13 @@ def calc_ns_star(
 
 
 def calc_kmm(
-    tk: NDArray[np.float64],
-    patm: NDArray[np.float64],
+    tk: NDArray[np.floating],
+    patm: NDArray[np.floating],
     tk_ref: float = PModelConst().tk_ref,
     k_co: float = CoreConst().k_co,
     k_R: float = CoreConst().k_R,
     coef: dict[str, float] = PModelConst().bernacchi_kmm,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the Michaelis Menten coefficient of Rubisco-limited assimilation.
 
     Calculates the Michaelis Menten coefficient of Rubisco-limited assimilation
@@ -368,10 +368,10 @@ def calc_kmm(
 
 
 def calc_soilmstress_stocker(
-    soilm: NDArray[np.float64],
-    meanalpha: NDArray[np.float64] = np.array(1.0),
+    soilm: NDArray[np.floating],
+    meanalpha: NDArray[np.floating] = np.array(1.0),
     coef: dict[str, float] = PModelConst().soilmstress_stocker,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate Stocker's empirical soil moisture stress factor.
 
     This function calculates a penalty factor :math:`\beta(\theta)` for well-watered GPP
@@ -480,10 +480,10 @@ def calc_soilmstress_stocker(
 
 
 def calc_soilmstress_mengoli(
-    soilm: NDArray[np.float64] = np.array(1.0),
-    aridity_index: NDArray[np.float64] = np.array(1.0),
+    soilm: NDArray[np.floating] = np.array(1.0),
+    aridity_index: NDArray[np.floating] = np.array(1.0),
     coef: dict[str, float] = PModelConst().soilmstress_mengoli,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the Mengoli et al. empirical soil moisture stress factor.
 
     This function calculates a penalty factor :math:`\beta(\theta)` for well-watered GPP
@@ -579,8 +579,8 @@ def calc_soilmstress_mengoli(
 
 
 def calc_co2_to_ca(
-    co2: NDArray[np.float64], patm: NDArray[np.float64]
-) -> NDArray[np.float64]:
+    co2: NDArray[np.floating], patm: NDArray[np.floating]
+) -> NDArray[np.floating]:
     r"""Convert :math:`\ce{CO2}` ppm to Pa.
 
     Converts ambient :math:`\ce{CO2}` (:math:`c_a`) in part per million to Pascals,

--- a/pyrealm/pmodel/isotopes.py
+++ b/pyrealm/pmodel/isotopes.py
@@ -43,8 +43,8 @@ class CalcCarbonIsotopes:
     def __init__(
         self,
         pmodel: PModel,
-        D14CO2: NDArray[np.float64],
-        d13CO2: NDArray[np.float64],
+        D14CO2: NDArray[np.floating],
+        d13CO2: NDArray[np.floating],
         isotopes_const: IsotopesConst = IsotopesConst(),
     ):
         # Check inputs are congruent
@@ -58,22 +58,22 @@ class CalcCarbonIsotopes:
         """Indicates if estimates calculated for C3 or C4 photosynthesis."""
 
         # Attributes defined by methods below
-        self.Delta13C_simple: NDArray[np.float64]
+        self.Delta13C_simple: NDArray[np.floating]
         r"""Discrimination against carbon 13 (:math:`\Delta\ce{^{13}C}`, permil)
         excluding photorespiration."""
-        self.Delta14C: NDArray[np.float64]
+        self.Delta14C: NDArray[np.floating]
         r"""Discrimination against carbon 13 (:math:`\Delta\ce{^{13}C}`, permil)
         including photorespiration."""
-        self.Delta13C: NDArray[np.float64]
+        self.Delta13C: NDArray[np.floating]
         r"""Discrimination against carbon 14 (:math:`\Delta\ce{^{14}C}`, permil)
         including photorespiration."""
-        self.d13C_leaf: NDArray[np.float64]
+        self.d13C_leaf: NDArray[np.floating]
         r"""Isotopic ratio of carbon 13 in leaves
         (:math:`\delta\ce{^{13}C}`, permil)."""
-        self.d14C_leaf: NDArray[np.float64]
+        self.d14C_leaf: NDArray[np.floating]
         r"""Isotopic ratio of carbon 14 in leaves
         (:math:`\delta\ce{^{14}C}`, permil)."""
-        self.d13C_wood: NDArray[np.float64]
+        self.d13C_wood: NDArray[np.floating]
         r"""Isotopic ratio of carbon 13 in wood (:math:`\delta\ce{^{13}C}`, permil),
         given a parameterized post-photosynthetic fractionation."""
 

--- a/pyrealm/pmodel/jmax_limitation.py
+++ b/pyrealm/pmodel/jmax_limitation.py
@@ -65,9 +65,9 @@ class JmaxLimitationABC(metaclass=ABCMeta):
     """The PModel constants instance used for the calculation."""
     _shape: tuple[int, ...] = field(init=False)
     """Records the common numpy array shape in the data."""
-    f_j: NDArray[np.float64] = field(init=False)
+    f_j: NDArray[np.floating] = field(init=False)
     """:math:`J_{max}` limitation factor."""
-    f_v: NDArray[np.float64] = field(init=False)
+    f_v: NDArray[np.floating] = field(init=False)
     """:math:`V_{cmax}` limitation factor."""
 
     def __post_init__(self) -> None:
@@ -229,9 +229,9 @@ class JmaxLimitationSmith19(
         array([0.7544])
     """
 
-    omega: NDArray[np.float64] = field(init=False)
+    omega: NDArray[np.floating] = field(init=False)
     """Values of the `omega` parameter (:cite:`Smith:2019dv`)."""
-    omega_star: NDArray[np.float64] = field(init=False)
+    omega_star: NDArray[np.floating] = field(init=False)
     """Values of the `omega_star` parameter (:cite:`Smith:2019dv`)."""
 
     def _calculate_limitation_terms(self) -> None:

--- a/pyrealm/pmodel/optimal_chi.py
+++ b/pyrealm/pmodel/optimal_chi.py
@@ -106,23 +106,23 @@ class OptimalChiABC(ABC):
         # default value as they must be populated by the set_beta and estimate_chi
         # methods, which are called below, and so will be populated before __init__
         # returns.
-        self.beta: NDArray[np.float64]
+        self.beta: NDArray[np.floating]
         """The ratio of carboxylation to transpiration cost factors."""
-        self.xi: NDArray[np.float64]
+        self.xi: NDArray[np.floating]
         r"""Defines the sensitivity of :math:`\chi` to the vapour pressure deficit,
         related to the carbon cost of water (Medlyn et al. 2011; Prentice et 2014)."""
-        self.chi: NDArray[np.float64]
+        self.chi: NDArray[np.floating]
         r"""The ratio of leaf internal to ambient :math:`\ce{CO2}` partial pressure
         (:math:`\chi`)."""
-        self.mc: NDArray[np.float64]
+        self.mc: NDArray[np.floating]
         r""":math:`\ce{CO2}` limitation factor for RuBisCO-limited assimilation
         (:math:`m_c`)."""
-        self.mj: NDArray[np.float64]
+        self.mj: NDArray[np.floating]
         r""":math:`\ce{CO2}` limitation factor for light-limited assimilation
         (:math:`m_j`)."""
-        self.ci: NDArray[np.float64]
+        self.ci: NDArray[np.floating]
         r"""The leaf internal :math:`\ce{CO2}` partial pressure (:math:`c_i`)."""
-        self.mjoc: NDArray[np.float64]
+        self.mjoc: NDArray[np.floating]
         r"""Ratio of :math:`m_j/m_c`."""
 
         # Run the calculation methods after checking for any required variables
@@ -140,7 +140,7 @@ class OptimalChiABC(ABC):
         """Set the beta values."""
 
     @abstractmethod
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate xi, chi and other variables."""
 
     def _check_requires(self) -> None:
@@ -247,7 +247,7 @@ class OptimalChiPrentice14(
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
         self.beta = self.pmodel_const.beta_cost_ratio_c3
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C3 plants."""
 
         if xi_values is not None:
@@ -315,7 +315,7 @@ class OptimalChiPrentice14RootzoneStress(
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
         self.beta = self.pmodel_const.beta_cost_ratio_c3
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C3 plants."""
 
         if xi_values is not None:
@@ -379,7 +379,7 @@ class OptimalChiC4(
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
         self.beta = self.pmodel_const.beta_cost_ratio_c4
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C4 plants, setting ``mj`` and ``mc`` to 1."""
         if xi_values is not None:
             _ = check_input_shapes(self.env.ca, xi_values)
@@ -447,7 +447,7 @@ class OptimalChiC4RootzoneStress(
         # leaf-internal-to-ambient CO2 partial pressure (ci/ca) ratio
         self.beta = self.pmodel_const.beta_cost_ratio_c4
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C4 plants, setting ``mj`` and ``mc`` to 1."""
         if xi_values is not None:
             _ = check_input_shapes(self.env.ca, xi_values)
@@ -533,7 +533,7 @@ class OptimalChiLavergne20C3(
             + self.pmodel_const.lavergne_2020_c3[0]
         )
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C3 plants."""
 
         if xi_values is not None:
@@ -625,7 +625,7 @@ class OptimalChiLavergne20C4(
             + self.pmodel_const.lavergne_2020_c4[0]
         )
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C4 plants excluding photorespiration."""
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
@@ -699,7 +699,7 @@ class OptimalChiC4NoGamma(
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
         self.beta = self.pmodel_const.beta_cost_ratio_c4
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C4 plants excluding photorespiration."""
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
@@ -773,7 +773,7 @@ class OptimalChiC4NoGammaRootzoneStress(
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.
         self.beta = self.pmodel_const.beta_cost_ratio_c4
 
-    def estimate_chi(self, xi_values: NDArray[np.float64] | None = None) -> None:
+    def estimate_chi(self, xi_values: NDArray[np.floating] | None = None) -> None:
         """Estimate ``chi`` for C4 plants excluding photorespiration."""
 
         # Calculate chi and xi as in Prentice 14 but removing gamma terms.

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -182,7 +182,7 @@ class PModelABC(ABC):
         # Define the other model attributes
         # -----------------------------------------------------------------------
 
-        self.iwue: NDArray[np.float64]
+        self.iwue: NDArray[np.floating]
         """Intrinsic water use efficiency (iWUE, µmol mol-1), calculated as:
 
         .. math::
@@ -193,7 +193,7 @@ class PModelABC(ABC):
         atmospheric pressure in megapascals.
         """
 
-        self.lue: NDArray[np.float64]
+        self.lue: NDArray[np.floating]
         r"""Light use efficiency (LUE, g C mol-1), calculated as:
 
         .. math::
@@ -205,7 +205,7 @@ class PModelABC(ABC):
         the molar mass of carbon.
         """
 
-        self.vcmax: NDArray[np.float64]
+        self.vcmax: NDArray[np.floating]
         r"""Maximum rate of carboxylation at the growth temperature (µmol m-2 s-1),
         calculated as:
 
@@ -216,12 +216,12 @@ class PModelABC(ABC):
         where  :math:`f_v` is a limitation term calculated via the method selected in
         `method_jmaxlim`."""
 
-        self.vcmax25: NDArray[np.float64]
+        self.vcmax25: NDArray[np.floating]
         """Maximum rate of carboxylation at standard temperature (µmol m-2 s-1),
         estimated from :math:`V_{cmax}` using the selected method for Arrhenius scaling.
         """
 
-        self.jmax: NDArray[np.float64]
+        self.jmax: NDArray[np.floating]
         r"""Maximum rate of electron transport at the growth temperature (µmol m-2 s-1),
         calculated as:
         
@@ -232,12 +232,12 @@ class PModelABC(ABC):
         where  :math:`f_j` is a limitation term calculated via the method selected in
         `method_jmaxlim`."""
 
-        self.jmax25: NDArray[np.float64]
+        self.jmax25: NDArray[np.floating]
         """Maximum rate of electron transport at standard temperature (µmol m-2 s-1),
         estimated from :math:`J_{max}` using the selected method for Arrhenius scaling.
         """
 
-        self.gpp: NDArray[np.float64]
+        self.gpp: NDArray[np.floating]
         r"""Gross primary productivity (µg C m-2 s-1) calculated as:
         
         .. math::
@@ -247,7 +247,7 @@ class PModelABC(ABC):
         where :math:`I_{abs}` is the absorbed photosynthetic radiation.
         """
 
-        self.gs: NDArray[np.float64]
+        self.gs: NDArray[np.floating]
         r"""Stomatal conductance (µmol m-2 s-1), calculated as:
 
         .. math::
@@ -262,11 +262,11 @@ class PModelABC(ABC):
         \to 0` and the reported values will be set to ``np.nan`` under these
         conditions."""
 
-        self.A_c: NDArray[np.float64]
+        self.A_c: NDArray[np.floating]
         """Maximum assimilation rate limited by carboxylation."""
-        self.A_j: NDArray[np.float64]
+        self.A_j: NDArray[np.floating]
         """Maximum assimilation rate limited by electron transport."""
-        self.J: NDArray[np.float64]
+        self.J: NDArray[np.floating]
         """Electron transfer rate."""
 
     @abstractmethod
@@ -674,19 +674,19 @@ class SubdailyPModel(PModelABC):
         """
 
         # TODO - maybe encapsulate these in a dataclass?
-        self.vcmax25_daily_optimal: NDArray[np.float64]
+        self.vcmax25_daily_optimal: NDArray[np.floating]
         r"""Daily optimal values in acclimation window for :math:`V_{cmax}`, scaled to
          standard temperature (:math:`V_{cmax25}`)."""
-        self.vcmax25_daily_realised: NDArray[np.float64]
+        self.vcmax25_daily_realised: NDArray[np.floating]
         r"""Realised daily responses in :math:`V_{cmax25}`"""
-        self.jmax25_daily_optimal: NDArray[np.float64]
+        self.jmax25_daily_optimal: NDArray[np.floating]
         r"""Daily optimal values in acclimation window for :math:`J_{max}`, scaled to
          standard temperature (:math:`J_{max25}`)."""
-        self.jmax25_daily_realised: NDArray[np.float64]
+        self.jmax25_daily_realised: NDArray[np.floating]
         r"""Realised daily responses in :math:`J_{max25}`"""
-        self.xi_daily_optimal: NDArray[np.float64]
+        self.xi_daily_optimal: NDArray[np.floating]
         r"""Daily optimal values in acclimation window for :math:`\xi`"""
-        self.xi_daily_realised: NDArray[np.float64]
+        self.xi_daily_realised: NDArray[np.floating]
         r"""Realised daily responses in :math:`\xi`"""
 
         # Fit the model
@@ -890,14 +890,14 @@ class SubdailyPModel(PModelABC):
         #    actual subdaily temperatures.
         arrhenius_subdaily = self._arrhenius_class(env=self.env)
 
-        self.vcmax: NDArray[np.float64] = (
+        self.vcmax: NDArray[np.floating] = (
             self.vcmax25
             * arrhenius_subdaily.calculate_arrhenius_factor(
                 coefficients=self.env.pmodel_const.arrhenius_vcmax
             )
         )
 
-        self.jmax: NDArray[np.float64] = (
+        self.jmax: NDArray[np.floating] = (
             self.jmax25
             * arrhenius_subdaily.calculate_arrhenius_factor(
                 coefficients=self.env.pmodel_const.arrhenius_jmax

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -78,7 +78,7 @@ class PModelABC(ABC):
         method_optchi: str = "prentice14",
         method_jmaxlim: str = "wang17",
         method_arrhenius: str = "simple",
-        reference_kphio: float | NDArray | None = None,
+        reference_kphio: float | NDArray[np.floating] | None = None,
         **kwargs: dict[str, Any],
     ):
         self.shape: tuple = env.shape
@@ -384,7 +384,7 @@ class PModel(PModelABC):
         method_jmaxlim: str = "wang17",
         method_kphio: str = "temperature",
         method_arrhenius: str = "simple",
-        reference_kphio: float | NDArray | None = None,
+        reference_kphio: float | NDArray[np.floating] | None = None,
     ) -> None:
         # Initialise the superclass
         super().__init__(
@@ -490,7 +490,10 @@ class PModel(PModelABC):
     def to_subdaily(
         self,
         acclim_model: AcclimationModel,
-        previous_realised: tuple[NDArray, NDArray, NDArray] | None = None,
+        previous_realised: tuple[
+            NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]
+        ]
+        | None = None,
     ) -> SubdailyPModel:
         r"""Convert a standard PModel to a subdaily P Model.
 
@@ -640,8 +643,8 @@ class SubdailyPModel(PModelABC):
         method_jmaxlim: str = "wang17",
         method_kphio: str = "temperature",
         method_arrhenius: str = "simple",
-        reference_kphio: float | NDArray | None = None,
-        previous_realised: dict[str, NDArray] | None = None,
+        reference_kphio: float | NDArray[np.floating] | None = None,
+        previous_realised: dict[str, NDArray[np.floating]] | None = None,
     ) -> None:
         # Initialise the superclass
         super().__init__(

--- a/pyrealm/pmodel/pmodel_environment.py
+++ b/pyrealm/pmodel/pmodel_environment.py
@@ -105,16 +105,16 @@ class PModelEnvironment:
 
     def __init__(
         self,
-        tc: NDArray[np.float64],
-        vpd: NDArray[np.float64],
-        co2: NDArray[np.float64],
-        patm: NDArray[np.float64],
-        fapar: NDArray[np.float64] = np.array([1.0]),
-        ppfd: NDArray[np.float64] = np.array([1.0]),
+        tc: NDArray[np.floating],
+        vpd: NDArray[np.floating],
+        co2: NDArray[np.floating],
+        patm: NDArray[np.floating],
+        fapar: NDArray[np.floating] = np.array([1.0]),
+        ppfd: NDArray[np.floating] = np.array([1.0]),
         pmodel_const: PModelConst = PModelConst(),
         core_const: CoreConst = CoreConst(),
         bounds_checker: BoundsChecker = BoundsChecker(),
-        **kwargs: NDArray[np.float64],
+        **kwargs: NDArray[np.floating],
     ):
         # Check shapes of inputs are congruent
         self.shape: tuple = check_input_shapes(
@@ -123,17 +123,17 @@ class PModelEnvironment:
         """The shape of the environmental data arrays."""
 
         # Validate and store the core forcing variables
-        self.tc: NDArray[np.float64] = bounds_checker.check("tc", tc)
+        self.tc: NDArray[np.floating] = bounds_checker.check("tc", tc)
         """The temperature at which to estimate photosynthesis, °C"""
-        self.vpd: NDArray[np.float64] = bounds_checker.check("vpd", vpd)
+        self.vpd: NDArray[np.floating] = bounds_checker.check("vpd", vpd)
         """Vapour pressure deficit, Pa"""
-        self.co2: NDArray[np.float64] = bounds_checker.check("co2", co2)
+        self.co2: NDArray[np.floating] = bounds_checker.check("co2", co2)
         """CO2 concentration, ppm"""
-        self.patm: NDArray[np.float64] = bounds_checker.check("patm", patm)
+        self.patm: NDArray[np.floating] = bounds_checker.check("patm", patm)
         """Atmospheric pressure, Pa"""
-        self.fapar: NDArray[np.float64] = bounds_checker.check("fapar", fapar)
+        self.fapar: NDArray[np.floating] = bounds_checker.check("fapar", fapar)
         """The fraction of absorbed photosynthetically active radiation (FAPAR, -)"""
-        self.ppfd: NDArray[np.float64] = bounds_checker.check("ppfd", ppfd)
+        self.ppfd: NDArray[np.floating] = bounds_checker.check("ppfd", ppfd)
         """The photosynthetic photon flux density (PPFD, µmol m-2 s-1)"""
 
         # Store constant settings and bounds checker
@@ -159,13 +159,13 @@ class PModelEnvironment:
             )
 
         # Internal calculations
-        self.tk: NDArray[np.float64] = self.tc + self.core_const.k_CtoK
+        self.tk: NDArray[np.floating] = self.tc + self.core_const.k_CtoK
         """The temperature at which to estimate photosynthesis in Kelvin (K)"""
 
-        self.ca: NDArray[np.float64] = calc_co2_to_ca(co2=self.co2, patm=self.patm)
+        self.ca: NDArray[np.floating] = calc_co2_to_ca(co2=self.co2, patm=self.patm)
         """Ambient CO2 partial pressure, Pa"""
 
-        self.gammastar: NDArray[np.float64] = calc_gammastar(
+        self.gammastar: NDArray[np.floating] = calc_gammastar(
             tk=self.tk,
             patm=patm,
             tk_ref=self.pmodel_const.tk_ref,
@@ -174,7 +174,7 @@ class PModelEnvironment:
         )
         r"""Photorespiratory compensation point (:math:`\Gamma^\ast`, Pa)"""
 
-        self.kmm: NDArray[np.float64] = calc_kmm(
+        self.kmm: NDArray[np.floating] = calc_kmm(
             tk=self.tk,
             patm=patm,
             tk_ref=self.pmodel_const.tk_ref,

--- a/pyrealm/pmodel/quantum_yield.py
+++ b/pyrealm/pmodel/quantum_yield.py
@@ -137,7 +137,7 @@ class QuantumYieldABC(ABC):
                     "of reference kphio values"
                 )
 
-        self.reference_kphio: NDArray[np.float64] = reference_kphio
+        self.reference_kphio: NDArray[np.floating] = reference_kphio
         """The kphio reference value for the method."""
         self.use_c4: bool = use_c4
         """Use a C4 parameterisation if available."""
@@ -145,7 +145,7 @@ class QuantumYieldABC(ABC):
         # Declare attributes populated by methods. These are typed but not assigned a
         # default value as they must are populated by the subclass specific
         # calculate_kphio method, which is called below to populate the values.
-        self.kphio: NDArray[np.float64]
+        self.kphio: NDArray[np.floating]
         """The calculated intrinsic quantum yield of photosynthesis."""
 
         # Run the calculation methods after checking for any required variables
@@ -283,8 +283,8 @@ class QuantumYieldSandoval(
     __experimental__: bool = True
 
     def peak_quantum_yield(
-        self, aridity_index: NDArray[np.float64]
-    ) -> NDArray[np.float64]:
+        self, aridity_index: NDArray[np.floating]
+    ) -> NDArray[np.floating]:
         """Calculate the peak quantum yield as a function of the aridity index.
 
         Args:

--- a/pyrealm/pmodel/two_leaf.py
+++ b/pyrealm/pmodel/two_leaf.py
@@ -88,10 +88,10 @@ class TwoLeafIrradiance:
 
     def __init__(
         self,
-        solar_elevation: NDArray[np.float64],
-        ppfd: NDArray[np.float64],
-        leaf_area_index: NDArray[np.float64],
-        patm: NDArray[np.float64],
+        solar_elevation: NDArray[np.floating],
+        ppfd: NDArray[np.floating],
+        leaf_area_index: NDArray[np.floating],
+        patm: NDArray[np.floating],
         core_constants: CoreConst = CoreConst(),
         two_leaf_constants: TwoLeafConst = TwoLeafConst(),
         bounds_checker: BoundsChecker = BoundsChecker(),
@@ -102,17 +102,17 @@ class TwoLeafIrradiance:
         check_input_shapes(solar_elevation, ppfd, leaf_area_index, patm)
 
         # Check bounds and store input variables
-        self.solar_elevation: NDArray[np.float64] = bounds_checker.check(
+        self.solar_elevation: NDArray[np.floating] = bounds_checker.check(
             "solar_elevation", solar_elevation
         )
         r"""The solar elevation inputs (:math:`\beta`, radians)"""
-        self.ppfd: NDArray[np.float64] = bounds_checker.check("ppfd", ppfd)
+        self.ppfd: NDArray[np.floating] = bounds_checker.check("ppfd", ppfd)
         """The photosynthetic photon flux density inputs (PPFD, µmol m-2 s-1)"""
-        self.leaf_area_index: NDArray[np.float64] = bounds_checker.check(
+        self.leaf_area_index: NDArray[np.floating] = bounds_checker.check(
             "leaf_area_index", leaf_area_index
         )
         """The leaf area index inputs (:math:`L`, unitless)"""
-        self.patm: NDArray[np.float64] = bounds_checker.check("patm", patm)
+        self.patm: NDArray[np.floating] = bounds_checker.check("patm", patm)
         """The atmospheric pressure (:math:`P`, pascals)"""
         self.core_constants: CoreConst = core_constants
         """An instance of the core constants class."""
@@ -121,35 +121,35 @@ class TwoLeafIrradiance:
 
         # Define instance attributes
 
-        self.fraction_of_diffuse_radiation: NDArray[np.float64]
+        self.fraction_of_diffuse_radiation: NDArray[np.floating]
         """The fraction of diffuse radiation (:math:`f_d`)"""
-        self.diffuse_irradiance: NDArray[np.float64]
+        self.diffuse_irradiance: NDArray[np.floating]
         """The diffuse irradiance (:math:`I_d`) reaching the canopy."""
-        self.beam_irradiance: NDArray[np.float64]
+        self.beam_irradiance: NDArray[np.floating]
         """The beam irradiance (:math:`I_b`) reaching the canopy."""
 
-        self.beam_extinction_coef: NDArray[np.float64]
+        self.beam_extinction_coef: NDArray[np.floating]
         """The beam extinction coefficient (:math:`k_{b}`)"""
-        self.scattered_beam_extinction_coef: NDArray[np.float64]
+        self.scattered_beam_extinction_coef: NDArray[np.floating]
         """The scattered beam extinction coefficient (:math:`k_{b}'`)"""
 
-        self.beam_reflectance: NDArray[np.float64]
+        self.beam_reflectance: NDArray[np.floating]
         r"""The canopy beam reflectance for leaves with uniform angle distribution
          (:math:`\rho_{cb}`)"""
 
-        self.sunlit_beam_irradiance: NDArray[np.float64]
+        self.sunlit_beam_irradiance: NDArray[np.floating]
         """The sunlit beam irradiance (:math:`I_{sb}`)."""
-        self.sunlit_diffuse_irradiance: NDArray[np.float64]
+        self.sunlit_diffuse_irradiance: NDArray[np.floating]
         """The sunlit diffuse irradiance (:math:`I_{sd}`)."""
-        self.sunlit_scattered_irradiance: NDArray[np.float64]
+        self.sunlit_scattered_irradiance: NDArray[np.floating]
         """The sunlit scattered irradiance (:math:`I_{ss}`)."""
 
-        self.canopy_irradiance: NDArray[np.float64]
+        self.canopy_irradiance: NDArray[np.floating]
         """The total canopy irradiance (:math:`I_c`)."""
 
-        self.sunlit_absorbed_irradiance: NDArray[np.float64]
+        self.sunlit_absorbed_irradiance: NDArray[np.floating]
         """The sunlit leaf absorbed irradiance (:math:`I_{csun}`)."""
-        self.shaded_absorbed_irradiance: NDArray[np.float64]
+        self.shaded_absorbed_irradiance: NDArray[np.floating]
         """The shaded leaf absorbed irradiance (:math:`I_{cshade}`)."""
 
         # Automatically calculate the absorbed irradiances.
@@ -244,10 +244,10 @@ class TwoLeafIrradiance:
 
 
 def calculate_beam_extinction_coef(
-    solar_elevation: NDArray[np.float64],
+    solar_elevation: NDArray[np.floating],
     solar_obscurity_angle: float = TwoLeafConst().solar_obscurity_angle,
     extinction_numerator: float = TwoLeafConst().direct_beam_extinction_numerator,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the beam extinction coefficient.
 
     The beam extinction coefficient (:math:`k_b`) captures changes in the the
@@ -276,12 +276,12 @@ def calculate_beam_extinction_coef(
 
 
 def calculate_fraction_of_diffuse_radiation(
-    patm: NDArray[np.float64],
-    solar_elevation: NDArray[np.float64],
+    patm: NDArray[np.floating],
+    solar_elevation: NDArray[np.floating],
     standard_pressure: float = CoreConst().k_Po,
     atmospheric_scattering: float = TwoLeafConst().atmospheric_scattering_coef,
     atmos_transmission_par: float = TwoLeafConst().atmos_transmission_par,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the fraction of diffuse radiation.
 
     The fraction of diffuse radiation (:math:`f_d`) captures the proportion of
@@ -330,9 +330,9 @@ def calculate_fraction_of_diffuse_radiation(
 
 
 def calculate_beam_reflectance(
-    beam_extinction: NDArray[np.float64],
+    beam_extinction: NDArray[np.floating],
     horizontal_leaf_reflectance: float = TwoLeafConst().horizontal_leaf_reflectance,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the beam irradiance for leaves with a uniform angle distribution.
 
     The beam irradiance with a uniform leaf angle distribution (:math:`\rho_{cb}`)
@@ -358,14 +358,14 @@ def calculate_beam_reflectance(
 
 
 def calculate_canopy_irradiance(
-    beam_reflectance: NDArray[np.float64],
-    beam_irradiance: NDArray[np.float64],
-    scattered_beam_extinction_coef: NDArray[np.float64],
-    diffuse_radiation: NDArray[np.float64],
-    leaf_area_index: NDArray[np.float64],
+    beam_reflectance: NDArray[np.floating],
+    beam_irradiance: NDArray[np.floating],
+    scattered_beam_extinction_coef: NDArray[np.floating],
+    diffuse_radiation: NDArray[np.floating],
+    leaf_area_index: NDArray[np.floating],
     diffuse_reflectance: float = TwoLeafConst().diffuse_reflectance,
     diffuse_extinction_coef: float = TwoLeafConst().diffuse_extinction_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the canopy irradiance.
 
     The canopy irradiance (:math:`I_c`) is the total irradiance within the canopy,
@@ -401,11 +401,11 @@ def calculate_canopy_irradiance(
 
 
 def calculate_sunlit_beam_irradiance(
-    beam_irradiance: NDArray[np.float64],
-    beam_extinction_coef: NDArray[np.float64],
-    leaf_area_index: NDArray[np.float64],
+    beam_irradiance: NDArray[np.floating],
+    beam_extinction_coef: NDArray[np.floating],
+    leaf_area_index: NDArray[np.floating],
     leaf_scattering_coef: float = TwoLeafConst().leaf_scattering_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the sunlit beam irradiance.
 
     The sunlit beam irradiance (:math:`I_{sun_beam}`) is the direct sunlight received by
@@ -433,12 +433,12 @@ def calculate_sunlit_beam_irradiance(
 
 
 def calculate_sunlit_diffuse_irradiance(
-    diffuse_irradiance: NDArray[np.float64],
-    beam_extinction_coef: NDArray[np.float64],
-    leaf_area_index: NDArray[np.float64],
+    diffuse_irradiance: NDArray[np.floating],
+    beam_extinction_coef: NDArray[np.floating],
+    leaf_area_index: NDArray[np.floating],
     diffuse_reflectance: float = TwoLeafConst().diffuse_reflectance,
     diffuse_extinction_coef: float = TwoLeafConst().diffuse_extinction_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the sunlit diffuse irradiance.
 
     The sunlit diffuse irradiance (:math:`I_{s_d}`) is the diffuse radiation
@@ -476,13 +476,13 @@ def calculate_sunlit_diffuse_irradiance(
 
 
 def calculate_sunlit_scattered_irradiance(
-    beam_irradiance: NDArray[np.float64],
-    beam_reflectance: NDArray[np.float64],
-    scattered_beam_extinction_coef: NDArray[np.float64],
-    beam_extinction_coef: NDArray[np.float64],
-    leaf_area_index: NDArray[np.float64],
+    beam_irradiance: NDArray[np.floating],
+    beam_reflectance: NDArray[np.floating],
+    scattered_beam_extinction_coef: NDArray[np.floating],
+    beam_extinction_coef: NDArray[np.floating],
+    leaf_area_index: NDArray[np.floating],
     leaf_scattering_coef: float = TwoLeafConst().leaf_scattering_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the sunlit scattered irradiance.
 
     The sunlit scattered irradiance (:math:`I_{ss}`) is the scattered
@@ -624,59 +624,59 @@ class TwoLeafAssimilation:
         #        class, but removes the parallel arguments.
         #      - See https://github.com/ImperialCollegeLondon/pyrealm/issues/469
 
-        self.canopy_extinction_coef: NDArray[np.float64]
+        self.canopy_extinction_coef: NDArray[np.floating]
         """An extinction coefficient capturing the vertical structure of carboxylation
         capacity within the canopy (:math:`k_v`)."""
-        self.Vcmax25_canopy: NDArray[np.float64]
+        self.Vcmax25_canopy: NDArray[np.floating]
         r"""The total canopy carboxylation capacity at standard temperature
         :math:`V_{cmax25\_C}`"""
-        self.Vcmax25_sun: NDArray[np.float64]
+        self.Vcmax25_sun: NDArray[np.floating]
         r"""The maximum rate of carboxylation at standard temperature within sunlit 
         leaves (:math:`V_{cmax25\_Sn}`)"""
-        self.Vcmax25_shade: NDArray[np.float64]
+        self.Vcmax25_shade: NDArray[np.floating]
         r"""The maximum rate of carboxylation at standard temperature within shaded 
         leaves (:math:`V_{cmax25\_Sd}`)"""
-        self.Vcmax_sun: NDArray[np.float64]
+        self.Vcmax_sun: NDArray[np.floating]
         r"""The maximum rate of carboxylation at the observed temperature within sunlit
         leaves (:math:`V_{cmax\_Sn}`)"""
-        self.Vcmax_shade: NDArray[np.float64]
+        self.Vcmax_shade: NDArray[np.floating]
         r"""The maximum rate of carboxylation at the observed temperature within shaded
         leaves (:math:`V_{cmax\_Sd}`)"""
-        self.Jmax25_sun: NDArray[np.float64]
+        self.Jmax25_sun: NDArray[np.floating]
         r"""The maximum rate of electron transfer at standard temperature within sunlit
         leaves (:math:`J_{max25\_Sn}`)"""
-        self.Jmax25_shade: NDArray[np.float64]
+        self.Jmax25_shade: NDArray[np.floating]
         r"""The maximum rate of electron transfer at standard temperature within shaded
         leaves (:math:`J_{max25\_Sd}`)"""
-        self.Jmax_sun: NDArray[np.float64]
+        self.Jmax_sun: NDArray[np.floating]
         r"""The maximum rate of electron transfer at the observed temperature within
         sunlit leaves (:math:`J_{max\_Sn}`)"""
-        self.Jmax_shade: NDArray[np.float64]
+        self.Jmax_shade: NDArray[np.floating]
         r"""The maximum rate of electron transfer at the observed temperature within
         shaded leaves (:math:`J_{max25\_Sn}`)"""
-        self.J_sun: NDArray[np.float64]
+        self.J_sun: NDArray[np.floating]
         r"""The realised rate of electron transfer within sunlit leaves
         (:math:`J_{Sn}`"""
-        self.J_shade: NDArray[np.float64]
+        self.J_shade: NDArray[np.floating]
         r"""The realised rate of electron transfer within sunlit leaves
         (:math:`J_{Sd}`"""
-        self.Av_sun: NDArray[np.float64]
+        self.Av_sun: NDArray[np.floating]
         r"""The potential rate of assimilation associated with carboxylation in sunlit
         leaves (:math:`A_{v\_Sn}`)."""
-        self.Av_shade: NDArray[np.float64]
+        self.Av_shade: NDArray[np.floating]
         r"""The potential rate of assimilation associated with carboxylation in shaded
         leaves (:math:`A_{v\_Sd}`)."""
-        self.Aj_sun: NDArray[np.float64]
+        self.Aj_sun: NDArray[np.floating]
         r"""The potential rate of assimilation associated with electron transfer in
         sunlit leaves (:math:`A_{j\_Sn}`)."""
-        self.Aj_shade: NDArray[np.float64]
+        self.Aj_shade: NDArray[np.floating]
         r"""The potential rate of assimilation associated with electron transfer in
         shaded leaves (:math:`A_{j\_Sn}`)."""
-        self.A_sun: NDArray[np.float64]
+        self.A_sun: NDArray[np.floating]
         r"""The realised assimilation rate for sunlit leaves (:math:`A_{Sn}`)."""
-        self.A_shade: NDArray[np.float64]
+        self.A_shade: NDArray[np.floating]
         r"""The realised assimilation rate for shaded leaves (:math:`A_{Sd}`)."""
-        self.gpp: NDArray[np.float64]
+        self.gpp: NDArray[np.floating]
         r"""The gross primary productivity across the sunlit and shaded leaves."""
 
         # Automatically run the
@@ -765,9 +765,9 @@ class TwoLeafAssimilation:
 
 
 def calculate_canopy_extinction_coef(
-    vcmax: NDArray[np.float64],
+    vcmax: NDArray[np.floating],
     coef: tuple[float, float] = TwoLeafConst().vcmax_lloyd_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the canopy extinction coefficient.
 
     The extinction coefficient (:math:`k_v`) captures the decrease in photosynthetic
@@ -793,10 +793,10 @@ def calculate_canopy_extinction_coef(
 
 
 def calculate_canopy_vcmax25(
-    leaf_area_index: NDArray[np.float64],
-    vcmax25: NDArray[np.float64],
-    canopy_extinction_coef: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    leaf_area_index: NDArray[np.floating],
+    vcmax25: NDArray[np.floating],
+    canopy_extinction_coef: NDArray[np.floating],
+) -> NDArray[np.floating]:
     r"""Calculate standardised carboxylation rate in the canopy.
 
     This function calculates the maximum carboxylation rate of the canopy at a reference
@@ -824,11 +824,11 @@ def calculate_canopy_vcmax25(
 
 
 def calculate_sun_vcmax25(
-    leaf_area_index: NDArray[np.float64],
-    vcmax25: NDArray[np.float64],
-    canopy_extinction_coef: NDArray[np.float64],
-    beam_extinction_coef: NDArray[np.float64],
-) -> NDArray[np.float64]:
+    leaf_area_index: NDArray[np.floating],
+    vcmax25: NDArray[np.floating],
+    canopy_extinction_coef: NDArray[np.floating],
+    beam_extinction_coef: NDArray[np.floating],
+) -> NDArray[np.floating]:
     r"""Calculate standardised carboxylation rate of sunlit leaves.
 
     Calculates the maximum carboxylation rate for sunlit leaves at the standard
@@ -868,9 +868,9 @@ def calculate_sun_vcmax25(
 
 
 def calculate_jmax25(
-    vcmax25: NDArray[np.float64],
+    vcmax25: NDArray[np.floating],
     coef: tuple[float, float] = TwoLeafConst().jmax25_wullschleger_coef,
-) -> NDArray[np.float64]:
+) -> NDArray[np.floating]:
     r"""Calculate the maximum rate of electron transport.
 
     This function calculates the maximum rate of electron transport (:math:`J_{max25}`)
@@ -896,8 +896,8 @@ def calculate_jmax25(
 
 
 def calculate_electron_transport_rate(
-    jmax: NDArray[np.float64], absorbed_irradiance: NDArray[np.float64]
-) -> NDArray[np.float64]:
+    jmax: NDArray[np.floating], absorbed_irradiance: NDArray[np.floating]
+) -> NDArray[np.floating]:
     r"""Calculate electron transport rate.
 
     This function calculates the realised electron transport rate (:math:`J`), given

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -48,8 +48,8 @@ class DailyEvapFluxes:
     """
 
     solar: DailySolarFluxes
-    pa: InitVar[NDArray]
-    tc: InitVar[NDArray]
+    pa: InitVar[NDArray[np.floating]]
+    tc: InitVar[NDArray[np.floating]]
     kWm: NDArray[np.floating] = field(default_factory=lambda: np.array([150.0]))
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
 
@@ -126,7 +126,10 @@ class DailyEvapFluxes:
         wn: NDArray[np.floating],
         day_idx: int | None = None,
         only_aet: bool = True,
-    ) -> NDArray[np.floating] | tuple[NDArray, NDArray, NDArray]:
+    ) -> (
+        NDArray[np.floating]
+        | tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]
+    ):
         """Estimate actual evapotranspiration.
 
         This method estimates the daily actual evapotranspiration (AET, mm/day), given

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -50,29 +50,29 @@ class DailyEvapFluxes:
     solar: DailySolarFluxes
     pa: InitVar[NDArray]
     tc: InitVar[NDArray]
-    kWm: NDArray[np.float64] = field(default_factory=lambda: np.array([150.0]))
+    kWm: NDArray[np.floating] = field(default_factory=lambda: np.array([150.0]))
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
 
-    sat: NDArray[np.float64] = field(init=False)
+    sat: NDArray[np.floating] = field(init=False)
     """Slope of saturation vapour pressure temperature curve, Pa/K"""
-    lv: NDArray[np.float64] = field(init=False)
+    lv: NDArray[np.floating] = field(init=False)
     """Enthalpy of vaporization, J/kg"""
-    pw: NDArray[np.float64] = field(init=False)
+    pw: NDArray[np.floating] = field(init=False)
     """Density of water, kg/m^3"""
-    psy: NDArray[np.float64] = field(init=False)
+    psy: NDArray[np.floating] = field(init=False)
     """Psychrometric constant, Pa/K"""
-    econ: NDArray[np.float64] = field(init=False)
+    econ: NDArray[np.floating] = field(init=False)
     """Water-to-energy conversion factor"""
-    cond: NDArray[np.float64] = field(init=False)
+    cond: NDArray[np.floating] = field(init=False)
     """Daily condensation, mm"""
-    eet_d: NDArray[np.float64] = field(init=False)
+    eet_d: NDArray[np.floating] = field(init=False)
     """Daily equilibrium evapotranspiration (EET), mm"""
-    pet_d: NDArray[np.float64] = field(init=False)
+    pet_d: NDArray[np.floating] = field(init=False)
     """Daily potential evapotranspiration (PET), mm"""
-    rx: NDArray[np.float64] = field(init=False)
+    rx: NDArray[np.floating] = field(init=False)
     """Variable substitute, (mm/hr)/(W/m^2)"""
 
-    def __post_init__(self, pa: NDArray[np.float64], tc: NDArray[np.float64]) -> None:
+    def __post_init__(self, pa: NDArray[np.floating], tc: NDArray[np.floating]) -> None:
         """Calculate invariant components of evapotranspiration.
 
         The post_init method calculates the components of the evaporative fluxes that
@@ -122,8 +122,11 @@ class DailyEvapFluxes:
         self.rx = (3.6e6) * (1.0 + self.core_const.k_w) * self.econ
 
     def estimate_aet(
-        self, wn: NDArray[np.float64], day_idx: int | None = None, only_aet: bool = True
-    ) -> NDArray[np.float64] | tuple[NDArray, NDArray, NDArray]:
+        self,
+        wn: NDArray[np.floating],
+        day_idx: int | None = None,
+        only_aet: bool = True,
+    ) -> NDArray[np.floating] | tuple[NDArray, NDArray, NDArray]:
         """Estimate actual evapotranspiration.
 
         This method estimates the daily actual evapotranspiration (AET, mm/day), given

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -44,50 +44,50 @@ class DailySolarFluxes:
         temperature: Daily temperature of observations (°C)
     """
 
-    latitude: InitVar[NDArray[np.float64]]
-    elevation: InitVar[NDArray[np.float64]]
+    latitude: InitVar[NDArray[np.floating]]
+    elevation: InitVar[NDArray[np.floating]]
     dates: Calendar
-    sunshine_fraction: InitVar[NDArray[np.float64]]
-    temperature: InitVar[NDArray[np.float64]]
+    sunshine_fraction: InitVar[NDArray[np.floating]]
+    temperature: InitVar[NDArray[np.floating]]
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
 
-    nu: NDArray[np.float64] = field(init=False)
+    nu: NDArray[np.floating] = field(init=False)
     r"""True heliocentric anomaly (:math:`\nu`, degrees)"""
-    lambda_: NDArray[np.float64] = field(init=False)
+    lambda_: NDArray[np.floating] = field(init=False)
     r"""True heliocentric longitude, (:math:`\lambda`, degrees)"""
-    distance_factor: NDArray[np.float64] = field(init=False)
+    distance_factor: NDArray[np.floating] = field(init=False)
     """Distance factor (:math:`d_r`, -)"""
-    declination: NDArray[np.float64] = field(init=False)
+    declination: NDArray[np.floating] = field(init=False)
     r"""Declination angle (:math:`\delta`, degrees)"""
-    ru: NDArray[np.float64] = field(init=False)
+    ru: NDArray[np.floating] = field(init=False)
     """Intermediate variable (:math:`r_u`, unitless)"""
-    rv: NDArray[np.float64] = field(init=False)
+    rv: NDArray[np.floating] = field(init=False)
     """Intermediate variable (:math:`r_v`, unitless)"""
-    sunset_hour_angle: NDArray[np.float64] = field(init=False)
+    sunset_hour_angle: NDArray[np.floating] = field(init=False)
     """Sunset hour angle (:math:`h_s`, degrees)"""
-    daily_solar_radiation: NDArray[np.float64] = field(init=False)
+    daily_solar_radiation: NDArray[np.floating] = field(init=False)
     """Daily extraterrestrial solar radiation (:math:`R_d`, J m-2)"""
-    transmissivity: NDArray[np.float64] = field(init=False)
+    transmissivity: NDArray[np.floating] = field(init=False)
     r"""Transmittivity (:math:`\tau`, unitless)"""
-    daily_ppfd: NDArray[np.float64] = field(init=False)
+    daily_ppfd: NDArray[np.floating] = field(init=False)
     """Daily photosynthetic photon flux density (PPFD, µmol m-2 s-1)"""
-    net_longwave_radiation: NDArray[np.float64] = field(init=False)
+    net_longwave_radiation: NDArray[np.floating] = field(init=False)
     """Net longwave radiation (:math:`R_{nl}`, W m-2)"""
-    rw: NDArray[np.float64] = field(init=False)
+    rw: NDArray[np.floating] = field(init=False)
     """Intermediate variable (:math:`r_w`,  W m-2)"""
-    crossover_hour_angle: NDArray[np.float64] = field(init=False)
+    crossover_hour_angle: NDArray[np.floating] = field(init=False)
     """Net radiation cross-over hour angle, (:math:`h_n`, degrees)"""
-    daytime_net_radiation: NDArray[np.float64] = field(init=False)
+    daytime_net_radiation: NDArray[np.floating] = field(init=False)
     """Daytime net radiation (:math:`R_{d}`, J m-2)"""
-    nighttime_net_radiation: NDArray[np.float64] = field(init=False)
+    nighttime_net_radiation: NDArray[np.floating] = field(init=False)
     """Nighttime net radiation (:math:`R_{nn}`, J m-2)"""
 
     def __post_init__(
         self,
-        latitude: NDArray[np.float64],
-        elevation: NDArray[np.float64],
-        sunshine_fraction: NDArray[np.float64],
-        temperature: NDArray[np.float64],
+        latitude: NDArray[np.floating],
+        elevation: NDArray[np.floating],
+        sunshine_fraction: NDArray[np.floating],
+        temperature: NDArray[np.floating],
     ) -> None:
         """Populates key fluxes from input variables."""
 

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -242,7 +242,7 @@ class SplashModel:
 
     def estimate_daily_water_balance(
         self, previous_wn: NDArray[np.floating], day_idx: int | None = None
-    ) -> tuple[NDArray, NDArray, NDArray]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
         r"""Estimate the daily water balance.
 
         This function estimates the daily water balance within observations. The
@@ -313,7 +313,7 @@ class SplashModel:
     def calculate_soil_moisture(
         self,
         wn_init: NDArray[np.floating],
-    ) -> tuple[NDArray, NDArray, NDArray]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
         """Calculate the soil moisture, AET and runoff from a SplashModel.
 
         This function takes an initial array of soil moisture values for the first

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -59,13 +59,13 @@ class SplashModel:
 
     def __init__(
         self,
-        lat: NDArray[np.float64],
-        elv: NDArray[np.float64],
-        sf: NDArray[np.float64],
-        tc: NDArray[np.float64],
-        pn: NDArray[np.float64],
+        lat: NDArray[np.floating],
+        elv: NDArray[np.floating],
+        sf: NDArray[np.floating],
+        tc: NDArray[np.floating],
+        pn: NDArray[np.floating],
         dates: Calendar,
-        kWm: NDArray[np.float64] = np.array([150.0]),
+        kWm: NDArray[np.floating] = np.array([150.0]),
         core_const: CoreConst = CoreConst(),
         bounds_checker: BoundsChecker = BoundsChecker(),
     ):
@@ -91,23 +91,23 @@ class SplashModel:
         tc = broadcast_time(tc, self.shape)
         pn = broadcast_time(pn, self.shape)
 
-        self.elv: NDArray[np.float64] = elv
+        self.elv: NDArray[np.floating] = elv
         """The elevation of sites."""
-        self.lat: NDArray[np.float64] = bounds_checker.check("lat", lat)
+        self.lat: NDArray[np.floating] = bounds_checker.check("lat", lat)
         """The latitude of sites."""
-        self.sf: NDArray[np.float64] = bounds_checker.check("sf", sf)
+        self.sf: NDArray[np.floating] = bounds_checker.check("sf", sf)
         """The sunshine fraction (0-1) of daily observations."""
-        self.tc: NDArray[np.float64] = bounds_checker.check("tc", tc)
+        self.tc: NDArray[np.floating] = bounds_checker.check("tc", tc)
         """The air temperature in °C of daily observations."""
-        self.pn: NDArray[np.float64] = bounds_checker.check("pn", pn)
+        self.pn: NDArray[np.floating] = bounds_checker.check("pn", pn)
         """The precipitation in mm of daily observations."""
         self.dates: Calendar = dates
         """The dates of observations along the first array axis."""
-        self.kWm: NDArray[np.float64] = bounds_checker.check("kWm", kWm)
+        self.kWm: NDArray[np.floating] = bounds_checker.check("kWm", kWm)
         """The maximum soil water capacity for sites."""
 
         # TODO - potentially allow _actual_ climatic pressure data as an input
-        self.pa: NDArray[np.float64] = calc_patm(elv, core_const=core_const)
+        self.pa: NDArray[np.floating] = calc_patm(elv, core_const=core_const)
         """The atmospheric pressure at sites, derived from elevation"""
 
         # Calculate the daily solar fluxes - these are invariant across the simulation
@@ -128,12 +128,12 @@ class SplashModel:
 
     def estimate_initial_soil_moisture(
         self,
-        wn_init: NDArray[np.float64] | None = None,
+        wn_init: NDArray[np.floating] | None = None,
         max_iter: int = 10,
         max_diff: float = 1.0,
         return_convergence: bool = False,
         verbose: bool = False,
-    ) -> NDArray[np.float64]:
+    ) -> NDArray[np.floating]:
         """Estimate initial soil moisture.
 
         This method uses the first year of data provided to a SplashModel instance to
@@ -241,7 +241,7 @@ class SplashModel:
             return wn_start
 
     def estimate_daily_water_balance(
-        self, previous_wn: NDArray[np.float64], day_idx: int | None = None
+        self, previous_wn: NDArray[np.floating], day_idx: int | None = None
     ) -> tuple[NDArray, NDArray, NDArray]:
         r"""Estimate the daily water balance.
 
@@ -312,7 +312,7 @@ class SplashModel:
 
     def calculate_soil_moisture(
         self,
-        wn_init: NDArray[np.float64],
+        wn_init: NDArray[np.floating],
     ) -> tuple[NDArray, NDArray, NDArray]:
         """Calculate the soil moisture, AET and runoff from a SplashModel.
 

--- a/pyrealm_build_data/phenology/python_implementation.py
+++ b/pyrealm_build_data/phenology/python_implementation.py
@@ -32,7 +32,9 @@ from pyrealm.pmodel.functions import calc_soilmstress_mengoli
 
 
 # Local RLE function - will be in pyrealm.demography.growing_season
-def run_length_encode(values: NDArray) -> tuple[NDArray[np.int_], NDArray]:
+def run_length_encode(
+    values: NDArray[np.bool_ | np.int_],
+) -> tuple[NDArray[np.int_], NDArray[np.int_]]:
     """Calculate run length encoding of 1D arrays.
 
     The function returns a tuple containing an array of the run lengths and an array of

--- a/tests/unit/demography/test_core.py
+++ b/tests/unit/demography/test_core.py
@@ -23,9 +23,9 @@ def test_PandasExporter() -> None:
         """Simple test dataclass implementing the ABC."""
 
         array_attrs: ClassVar[tuple[str, ...]] = ("c", "d", "e")
-        c: NDArray[np.float64]
-        d: NDArray[np.float64]
-        e: NDArray[np.float64]
+        c: NDArray[np.floating]
+        d: NDArray[np.floating]
+        e: NDArray[np.floating]
 
     # create instance and run method
     instance = TestClass(
@@ -55,8 +55,8 @@ def test_CohortMethods() -> None:
         count_attr: ClassVar[str] = "n_cohorts"
 
         n_cohorts: int
-        a: NDArray[np.float64]
-        b: NDArray[np.float64]
+        a: NDArray[np.floating]
+        b: NDArray[np.floating]
 
     # Create instances
     t1 = TestClass(n_cohorts=3, a=np.array([1, 2, 3]), b=np.array([4, 5, 6]))
@@ -86,8 +86,8 @@ def test_Cohorts_add_cohort_data_failure() -> None:
 
         array_attrs: ClassVar[tuple[str, ...]] = ("a", "b")
 
-        a: NDArray[np.float64]
-        b: NDArray[np.float64]
+        a: NDArray[np.floating]
+        b: NDArray[np.floating]
 
     @dataclass
     class NotTheSameClass(CohortMethods):
@@ -95,8 +95,8 @@ def test_Cohorts_add_cohort_data_failure() -> None:
 
         array_attrs: ClassVar[tuple[str, ...]] = ("c", "d")
 
-        c: NDArray[np.float64]
-        d: NDArray[np.float64]
+        c: NDArray[np.floating]
+        d: NDArray[np.floating]
 
     # Create instances
     t1 = TestClass(a=np.array([1, 2, 3]), b=np.array([4, 5, 6]))
@@ -127,9 +127,9 @@ def test_PandasExporter_Cohorts_multiple_inheritance() -> None:
         n: InitVar[int]
         start_vals: InitVar[NDArray[np.int_]]
 
-        c: NDArray[np.float64] = field(init=False)
+        c: NDArray[np.floating] = field(init=False)
         d: NDArray[np.int_] = field(init=False)
-        e: NDArray[np.float64] = field(init=False)
+        e: NDArray[np.floating] = field(init=False)
         n_foobars: int = field(init=False)
 
         def __post_init__(self, n: int, start_vals: NDArray[np.int_]) -> None:


### PR DESCRIPTION
# Description

With newer `numpy` versions, it is probably cleaner to move to the newer typing options for typing floating point arrays. We currently use `np.float64` widely, but we really don't care about the float length particularly and these can be more generically typed as `np.floating`, which reduces chances of meaningless float typing problems if `pyrealm` is called in other packages.

So, this PR:
* Moves all `NDArray[np.float64]` to `NDArray[np.floating]`
* Adds `[np.floating]` typing to nearly all bare `NDArray` types. `pyrealm.core.time_series.broadcast_time` does not care what it broadcasts, although `np.floating` is most likely.
* Squashes a few rogue `NDArray[np.float32]` types back into line as `NDArray[np.floating]`

@sjavis - I think this is most likely to impact your `xarray` work so I've asked you to review. I think standardising our float array typing is going to be helpful, but it might causes issues!

Fixes #556 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
