### PR TITLE
Remove overzealous warnings formatting

### DIFF
--- a/pyrealm/__init__.py
+++ b/pyrealm/__init__.py
@@ -1,7 +1,4 @@
-"""The pyrealm package.
-
-TODO: complete this documentation
-"""
+"""The pyrealm package."""
 
 import importlib.metadata
 

--- a/pyrealm/__init__.py
+++ b/pyrealm/__init__.py
@@ -4,23 +4,5 @@ TODO: complete this documentation
 """
 
 import importlib.metadata
-import os
-import warnings
 
 __version__ = importlib.metadata.version("pyrealm")
-
-
-# Setup warnings to simpler one line warning
-def warning_on_one_line(
-    message: Warning | str,
-    category: type[Warning],
-    filename: str,
-    lineno: int,
-    line: str | None = None,
-) -> str:
-    """Provide a simple one line warning for use in docstrings."""
-    filename = os.path.join("pyrealm", os.path.basename(filename))
-    return f"{filename}:{lineno}: {category.__name__}: {message}\n"
-
-
-warnings.formatwarning = warning_on_one_line

--- a/pyrealm/core/hygro.py
+++ b/pyrealm/core/hygro.py
@@ -120,10 +120,6 @@ def convert_rh_to_vpd(
         >>> allen = CoreConst(magnus_option='Allen1998')
         >>> convert_rh_to_vpd(rh, temp, core_const=allen).round(7)
         array([0.7461016])
-        >>> rh_percent = np.array([70])
-        >>> convert_rh_to_vpd(rh_percent, temp).round(7) #doctest: +ELLIPSIS
-        pyrealm... contains values outside the expected range (0,1). Check units?
-        array([-171.1823864])
     """
 
     rh = bounds_checker.check("rh", rh)


### PR DESCRIPTION
# Description

This PR removes code from `pyrealm.__init__.py` that was intended to provide package specific warning formatting but actually globally changes formatting and obscures warning sources. The intended package functionality is not really needed any more.

Fixes #587 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
