### PR TITLE
Add codespell to pre commit hooks

### DIFF
--- a/.codespellexclude.txt
+++ b/.codespellexclude.txt
@@ -1,0 +1,3 @@
+    This function calculates daytime net radiation (:math:`R_{nd}` :math:`J/m^2`), using
+        R_{nd} = \left( \frac{n_s}{\pi} \right)
+    Calculates the daily net radiation (:math:`R_{nd}`, J m-2) as:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,10 @@ repos:
             )$
       additional_dependencies:
         - black==24.4.2 # Matches hook
-      
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+      args: ["--toml", "pyproject.toml"]
+      additional_dependencies:
+        - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,4 @@ repos:
       args: ["--toml", "pyproject.toml"]
       additional_dependencies:
         - tomli
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@ notably the API of the `pmodel` module, as well as introducing new functionality
 - The `PModelEnvironment` class has been updated. It now requires that the user also
   provides `fapar` and `ppfd` data, currently with no default values. The provision of
   additional variables has also been made more flexible, allowing users to provide
-  arbitary extra variables to the environment. This makes it easier to adopt new PModel
+  arbitrary extra variables to the environment. This makes it easier to adopt new PModel
   methods implementations with new required variables.
 
   **Breaking change**: Need to specify `fapar` and `ppfd` in `PModelEnvironment`.
@@ -181,7 +181,7 @@ notably the API of the `pmodel` module, as well as introducing new functionality
 
 ## 0.9.0
 
-- Draft implementation of slow reponses in P Model using weighted average approach
+- Draft implementation of slow responses in P Model using weighted average approach
 - Substantial maintenance review
 - User facing breaking changes:
   - Support for scalar inputs removed - numpy arrays now expected as inputs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ details.
 
 The package includes configuration for a set of `pre-commit` hooks to ensure code
 commits meet common community quality standards. The `pre-commit` tool blocks `git`
-commits until all hooks pass. You should install these to ensure that your commited code
-meets these standards.
+commits until all hooks pass. You should install these to ensure that your committed
+code meets these standards.
 
 See the [pre-commit configuration
 page](https://pyrealm.readthedocs.io/en/latest/development/code_qa_and_typing.md) for
@@ -106,9 +106,9 @@ the `profiling` directory. When this bash script is run without an argument, the
 `HEAD` will be compared to the `origin/develop` branch. Alternatively, the two commits
 to be compared can be provided as parameters with `-n` for the "new" commit (the current
 HEAD, or code you have changed), and `-o` for the "old" commit (the baseline code you
-want to compare the perfomance against). The code will fail with an error message if the
-new performance is more than 5% slower than the baseline, otherwise it will succeed with
-a message indicating whether the new code is faster or has similar performance.
+want to compare the performance against). The code will fail with an error message if
+the new performance is more than 5% slower than the baseline, otherwise it will succeed
+with a message indicating whether the new code is faster or has similar performance.
 
 ```sh
 cd profiling

--- a/docs/source/development/code_qa_and_typing.md
+++ b/docs/source/development/code_qa_and_typing.md
@@ -50,7 +50,7 @@ contains the pre-commit hooks used by `pyrealm`. The configuration file contains
 to each individual hook but in overview:
 
 `check for merge conflicts`
-: Checks for remaning `git` merge conflict markers in code files.
+: Checks for remaining `git` merge conflict markers in code files.
 
 `debug statements (python)`
 : Checks for debugger imports and `breakpoint()` calls, which should not end up in
@@ -137,7 +137,7 @@ developed to help support clear and consistent typing. We use
 bit of getting used to but is a key tool in maintaining clear code and variable
 structures.
 
-## Supressing checking
+## Suppressing checking
 
 The `pre-commit` tools sometimes complain about things that we do not want to change.
 Almost all of the tools can be told to suppress checking, using comments with a set
@@ -162,4 +162,4 @@ This should not be done lightly: we are using these QA tools for a reason.
   suppress format warnings. An example is `<!-- markdownlint-disable-line MD001 -->` and
   the tool homepage provides [a list of the MD rule0
   codes](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) that can be
-  used to surpress warnings.
+  used to suppress warnings.

--- a/docs/source/development/documentation.md
+++ b/docs/source/development/documentation.md
@@ -132,8 +132,8 @@ custom Author/Year citation style. The reference library in `source/refs.bib` ne
 be kept up to date with the literature for the project.
 
 The three common use cases are shown below using a couple of reference tags
-(`Prentice:2014bc` and `Wang:2017go`) that are inclued provided in the current
-[reference library](../refs.bib).
+(`Prentice:2014bc` and `Wang:2017go`) that are provided in the current [reference
+library](../refs.bib).
 
 * Cite with date in parentheses (``{cite:t}`Prentice:2014bc` ``): the model implemented
   in {cite:p}`Prentice:2014bc`.

--- a/docs/source/development/overview.md
+++ b/docs/source/development/overview.md
@@ -256,7 +256,7 @@ Exception) is generated.
 Again, the `pytest` package and plugins are installed by `poetry`. See the [code testing
 page](./code_testing.md) for more details but you should be able to check the tests run
 using the following command. Be warned that the `mypy` steps can be very time consuming
-on the first run, but `pytest` does some cacheing that makes them quicker when they next
+on the first run, but `pytest` does some caching that makes them quicker when they next
 run.
 
 ```sh
@@ -313,7 +313,7 @@ page](./release_process.md) for details.
 ## Setup script example
 
 The scripts below bundle all the commands together to show the set up process, including
-using `pyenv` to mangage `python` versions, ending by running the unit tests. This sets
+using `pyenv` to manage `python` versions, ending by running the unit tests. This sets
 up everything you need, ready to start developing on pyrealm.
 
 :::{admonition} Setup script

--- a/docs/source/development/profiling_and_benchmarking.md
+++ b/docs/source/development/profiling_and_benchmarking.md
@@ -67,11 +67,11 @@ poetry run pytest --profile-svg -m "profiling"
 
 This selects _only_ the profiling tests and runs them using `pytest-profiling`. The
 `--profile-svg` both runs the profiling _and_ generates a figure showing the call
-hierachy of code objects and the time spent in each call. Generating this graph requires
-the [graphviz](https://pypi.org/project/graphviz/) command line library, which provides
-the `dot` command for generating SVG graph diagrams. You will need to install `graphviz`
-to use this option. Alternatively, you can use the following command to only generate
-the profile data.
+hierarchy of code objects and the time spent in each call. Generating this graph
+requires the [graphviz](https://pypi.org/project/graphviz/) command line library, which
+provides the `dot` command for generating SVG graph diagrams. You will need to install
+`graphviz` to use this option. Alternatively, you can use the following command to only
+generate the profile data.
 
 ```bash
 poetry run pytest --profile -m "profiling"

--- a/docs/source/development/release_process.md
+++ b/docs/source/development/release_process.md
@@ -54,10 +54,10 @@ The steps of the process are:
    Log in to [https://readthedocs.org](https://readthedocs.org) which is the admin site
    controlling the build process. From the Versions tab, activate the `release/X.Y.Z`
    branch and wait for it to build. Check the Builds tab to see that it has built
-   successfully! If it has built succesfully, do check pages to make sure that page code
-   has executed successfully, and then go back to the Versions tab and deactivate and
-   hide the branch. If the release branch needs any changes, do come back and check that
-   those changes have also built successfully.
+   successfully! If it has built successfully, do check pages to make sure that page
+   code has executed successfully, and then go back to the Versions tab and deactivate
+   and hide the branch. If the release branch needs any changes, do come back and check
+   that those changes have also built successfully.
 
 1. **Start a pull request against the `main` branch**. The PR will transfer all of the
    changes to the `develop` branch since the last release on to the `main` branch. The
@@ -159,7 +159,7 @@ twine upload --repository testpypi --config-file .pypirc dist/*
 twine upload --repository pypi --config-file .pypirc dist/*
 ```
 
-The tricky bit is that you need to provide a config file containining authentication
+The tricky bit is that you need to provide a config file containing authentication
 tokens to permit publication. Those tokens **must not be included in the repository**
 and so need to be carefully shared with developers who make releases. If this is being
 used the `.pypirc` file contents will look something like:

--- a/docs/source/users/demography/canopy.md
+++ b/docs/source/users/demography/canopy.md
@@ -373,7 +373,7 @@ The canopy and crown models are extended by providing two gap fractions:
   displace leaf area further down into the canopy. Crown gaps do not push all the way
   down  to the ground - they only allow light to penetrate more deeply into the crown.
 * The canopy gap fraction ($f_G$) is described above and captures how the canopy across
-  the whole community may leave space unfilled in the canopy. Light passing throught
+  the whole community may leave space unfilled in the canopy. Light passing through
   canopy gaps passes unimpeded from the top of the canopy down to the ground.
 
 The code below alters the community and canopy model used above to include both crown

--- a/docs/source/users/demography/crown.md
+++ b/docs/source/users/demography/crown.md
@@ -207,7 +207,7 @@ ax2.set_aspect("equal")
 
 The examples below show the calculation of crown variables in `pyrealm`.
 
-### Calculting crown profiles
+### Calculating crown profiles
 
 The  {class}`~pyrealm.demography.crown.CrownProfile` class is used to calculate crown
 profiles for PFTs. It requires:

--- a/docs/source/users/demography/t_model.md
+++ b/docs/source/users/demography/t_model.md
@@ -284,7 +284,7 @@ fig.delaxes(axes[-1])
 ```
 
 As before, the {meth}`~pyrealm.demography.core.PandasExporter.to_pandas()` method of the
-{meth}`~pyrealm.demography.tmodel.StemAllometry` classs can be used to export
+{meth}`~pyrealm.demography.tmodel.StemAllometry` class can be used to export
 the data for each stem:
 
 ```{code-cell} ipython3

--- a/docs/source/users/pmodel/module_overview.md
+++ b/docs/source/users/pmodel/module_overview.md
@@ -70,7 +70,7 @@ model](./shared_components/two_leaf_model.md).
 In addition to the two P Model forms, this module also provides two extensions that
 build on the P Model:
 
-* The process of photosynthesis discriminates between the carbon isotopes occuring in
+* The process of photosynthesis discriminates between the carbon isotopes occurring in
   air, leaving characteristic isotopic signatures. The [Isotopic
   discrimination](isotopic_discrimination) module estimates the isotopic signatures from
   different P Models.

--- a/docs/source/users/pmodel/pmodel_details/worked_examples.md
+++ b/docs/source/users/pmodel/pmodel_details/worked_examples.md
@@ -81,7 +81,7 @@ The example shows the steps required using a single site with:
 The {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` also accepts estimates
 of the fraction of absorbed photosynthetically active radiation ($f_{APAR}$, `fapar`,
 unitless) and the photosynthetic photon flux density (PPFD,`ppfd`, µmol m-2 s-1).
-Together these are used to calculate the asorbed irradiance, which is used to scale up
+Together these are used to calculate the absorbed irradiance, which is used to scale up
 the estimated light use efficiency to estimate the actual productivity of the model.
 Here we are using:
 
@@ -106,7 +106,7 @@ env = PModelEnvironment(tc=20.0, patm=101325.0, vpd=820, co2=400, fapar=0.91, pp
 env
 ```
 
-The `env` object now holds the photosynthetic environment, which can be re-used with
+The `env` object now holds the photosynthetic environment, which can be reused with
 different P Model settings. The representation of a
 {class}`~pyrealm.pmodel.pmodel_environment.PModelEnvironment` object (`env`) is
 deliberately terse - just the shape of the data - but the

--- a/docs/source/users/pmodel/shared_components/photosynthetic_environment.md
+++ b/docs/source/users/pmodel/shared_components/photosynthetic_environment.md
@@ -57,7 +57,7 @@ functions.
 #
 # Note that the ranges are created (`_1d`) but are also cast to two dimensional
 # arrays of repeating values (`_2d`) to generate response surfaces for functions
-# with multuple inputs.
+# with multiple inputs.
 
 from matplotlib import pyplot
 import numpy as np

--- a/docs/source/users/pmodel/shared_components/quantum_yield.md
+++ b/docs/source/users/pmodel/shared_components/quantum_yield.md
@@ -33,7 +33,7 @@ The worked example from this page {download}`can be downloaded as Jupyter notebo
 #
 # Note that the ranges are created (`_1d`) but are also cast to two dimensional
 # arrays of repeating values (`_2d`) to generate response surfaces for functions
-# with multuple inputs.
+# with multiple inputs.
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/docs/source/users/pmodel/shared_components/soil_moisture.md
+++ b/docs/source/users/pmodel/shared_components/soil_moisture.md
@@ -104,7 +104,7 @@ obs_minutes = 30
 time_offsets = np.arange(0, n_obs * obs_minutes, obs_minutes).astype("timedelta64[m]")
 datetimes = np.datetime64("2000-01-01 00:00") + time_offsets
 
-# Constant P Model enviroment
+# Constant P Model environment
 env = PModelEnvironment(
     tc=np.full(n_obs, fill_value=20),
     patm=np.full(n_obs, fill_value=101325),

--- a/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_calculations.md
@@ -26,7 +26,7 @@ language_info:
 The worked example from this page {download}`can be downloaded as Jupyter notebook here </_static/SubdailyCalculations.ipynb>`.
 
 The code below works through the separate calculations used to include the acclimation
-of slow reponses into the predictions of the P Model. The code separates out individual
+of slow responses into the predictions of the P Model. The code separates out individual
 steps used in the estimation process in order to show intermediate results and provides
 an "exploded diagram" of the model. In practice, these calculations are handled
 internally by the model fitting in `pyrealm`, as shown in the [worked
@@ -215,7 +215,7 @@ jmax25_real = acclim_model.apply_acclimation(jmax25_acclim)
 ```
 
 The plots below show the instantaneously acclimated values for  $J_{max25}$,
-$V_{cmax25}$ and $\xi$ in grey along with the realised slow reponses, after
+$V_{cmax25}$ and $\xi$ in grey along with the realised slow responses, after
 application of the memory effect.
 
 ```{code-cell} ipython3
@@ -247,7 +247,7 @@ the realised slow responses for $\xi$, $J_{max25}$ and $V_{cmax25}$.
 #### Calculation of fast responses in $J_{max}$ and $V_{cmax}$
 
 Although the maximum rates at standard temperature $J_{max25}$ and $V_{cmax25}$ exhibit
-slow reponses, the values of $J_{max}$ and $V_{cmax}$ will respond to changes in
+slow responses, the values of $J_{max}$ and $V_{cmax}$ will respond to changes in
 temperature at fast scales:
 
 * The realised daily values of $J_{max25}$ and $V_{cmax25}$ are interpolated from the
@@ -274,7 +274,7 @@ jmax_subdaily = jmax25_subdaily * arrh_subdaily.calculate_arrhenius_factor(
 
 #### Calculation of $c_i$
 
-The subdaily variation in $c_i$ can now be calculated using $c_a$ and fast reponses in
+The subdaily variation in $c_i$ can now be calculated using $c_a$ and fast responses in
 $\Gamma^\ast$ with the realised slow responses of $\xi$. This is achieved by
 passing the realised values of $\xi$ as a fixed constraint to the calculation of
 optimal $\chi$, rather than calculating the instantaneously optimal values of $\xi$

--- a/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_model_and_missing_data.md
@@ -26,7 +26,7 @@ language_info:
 The worked example from this page {download}`can be downloaded as Jupyter notebook here </_static/SubdailyMissingData.ipynb>`.
 
 The acclimation process in the subdaily model uses a weighted mean of the daily
-acclimation conditions with preceeding daily conditions. When there are missing data,
+acclimation conditions with preceding daily conditions. When there are missing data,
 this results in problems in the estimation of the realised daily values for $\xi$,
 $V_{cmax25}$ and $J_{max25}$.
 

--- a/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
+++ b/docs/source/users/pmodel/subdaily_details/subdaily_overview.md
@@ -97,7 +97,7 @@ The implementation has the following steps:
 
 2. An [acclimation model](acclimation.md#the-acclimation-model) is then defined that
   sets a window of observations during the day that define the conditions that the slow
-  responses will acclimate towards. Thease are typically noon conditions that optimise
+  responses will acclimate towards. These are typically noon conditions that optimise
   light use efficiency during the daily period of highest photosynthetic photon flux
   density (PPFD). This model is used to calculate a daily time series of average
   conditions during this acclimation window.

--- a/docs/source/users/versions.md
+++ b/docs/source/users/versions.md
@@ -86,7 +86,7 @@ used the theoretical maximum value of 1/8.
   'fixed' and 'temperature' along with an experimental 'sandoval' method that models the
   effects of growth temperature and aridity on $\phi_0$.
 * All of the available method choices to `PModel` and `SubdailyPModel` now use $\phi_0 =
-  1/8$ as the default value but this can be overriden using `reference_kphio`.
+  1/8$ as the default value but this can be overridden using `reference_kphio`.
 
 Since this involves a change in the default behaviour that leads to different
 predictions, the `PModel` class in version 2.0.0 issues a warning to alert users.

--- a/profiling/run_benchmarking.py
+++ b/profiling/run_benchmarking.py
@@ -31,7 +31,7 @@ def get_function_map(root: Path) -> dict[tuple[str, int, str], str]:
     values are strings that identify functions within source files and methods within
     classes within source files.
 
-    One added difficulty is that the line numbering differs betwen the two approaches.
+    One added difficulty is that the line numbering differs between the two approaches.
     The line numbers reported by `ast` nodes are the _actual_ line where the `def` or
     `class` statement is found. The line numbers reported by `pstats` are offset if the
     callable has decorators, so this mapping function has to find the lowest line number

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,3 +171,7 @@ convention = "google"
 notebook_metadata_filter = "settings,mystnb,language_info,-jupytext.text_representation.jupytext_version"
 # Also stop it from stripping cell metadata, except for specific ones to lose.
 cell_metadata_filter = "all,-trusted"
+
+[tool.codespell]
+ignore-words = ".codespellignore.txt"
+skip = "*.js,*.html,*.css,*.ipynb,*.bib,*.svg,poetry.lock,./docs/build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,5 +173,6 @@ notebook_metadata_filter = "settings,mystnb,language_info,-jupytext.text_represe
 cell_metadata_filter = "all,-trusted"
 
 [tool.codespell]
+exclude-file = ".codespellexclude.txt"
 ignore-words = ".codespellignore.txt"
-skip = "*.js,*.html,*.css,*.ipynb,*.bib,*.svg,poetry.lock,./docs/build"
+skip = "*.js,*.html,*.css,*.ipynb,*.bib,*.svg,poetry.lock,./docs/build,pyrealm_build_data/splash/splash_py_version/*"

--- a/pyrealm/core/bounds.py
+++ b/pyrealm/core/bounds.py
@@ -15,7 +15,7 @@ The ``bounds`` module:
 
 A ``BoundsChecker`` class instance is created with a predefined internal dictionary of
 default variables and appropriate bounds. However, users can use the
-{meth}`~pyrealm.core.bounds.BoundsChecker.update` method to overide defaults or add new
+{meth}`~pyrealm.core.bounds.BoundsChecker.update` method to override defaults or add new
 variables by providing a new ``Bounds`` instance.
 
 The {meth}`~pyrealm.core.bounds.BoundsChecker.check` method can then be used to validate

--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -587,7 +587,7 @@ def calculate_daytime_net_radiation(
 
     Result:
         An array of daily net radiation.
-    """
+    """  # codespell:ignore nd
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
     rw = calculate_rw_intermediate(
         transmissivity=transmissivity,
@@ -653,7 +653,7 @@ def calculate_nighttime_net_radiation(
     solar_constant: float = CoreConst().solar_constant,
     day_seconds: float = CoreConst().day_seconds,
 ) -> NDArray[np.floating]:
-    r"""Calculates nightime net radiation.
+    r"""Calculates nighttime net radiation.
 
     This function calculates nighttime net radiation (:math:`R_{nn}`, J m-2) as:
 
@@ -715,7 +715,7 @@ def _calculate_nighttime_net_radiation(
     net_longwave_radiation: NDArray[np.floating],
     day_seconds: float = CoreConst().day_seconds,
 ) -> NDArray[np.floating]:
-    """Calculates nightime net radiation using precalculated intermediates.
+    """Calculates nighttime net radiation using precalculated intermediates.
 
     This function calculates nighttime net radiation (:math:`R_{nn}` :math:`J/m^2`), a
     using precalculated intermediate values (see :meth:`calculate_ru_rv_intermediates`

--- a/pyrealm/demography/core.py
+++ b/pyrealm/demography/core.py
@@ -50,7 +50,7 @@ class PandasExporter(ABC):
             stacked_data = {
                 "column_stem_index": np.repeat(np.arange(data_shape[1]), data_shape[0])
             }
-            # Ravel the attribute data using column-major Fortan style
+            # Ravel the attribute data using column-major Fortran style
             for ky, vl in data.items():
                 stacked_data[ky] = np.ravel(vl, order="F")
 

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -250,7 +250,7 @@ class CrownProfile(PandasExporter):
     In addition to the variables above, the class can also has properties the calculate
     the projected crown radius and projected leaf radius. These are simply the radii
     that would result in the two projected areas: the values are not directly meaningful
-    for calculating canopy models, but can be useful for exploring the behavour of
+    for calculating canopy models, but can be useful for exploring the behaviour of
     projected area on the same linear scale as the crown radius.
 
     Args:

--- a/pyrealm/pmodel/acclimation.py
+++ b/pyrealm/pmodel/acclimation.py
@@ -16,7 +16,7 @@ class AcclimationModel:
 
     This class provides methods that allow data to be converted between
     photsynthetically 'fast' and 'slow' timescales. Many plant responses to changing
-    enviroments are 'fast' - on the scale of minutes to seconds - but other responses
+    environments are 'fast' - on the scale of minutes to seconds - but other responses
     are slow - over the scale of days or weeks, capturing the timescales over which
     plants will acclimate to changing conditions.
 

--- a/pyrealm/pmodel/arrhenius.py
+++ b/pyrealm/pmodel/arrhenius.py
@@ -100,7 +100,7 @@ class ArrheniusFactorABC(ABC):
 
         Raises:
             ValueError: where the method name is not found in the coefficients
-                dictionary or the required coefficents are not found in that matched
+                dictionary or the required coefficients are not found in that matched
                 dictionary.
         """
 

--- a/pyrealm/pmodel/competition.py
+++ b/pyrealm/pmodel/competition.py
@@ -69,7 +69,7 @@ def calculate_tree_proportion(
 
     This function estimates the proportion of C3 trees in the community, which can then
     be used to penalise the fraction of C4 plants due to shading of C4 plants by canopy
-    closure, even when C4 photosynthesis is advantagious. The estimated tree cover
+    closure, even when C4 photosynthesis is advantageous. The estimated tree cover
     function is:
 
         .. math::

--- a/pyrealm/pmodel/functions.py
+++ b/pyrealm/pmodel/functions.py
@@ -235,7 +235,7 @@ def calc_gammastar(
         A float value or values for :math:`\Gamma^{*}` (in Pa)
 
     Examples:
-        >>> # CO2 compensation point at 20 °C  (293.15 K) and standard presssure
+        >>> # CO2 compensation point at 20 °C  (293.15 K) and standard pressure
         >>> calc_gammastar(np.array([293.15]), np.array([101325])).round(5)
         array([3.33925])
     """

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -35,7 +35,7 @@ class DailyEvapFluxes:
     SPLASH model to estimate initial equilibrium soil moisture, or the daily calculation
     of soil moisture along a time series. These quantities are estimated using the
     :meth:`~pyrealm.splash.evap.DailyEvapFluxes.estimate_aet` method, given an estimate
-    of soil moisture from the preceeding day.
+    of soil moisture from the preceding day.
 
     Args:
         solar: A :class:`~pyrealm.splash.solar.DailySolarFluxes` instance from which to
@@ -154,7 +154,7 @@ class DailyEvapFluxes:
 
         # Check day_idx inputs and create the indexing object `didx`, used to either
         # subset the calculations to particular request days or use the entire array of
-        # soil moisture. The slice here is used to programatically select `array[:]`.
+        # soil moisture. The slice here is used to programmatically select `array[:]`.
         if day_idx is None:
             splash_shape = self.shape
             didx: int | slice = slice(self.shape[0])

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -40,7 +40,7 @@ class SplashModel:
       these calculations, given an initial estimate of soil moisture in observed sites.
       This method simply iterates over the days, applying the
       :meth:`~pyrealm.splash.splash.SplashModel.estimate_daily_water_balance` method to
-      calculate the daily water balance, given the soil moisture of the preceeding day.
+      calculate the daily water balance, given the soil moisture of the preceding day.
 
     * The :meth:`~pyrealm.splash.splash.SplashModel.estimate_initial_soil_moisture`
       method can be used to estimate an initial soil moisture for a time series from the
@@ -247,7 +247,7 @@ class SplashModel:
 
         This function estimates the daily water balance within observations. The
         function first calculates the expected actual evapotranspiration (mm d-1,
-        :math:`\textrm{AET}_{[t]}`), given the soil moisture from the preceeding day
+        :math:`\textrm{AET}_{[t]}`), given the soil moisture from the preceding day
         (mm, :math:`W_{n[t-1]}`). Those are then used, along with the precipitation (mm
         d-1, :math:`P_{[t]}`) and condensation (mm d-1, :math:`C_{[t]}`) for the current
         day, to calculate the current soil moisture (mm, :math:`W_{n[t]}`) as:
@@ -269,7 +269,7 @@ class SplashModel:
         Args:
             day_idx: Optionally, the index of the date for which to calculate water
                 balance.
-            previous_wn: Soil moisture estimates for the preceeding day (mm)
+            previous_wn: Soil moisture estimates for the preceding day (mm)
 
         Returns:
             A tuple of numpy arrays containing estimated  AET, daily soil moisture and

--- a/pyrealm_build_data/sandoval_kphio/calc_phi0.R
+++ b/pyrealm_build_data/sandoval_kphio/calc_phi0.R
@@ -17,7 +17,7 @@ calc_phi0 <- function(AI, tc, mGDD0 = NA, phi_o_theo = 1 / 9) {
     # 01.define the parameters/constants
     ###############################################################################################
 
-    # DO change here to avoid imprecision in theoretical maxmimum and to allow alternatives
+    # DO change here to avoid imprecision in theoretical maximum and to allow alternatives
     # phi_o_theo <- 0.111 # theoretical maximum phi0 (Long, 1993;Sandoval et al., in.prep.)
 
     m <- 6.8681 # curvature parameter phio max (Sandoval et al., in.prep.)

--- a/pyrealm_build_data/t_model/rtmodel_test_outputs.r
+++ b/pyrealm_build_data/t_model/rtmodel_test_outputs.r
@@ -43,7 +43,7 @@ tmodel <- function(P0, year, a, cr, Hm, rho, rr,
         Rm1 <- Wss * rs
         # fine root respiration
         Rm2 <- zeta * sigma * Wf * rr
-        # NPP after multiplied by the yeild factor
+        # NPP after multiplied by the yield factor
         NPP1 <- y * (GPP - Rm1 - Rm2)
         # turnover of foliage and fine root
         NPP2 <- (Ac * L * ((1 / (sigma * tf)) + (zeta / tr)))
@@ -69,11 +69,11 @@ tmodel <- function(P0, year, a, cr, Hm, rho, rr,
         # final scaling to dD but the brackets differ. I've replaced
         # it with code that matches NPP3
 
-        # increament of foliage and fine root
+        # increment of foliage and fine root
         # dWfr <- (L * ((pi * cr)/(4 * a)) * (a * d * (1 - (H/Hm) + H)) *
         #  (1/sigma + zeta)) * dD
 
-        # increament of foliage and fine root
+        # increment of foliage and fine root
         dWfr <- (L * (
             (pi * cr) / (4 * a)
         ) * (
@@ -95,7 +95,7 @@ for (pft_idx in seq_len(nrow(pfts))) {
     # Get the PFT
     pft <- as.list(pfts[pft_idx, ])
 
-    # Seperate off the name
+    # Separate off the name
     name <- pft[["name"]]
     pft[["name"]] <- NULL
 
@@ -123,7 +123,7 @@ for (pft_idx in seq_len(nrow(pfts))) {
     # Get the PFT
     pft <- as.list(pfts[pft_idx, ])
 
-    # Seperate off the name
+    # Separate off the name
     name <- pft[["name"]]
     pft[["name"]] <- NULL
     pft[["P0"]] <- 7 / 0.9

--- a/pyrealm_build_data/t_model/t_model.r
+++ b/pyrealm_build_data/t_model/t_model.r
@@ -22,7 +22,7 @@ tmodel <- function(P0, year, a, cr, Hm, rho, rr, rs, L, zeta, y, sigma, tf, tr, 
         gpp <- P0[i] * (1 - exp(-(K * L))) # GPP fixed per m2 of crown
         Rm1 <- Wss * rs # sapwood respiration
         Rm2 <- zeta * sigma * Wf * rr # fine root respiration
-        NPP1 <- y * (GPP - Rm1 - Rm2) # NPP after multiplied by the yeild factor
+        NPP1 <- y * (GPP - Rm1 - Rm2) # NPP after multiplied by the yield factor
         NPP2 <- (Ac * L * ((1 / (sigma * tf)) + (zeta / tr))) # turnover of foliage and fine root
         # 		NPP3 <- (L * ((pi * cr)/(4 * a)) * (a * d * (1 - H/Hm) + H)) * (1/sigma + zeta)
         # 		dD <- (NPP1 - NPP2)/(NPP3 + dWs)
@@ -30,7 +30,7 @@ tmodel <- function(P0, year, a, cr, Hm, rho, rr, rs, L, zeta, y, sigma, tf, tr, 
         den <- (a / (2 * cr)) * rho * (a * d * (1 / H - 1 / Hm) + 2) + (L / d) * (a * d * (1 / H - 1 / Hm) + 1) * (1 / sigma + zeta)
         dD <- num / den # increment of diameter
         dWs <- (pi / 8 * rho * d * (a * d * (1 - (H / Hm)) + 2 * H)) * dD # increment of wood
-        dWfr <- (L * ((pi * cr) / (4 * a)) * (a * d * (1 - (H / Hm) + H)) * (1 / sigma + zeta)) * dD # increament of foliage and fine root
+        dWfr <- (L * ((pi * cr) / (4 * a)) * (a * d * (1 - (H / Hm) + H)) * (1 / sigma + zeta)) * dD # increment of foliage and fine root
         output[i, ] <- c(dD / 2 * 1000, d, H, Ac)
     }
     output

--- a/pyrealm_build_data/uk_data/__init__.py
+++ b/pyrealm_build_data/uk_data/__init__.py
@@ -6,5 +6,5 @@ The Python script ``create_2D_uk_inputs.py``  is used to generate the NetCDF out
 ``UK_WFDE5_FAPAR_2018_JuneJuly.nc``. The script is currently written with a hard-coded
 set of paths to key source data - the WFDE5 v2 climate data and a separate source of
 interpolated hourly fAPAR. This should probably be rewritten to generate reproducible
-content from publically available sources of these datasets.
+content from publicly available sources of these datasets.
 """  # noqa: D205

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -434,7 +434,7 @@ class Context:
     """Context class to pass between functions.
 
     Used to initialise arguments that depend on array shapes or for manual overrides
-    that rely upon the heirarchy of function/argument definitions.
+    that rely upon the hierarchy of function/argument definitions.
 
     Attributes:
         name (str): Name of the current method/function/class.
@@ -453,7 +453,7 @@ class Context:
     """A list of the superior function / classes for the current context."""
 
     def new(self, name: str) -> "Context":
-        """Generate a context for a new function/class, updating the heirarchy."""
+        """Generate a context for a new function/class, updating the hierarchy."""
         return Context(name, self.shapes, self.i_arg, [*self.parents, self.name])
 
     def shape(self) -> tuple[int, ...]:
@@ -545,7 +545,7 @@ def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
         if manual_arg is not None:
             kwargs[param_name] = manual_arg
 
-        # Skip unnecesary arguments
+        # Skip unnecessary arguments
         elif param_name == "self" or param.kind in (
             param.VAR_POSITIONAL,
             param.VAR_KEYWORD,

--- a/tests/regression/pmodel/test_pmodel.py
+++ b/tests/regression/pmodel/test_pmodel.py
@@ -59,7 +59,7 @@ def values():
 # Test structure
 # The basic structure of these tests  is to use a pytest.mark.parameterise
 # to pass in the variables to be passed to the function along with the key
-# for sets of expected ouputs and any context managers.
+# for sets of expected outputs and any context managers.
 #
 # A separate R file is used to read in the same inputs to R and run them through
 # rpmodel to generate the output file.
@@ -885,7 +885,7 @@ def test_lavergne_equivalence(tc, theta, variable_method, fixed_method, is_C4):
     the equivalent non-soil moisture versions.
     """
     # Cannot do this test using N-D inputs because the PModelConst expect scalar values
-    # for paramaterizing beta - you can't set an array of values. So, test combinations
+    # for parameterizing beta - you can't set an array of values. So, test combinations
     # of temperature and soil moisture.
 
     from pyrealm.constants import PModelConst

--- a/tests/regression/pmodel/test_pmodel_global_array.py
+++ b/tests/regression/pmodel/test_pmodel_global_array.py
@@ -117,7 +117,7 @@ def test_pmodel_global_array(dataset, ctrl):
     #                       kphio=0.05, do_ftemp_kphio=False)
     # scaled = model.unit_iabs.scale_iabs(fapar=0.3468055, ppfd=74848.94)
     #
-    # ## Run the P model in a loction with missing data
+    # ## Run the P model in a location with missing data
     #
     # idx = (0, 176, 653)
     #

--- a/tests/regression/splash/test_evap.py
+++ b/tests/regression/splash/test_evap.py
@@ -42,7 +42,7 @@ def test_evap_scalar(splash_core_constants):
     )
 
     # The original implementation provided sw=0.9 here, but that is now calculated
-    # internally from the wn value. Check that it is recreated succesfully.
+    # internally from the wn value. Check that it is recreated successfully.
     aet, hi, sw = evap.estimate_aet(wn=np.array([128.571429]), only_aet=False)
 
     # Output of __main__ code in original evap.py
@@ -187,7 +187,7 @@ def test_evap_array_grid(splash_core_constants, grid_benchmarks, expected_attr):
     # Now validate the expected AET - because the whole soil moisture sequence has
     # been created in the original implementation, the whole time sequence can be passed
     # in as a single array and calculated without daily iteration, *but* the soil
-    # moisture used to calculate AET is from the preceeding day, so need to shift the wn
+    # moisture used to calculate AET is from the preceding day, so need to shift the wn
     # sequence to start with the spun up values and drop the last day.
     wn_spun_up = np.expand_dims(expected["wn_spun_up"].data, axis=0)
     wn_sequence = np.vstack([wn_spun_up, expected["wn"].data[:-1, :, :]])

--- a/tests/regression/splash/test_splash.py
+++ b/tests/regression/splash/test_splash.py
@@ -1,7 +1,7 @@
 """This module tests the main methods in the SplashModel.
 
 - estimate_daily_water_balance, which estimates soil moisture and run off given
-  preceeding soil moisture
+  preceding soil moisture
 - estimate_initial_soil_moisture, which assumes a stationary relationship over an
   annual cycle to estimate a starting soil moisture.
 - calculate_soil_moisture, which iterates an initial soil moisture forward over a time

--- a/tests/regression/two_leaf_canopy/test_two_leaf_model.py
+++ b/tests/regression/two_leaf_canopy/test_two_leaf_model.py
@@ -27,7 +27,7 @@ def solar_elevation():
 
 @pytest.fixture
 def solar_irradiance(solar_elevation, get_data):
-    """Creates instace of TwoLeafIrradiance class."""
+    """Creates an instance of TwoLeafIrradiance class."""
 
     data = get_data.loc[(get_data["time"] == "2014-08-01 12:30:00")]
 

--- a/tests/unit/core/test_solar.py
+++ b/tests/unit/core/test_solar.py
@@ -320,9 +320,9 @@ def test_calculate_net_radiation_crossover_hour_angle(inputs, expected):
 def test_daytime_net_radiation(inputs, expected):
     """Tests calculation of net daytime radiation.
 
-    This test orginally had an expected value of [21774953], which required rtol=1e-6 in
-    the assertions. It isn't clear where that test value came from, but the current one
-    allows for more exact tests, which is probably better for trapping small errors.
+    This test originally had an expected value of [21774953], which required rtol=1e-6
+    in the assertions. It isn't clear where that test value came from, but the current
+    one allows for more exact tests, which is probably better for trapping small errors.
     """
 
     from pyrealm.core.solar import (

--- a/tests/unit/demography/test_community.py
+++ b/tests/unit/demography/test_community.py
@@ -151,7 +151,7 @@ def test_Cohorts(args, outcome, excep_message):
         cohort_ids = getattr(cohorts, "cohort_id", None)
         assert cohort_ids is not None
 
-        # This could be tested implictly by just running the line, but this is to
+        # This could be tested implicitly by just running the line, but this is to
         # clarify that this conversion must complete successfully as part of the test.
         with not_raises():
             _ = [uuid.UUID(id_value) for id_value in cohort_ids]

--- a/tests/unit/demography/test_crown.py
+++ b/tests/unit/demography/test_crown.py
@@ -41,7 +41,7 @@ example a total of 3 stem properties:
 def fixture_z_qz_stem_properties(request):
     """Fixture providing test combinations of trait, size (z) and q_z values.
 
-    This fixture provides a menu of inputs that can be used by tests throught indirect
+    This fixture provides a menu of inputs that can be used by tests through indirect
     parameterisation to share a set of test cases of inputs for the z, stem properties
     q_z arguments and expected outcome and exception message. In each case, the returned
     value is a ZQZInput instance.
@@ -622,7 +622,7 @@ def test_calculate_stem_projected_leaf_area_at_z_values(fixture_community):
 
     assert_allclose(leaf_area_fg0, expected_leaf_area_fg0)
 
-    # More rigourous check - with f_g = 0, the projected leaf area of each stem in the
+    # More rigorous check - with f_g = 0, the projected leaf area of each stem in the
     # lowest layer must equal the crown area (all the crown is now accounted for).
     assert_allclose(leaf_area_fg0[[0]], fixture_community.stem_allometry.crown_area)
     # Also the diagonal of the resulting matrix (4 heights for 4 cohorts) should _also_

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -813,7 +813,7 @@ def test_tmodel_enforce_positive_sizes(
 ):
     """Test the validation of positive size values in T model functions.
 
-    The function call is assembled programatically. It excludes testing of reproductive
+    The function call is assembled programmatically. It excludes testing of reproductive
     tissue respiration and turnover because these do allow zero values.
     """
     from pyrealm.demography import tmodel

--- a/tests/unit/pmodel/test_acclimation_model.py
+++ b/tests/unit/pmodel/test_acclimation_model.py
@@ -1007,7 +1007,7 @@ def test_AcclimationModel_fill_daily_to_subdaily_previous(
     """Test AcclimationModel.fill_daily_to_subdaily using method previous.
 
     The first parameterisation sets the exact same acclimation windows in a bunch of
-    different ways. The second paramaterisation provides inputs with different
+    different ways. The second parameterisation provides inputs with different
     dimensionality.
     """
 

--- a/tests/unit/splash/test_splash_model.py
+++ b/tests/unit/splash/test_splash_model.py
@@ -1,7 +1,7 @@
 """This module tests the main methods in the SplashModel.
 
 - estimate_daily_water_balance, which estimates soil moisture and run off given
-  preceeding soil moisture
+  preceding soil moisture
 - estimate_initial_soil_moisture, which assumes a stationary relationship over an
   annual cycle to estimate a starting soil moisture.
 - calculate_soil_moisture, which iterates an initial soil moisture forward over a time


### PR DESCRIPTION
# Description

This PR:
* Adds `codespell` to the pre-commit setup
* Adds config to `pyproject.toml`
* Adds `.codespellignore.txt` to add words to ignore (currently empty)
* Adds `.codespellexclude.txt` to add exact lines to ignore. This seems to be the only mechanism to easily exclude bogus matches within docstrings - you include the entire line in this file and then that line gets skipped before `codespell` breaks it up into words and checks it.
* Fixes a ton of mis-spellings.

Fixes #560

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
