### PR TITLE
fix missing bracket in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ from pyrealm.pmodel import PModelEnvironment, PModel
 # Calculate the photosynthetic environment given the conditions
 env = PModelEnvironment(
     tc=np.array([20]), vpd=np.array([1000]),
-    co2=np.array([400]), patm=np.array([101325.0],
+    co2=np.array([400]), patm=np.array([101325.0]),
     fapar=1, ppfd=300)
-)
 
 # Calculate the predictions of the P Model for a C3 plant
 pmodel_c3 = PModel(env)
@@ -91,7 +90,7 @@ pmodel_c3.gpp
 This should give the following output:
 
 ```python
-array([76.42544948])
+array([116.80365553])
 ```
 
 The package website provides worked examples of using `pyrealm`, for example to:


### PR DESCRIPTION
# Description

This PR fixes the missing bracket and output in the README.md in the example - estimated gross productivity of a C3 plant in a location.


