### PR TITLE
Add regression test of `FaparLimitationNew.from_pmodel`

### DIFF
--- a/pyrealm/phenology/fapar_limitation_new.py
+++ b/pyrealm/phenology/fapar_limitation_new.py
@@ -621,4 +621,5 @@ class FaparLimitationNew:
             years=avc.years,
             method=method,
             phenology_const=phenology_const,
+            **kwargs,
         )

--- a/tests/regression/phenology/conftest.py
+++ b/tests/regression/phenology/conftest.py
@@ -83,11 +83,11 @@ def pmodel_outputs(timescale):
 
 
 @pytest.fixture()
-def fapar_max_predictions(phenology_method):
+def fapar_max_predictions(method_predictions_dir):
     """Returns the annual fapar_max predictions for a given method."""
 
     datafile = (
-        resources.files(f"pyrealm_build_data.phenology.{phenology_method}")
+        resources.files(f"pyrealm_build_data.phenology.{method_predictions_dir}")
         / "fapar_max_predictions.csv"
     )
 
@@ -95,11 +95,11 @@ def fapar_max_predictions(phenology_method):
 
 
 @pytest.fixture()
-def daily_lai_predictions(phenology_method):
+def daily_lai_predictions(method_predictions_dir):
     """Returns the annual fapar_max predictions for a given method."""
 
     datafile = (
-        resources.files(f"pyrealm_build_data.phenology.{phenology_method}")
+        resources.files(f"pyrealm_build_data.phenology.{method_predictions_dir}")
         / "daily_lai_predictions.csv"
     )
 

--- a/tests/regression/phenology/test_fapar_limitation_new.py
+++ b/tests/regression/phenology/test_fapar_limitation_new.py
@@ -1,63 +1,15 @@
 """Test the FaparLimitation class."""
 
-import json
-from importlib import resources
-
-import pandas as pd
+import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
 
-def dataframe_to_dict_of_nparrays(data):
-    """Utility function to preconvert a dataframe of pd.Series to np.array."""
-
-    data_dict = {k: v.to_numpy() for k, v in data.items()}
-
-    return data_dict
-
-
-@pytest.fixture
-def site_data():
-    """Load the site data."""
-
-    datafile = (
-        resources.files("pyrealm_build_data.phenology.inputs.source")
-        / "DE-GRI_site_data.json"
-    )
-
-    with open(str(datafile)) as json_src:
-        site_data = json.load(json_src)
-
-    return site_data
-
-
-@pytest.fixture()
-def data_fapar_limitation(timescale, method_predictions_dir):
-    """Load the input data from csv file."""
-
-    inputs = pd.read_csv(
-        str(
-            resources.files(f"pyrealm_build_data.phenology.inputs.{timescale}")
-            / "annual_inputs.csv"
-        )
-    )
-
-    predictions = pd.read_csv(
-        str(
-            resources.files(f"pyrealm_build_data.phenology.{method_predictions_dir}")
-            / "fapar_max_predictions.csv"
-        )
-    )
-
-    data = inputs.merge(predictions)
-    return dataframe_to_dict_of_nparrays(data)
-
-
 @pytest.mark.parametrize(
-    argnames="timescale,timescale_abbr,assim_var",
+    argnames="timescale,assim_var",
     argvalues=(
-        pytest.param("fortnightly", "ft", "annual_total_A0", id="fortnightly"),
-        pytest.param("subdaily", "hh", "annual_total_A0_smstress", id="subdaily"),
+        pytest.param("ft", "annual_total_A0", id="fortnightly"),
+        pytest.param("hh", "annual_total_A0_smstress", id="subdaily"),
     ),
 )
 @pytest.mark.parametrize(
@@ -69,11 +21,11 @@ def data_fapar_limitation(timescale, method_predictions_dir):
 )
 def test_faparlimitation(
     site_data,
-    data_fapar_limitation,
-    timescale,  # parameterises data_fapar_limitation fixture
-    timescale_abbr,
+    annual_inputs,
+    fapar_max_predictions,
+    timescale,  # parameterises annual_inputs fixture
     assim_var,
-    method_predictions_dir,  # parameterises data_fapar_limitation fixture
+    method_predictions_dir,  # parameterises fapar_max_predictions fixture
     method,
 ):
     """Regression test for FaparLimitation constructor with fortnightly data."""
@@ -81,24 +33,132 @@ def test_faparlimitation(
     from pyrealm.phenology.fapar_limitation_new import FaparLimitationNew
 
     faparlim = FaparLimitationNew(
-        annual_total_potential_gpp=data_fapar_limitation[assim_var],
-        annual_mean_ca=data_fapar_limitation["annual_mean_ca_in_GS"],
-        annual_mean_chi=data_fapar_limitation["annual_mean_chi_in_GS"],
-        annual_mean_vpd=data_fapar_limitation["annual_mean_VPD_in_GS"],
-        annual_total_precip=data_fapar_limitation["annual_precip_molar"],
-        annual_growing_season_length=data_fapar_limitation["N_growing_days"],
-        years=data_fapar_limitation["year"].astype(str).astype("datetime64[Y]"),
+        annual_total_potential_gpp=annual_inputs[assim_var],
+        annual_mean_ca=annual_inputs["annual_mean_ca_in_GS"],
+        annual_mean_chi=annual_inputs["annual_mean_chi_in_GS"],
+        annual_mean_vpd=annual_inputs["annual_mean_VPD_in_GS"],
+        annual_total_precip=annual_inputs["annual_precip_molar"],
+        annual_growing_season_length=annual_inputs["N_growing_days"],
+        years=annual_inputs["year"].astype(str).astype("datetime64[Y]"),
         method=method,
         aridity_index=site_data["AI_from_cruts"],  # Not used by zhu method.
     )
 
     assert_allclose(
-        data_fapar_limitation[f"fapar_max_{timescale_abbr}"],
+        fapar_max_predictions[f"fapar_max_{timescale}"],
         faparlim.fapar_max,
         rtol=1e-6,
     )
     assert_allclose(
-        data_fapar_limitation[f"lai_max_{timescale_abbr}"],
+        fapar_max_predictions[f"lai_max_{timescale}"],
         faparlim.lai_max,
         rtol=1e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="method_predictions_dir, method",
+    argvalues=(
+        pytest.param("cai_zhou_method", "cai", id="cai"),
+        pytest.param("zhu_method", "zhu", id="zhu"),
+    ),
+)
+@pytest.mark.parametrize(
+    argnames="timescale",
+    argvalues=(
+        pytest.param("hh", id="subdaily"),
+        pytest.param("ft", id="fortnightly"),
+    ),
+)
+def test_fapar_limitation_frompmodel(
+    site_data,
+    pmodel_inputs,
+    pmodel_outputs,
+    daily_assimilation,
+    fapar_max_predictions,
+    daily_lai_predictions,
+    method_predictions_dir,
+    method,
+    timescale,
+):
+    """Regression test for  FaparLimitation.from_pmodel class method."""
+
+    from pyrealm.phenology.fapar_limitation_new import FaparLimitationNew
+    from pyrealm.pmodel import (
+        AcclimationModel,
+        PModel,
+        PModelEnvironment,
+        SubdailyPModel,
+    )
+
+    env = PModelEnvironment(
+        tc=pmodel_inputs["tc"],
+        vpd=pmodel_inputs["vpd"],
+        co2=pmodel_inputs["co2"],
+        patm=pmodel_inputs["patm"],
+        fapar=pmodel_inputs["fapar"],
+        ppfd=pmodel_inputs["ppfd"],
+    )
+
+    pmodel_inputs["time"] = pmodel_inputs["time"].astype("datetime64[s]")
+
+    # The two timescales use different PModels and also need to specify the datetimes
+    # and gpp penalty factors in FaparLimitation differently
+    if timescale == "ft":
+        # Fit PModel
+        pmodel = PModel(
+            env=env,
+            reference_kphio=1 / 8,
+            method_kphio="temperature",
+        )
+        # Define datetimes of observations - no GPP penalty
+        fl_datetimes = pmodel_inputs["time"]
+        gpp_penalty_factor = None
+
+    else:
+        # Set up the datetimes of the observations and set the acclimation window
+        acclim = AcclimationModel(
+            datetimes=pmodel_inputs["time"],
+            alpha=1 / 15,
+        )
+        acclim.set_window(
+            window_center=np.timedelta64(12, "h"),
+            half_width=np.timedelta64(30, "m"),
+        )
+
+        # Fit the subdaily PModel
+        pmodel = SubdailyPModel(
+            env=env,
+            acclim_model=acclim,
+            reference_kphio=1 / 8,
+            method_kphio="temperature",
+        )
+
+        # FaparLimitation uses the datetimes from pmodel.acclim_model and uses a soil
+        # moisture stress penalty
+        fl_datetimes = None
+        gpp_penalty_factor = pmodel_inputs["soilm_stress"]
+
+    # Check the GPP predictions
+    assert_allclose(pmodel.gpp, pmodel_outputs["gpp"], rtol=1e-7)
+    assert_allclose(pmodel.optchi.ci, pmodel_outputs["ci"], rtol=1e-7)
+    assert_allclose(pmodel.optchi.chi, pmodel_outputs["chi"], rtol=1e-7)
+
+    pmodel_inputs["time"] = pmodel_inputs["time"].astype("datetime64[s]")
+
+    faparlim = FaparLimitationNew.from_pmodel(
+        pmodel=pmodel,
+        method=method,
+        growing_season=pmodel_inputs["growing_season"],
+        datetimes=fl_datetimes,
+        precip=pmodel_inputs["precip_molar"],
+        gpp_penalty_factor=gpp_penalty_factor,
+        aridity_index=site_data["AI_from_cruts"],  # Not used by zhu method.
+    )
+
+    assert_allclose(
+        fapar_max_predictions[f"fapar_max_{timescale}"], faparlim.fapar_max, rtol=1e-6
+    )
+    assert_allclose(
+        fapar_max_predictions[f"lai_max_{timescale}"], faparlim.lai_max, rtol=1e-6
     )

--- a/tests/regression/phenology/test_phenology_faparlimitation.py
+++ b/tests/regression/phenology/test_phenology_faparlimitation.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 
 
 @pytest.mark.parametrize(
-    argnames="phenology_method",
+    argnames="method_predictions_dir",
     argvalues=(pytest.param("cai_zhou_method"),),
 )
 @pytest.mark.parametrize(
@@ -20,7 +20,7 @@ def test_faparlimitation(
     site_data,
     annual_inputs,
     fapar_max_predictions,
-    phenology_method,  # Used to parameterise the fapar_max_predictions fixture
+    method_predictions_dir,  # Used to parameterise the fapar_max_predictions fixture
     timescale,  # Also used to parameterise the annual_inputs fixture
     A0_variable,
 ):
@@ -58,7 +58,7 @@ def test_faparlimitation(
 
 
 @pytest.mark.parametrize(
-    argnames="phenology_method",
+    argnames="method_predictions_dir",
     argvalues=(pytest.param("cai_zhou_method"),),
 )
 @pytest.mark.parametrize(
@@ -73,8 +73,8 @@ def test_phenology(
     annual_inputs,
     daily_assimilation,
     daily_lai_predictions,
-    phenology_method,  # Used by pytest to parameterise the annual_inputs fixture
-    timescale,
+    method_predictions_dir,  # Used to parameterise the fapar_max_predictions fixture
+    timescale,  # Also used by pytest to parameterise the annual_inputs fixture
     A0_variable,
 ):
     """Regression test of the Phenology class on subdaily data."""
@@ -115,7 +115,7 @@ def test_phenology(
 
 
 @pytest.mark.parametrize(
-    argnames="phenology_method",
+    argnames="method_predictions_dir",
     argvalues=(pytest.param("cai_zhou_method"),),
 )
 @pytest.mark.parametrize(
@@ -132,6 +132,7 @@ def test_fapar_limitiation_frompmodel_to_phenology(
     daily_assimilation,
     fapar_max_predictions,
     daily_lai_predictions,
+    method_predictions_dir,  # Used to parameterise the fapar_max_predictions fixture
     timescale,
 ):
     """Regression test for from_pmodel FaparLimitation class method and Phenology.
@@ -220,7 +221,8 @@ def test_fapar_limitiation_frompmodel_to_phenology(
         fapar_max_predictions[f"lai_max_{timescale}"], faparlim.lai_max, rtol=1e-6
     )
 
-    # The subdaily and standard pmodel._get_daily_gpp have different APIs.
+    # The subdaily and standard pmodel._get_daily_gpp have different APIs and pylance
+    # moans.
     if timescale == "ft":
         days, gpp = pmodel._get_daily_gpp(datetimes=pmodel_inputs["time"])
     else:


### PR DESCRIPTION
# Description

I had left out a regression test of the `FaparLimitationNew.from_pmodel` method in the new implementation. This PR:

* Copies the existing test of the method on the old implementation out of `tests/regression/phenology/test_phenology_faparlimitation.py` and then updates it to run both methods available in the new implementation.
* Removes some fixture duplication and aligns the fixtures used by the new and old versions, so that both test suites run off the same fixtures and parameterisation.
* Fixes a bug where the additional variables in `**kwargs` were not being passed down through `from_pmodel` into the class constructor.

This is being merged down into the feature branch for this new functionality (#600)

Fixes #604 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
