### PR TITLE
Allow a gpp penalisation to be attached to a PModel instance

### DIFF
--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -246,7 +246,6 @@ class FaparLimitation:
         precip: NDArray[np.floating],
         aridity_index: NDArray[np.floating],
         datetimes: NDArray[np.datetime64] | None = None,
-        gpp_penalty_factor: NDArray[np.floating] | None = None,
         phenology_const: PhenologyConst = PhenologyConst(),
     ) -> FaparLimitation:
         r"""Create a FaparLimitation instance from a P Model and other inputs.
@@ -300,8 +299,6 @@ class FaparLimitation:
                 considered as part of the growing season.
             precip: An array of precipitation for each observation.
             aridity_index: A climatological estimate of local aridity index.
-            gpp_penalty_factor: A post-hoc penalty factor to be applied to estimated
-                GPP.
             phenology_const: An instance of
                 :class:`~pyrealm.constants.phenology_const.PhenologyConst`
         """
@@ -336,13 +333,8 @@ class FaparLimitation:
         # - TODO - handle incompleteness - when do we stop estimating annual values from
         #   partial years (or at least warn about it)
 
-        # Extract GPP and apply any observation level penalty factor
-        total_gpp = pmodel.gpp
-        if gpp_penalty_factor is not None:
-            total_gpp *= gpp_penalty_factor
-
         # Calculate annual mean potential GPP and scale up to the year
-        annual_mean_potential_gpp = avc.get_annual_means(total_gpp)
+        annual_mean_potential_gpp = avc.get_annual_means(pmodel.gpp)
         annual_total_potential_gpp = (
             annual_mean_potential_gpp * (avc.year_n_days) * 86400 * 1e-6
         ) / pmodel.core_const.k_c_molmass

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -26,7 +26,7 @@ from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 
 from pyrealm.constants import CoreConst, PModelConst
-from pyrealm.core.utilities import summarize_attrs
+from pyrealm.core.utilities import check_input_shapes, summarize_attrs
 from pyrealm.pmodel.acclimation import AcclimationModel
 from pyrealm.pmodel.arrhenius import ARRHENIUS_METHOD_REGISTRY, ArrheniusFactorABC
 from pyrealm.pmodel.jmax_limitation import (
@@ -246,15 +246,8 @@ class PModelABC(ABC):
         estimated from :math:`J_{max}` using the selected method for Arrhenius scaling.
         """
 
-        self.gpp: NDArray[np.floating]
-        r"""Gross primary productivity (µg C m-2 s-1) calculated as:
-        
-        .. math::
-
-            \text{GPP} = \text{LUE} \cdot I_{abs}
-            
-        where :math:`I_{abs}` is the absorbed photosynthetic radiation.
-        """
+        self._gpp: NDArray[np.floating]
+        """Private variable storing unpenalised GPP predictions in (µg C m-2 s-1)."""
 
         self.gs: NDArray[np.floating]
         r"""Stomatal conductance (µmol m-2 s-1), calculated as:
@@ -278,6 +271,17 @@ class PModelABC(ABC):
         self.J: NDArray[np.floating]
         """Electron transfer rate."""
 
+        self.gpp_penalty_factor: NDArray[np.floating] | None = None
+        """An optional post-hoc GPP penalty factor applied to the model."""
+
+    @property
+    def gpp(self) -> NDArray[np.floating]:
+        r"""Gross primary productivity (µg C m-2 s-1)."""
+        if self.gpp_penalty_factor is None:
+            return self._gpp
+
+        return self._gpp * self.gpp_penalty_factor
+
     @abstractmethod
     def _fit_model(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -293,6 +297,7 @@ class PModelABC(ABC):
 
         return (
             f"{self.__class__.__name__}("
+            f"{'' if self.gpp_penalty_factor is None else 'GPP penalized, '}"
             f"shape={self.shape}, "
             f"method_optchi={self.method_optchi}, "
             f"method_arrhenius={self.method_arrhenius}, "
@@ -307,11 +312,48 @@ class PModelABC(ABC):
             dp: The number of decimal places used in rounding summary stats.
         """
 
-        summarize_attrs(self, self._data_attributes, dp=dp)
+        attrs = self._data_attributes
+
+        if self.gpp_penalty_factor is not None:
+            attrs = (*attrs, ("gpp_penalty_factor", "-"))
+
+        summarize_attrs(self, attrs, dp=dp)
 
     def apply_gpp_conversion_factor(self, daily_mean_pmodel_gpp: NDArray) -> NDArray:
         """Apply the gpp conversion factor to the input daily gpp."""
         return daily_mean_pmodel_gpp * self.gpp_conversion_factor
+
+    def apply_gpp_penalty_factor(self, penalty_factor: NDArray[np.floating]) -> None:
+        """Apply a post-hoc GPP penalty factor to GPP predictions.
+
+        Some productivity models apply a post-hoc penalty factor to the predicted GPP of
+        the P Model to correct for other influences on productivity. Examples included
+        the soil moisture penalty factors implemented as
+        :meth:`pyrealm.pmodel.functions.calculate_soilmstress_mengoli` and
+        :meth:`pyrealm.pmodel.functions.calculate_soilmstress_stocker`.
+
+        This method allows such a factor (:math:`f 'in [0,1]`) to be applied to a fitted
+        P Model instance. The `gpp` attribute of the model will then return the product
+        of the raw GPP predictions and the provided penalty factor.
+
+        The main use of this method is to allow penalised GPP to be used with other
+        `pyrealm` methods that take a P Model as an input.
+
+        Args:
+            penalty_factor: An array of GPP penalty value.
+        """
+
+        _ = check_input_shapes(self.env.tc, penalty_factor)
+
+        self.gpp_penalty_factor = penalty_factor
+
+    def remove_gpp_penalty_factor(self) -> None:
+        """Removes a post-hoc GPP penalty factor.
+
+        This method removes a previously applied GPP penalty factor.
+        """
+
+        self.gpp_penalty_factor = None
 
     def _method_setter(
         self,
@@ -471,7 +513,7 @@ class PModel(PModelABC):
         iabs = self.env.fapar * self.env.ppfd
 
         # GPP
-        self.gpp = self.lue * iabs
+        self._gpp = self.lue * iabs
 
         # Calculate V_cmax and J_max
         self.vcmax = self.kphio.kphio * iabs * self.optchi.mjoc * self.jmaxlim.f_v
@@ -974,7 +1016,7 @@ class SubdailyPModel(PModelABC):
 
         # Calculate GPP and convert from mol to gC
         assimilation = np.minimum(self.A_j, self.A_c)
-        self.gpp = assimilation * self.env.core_const.k_c_molmass
+        self._gpp = assimilation * self.env.core_const.k_c_molmass
 
         # Stomatal conductance - do not estimate when VPD = 0 or when floating point
         # errors give rise to (ca - ci) < 0 and deliberately ignore the numpy divide by
@@ -1001,7 +1043,7 @@ class SubdailyPModel(PModelABC):
         """Average gpp values to daily means - does not apply penalty."""
 
         # Reshape gpp array by day
-        gpp_by_day = self.gpp.view()
+        gpp_by_day = self._gpp.view()
         gpp_by_day.shape = tuple(
             [
                 self.acclim_model.n_days,

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -276,7 +276,11 @@ class PModelABC(ABC):
 
     @property
     def gpp(self) -> NDArray[np.floating]:
-        r"""Gross primary productivity (µg C m-2 s-1)."""
+        r"""Gross primary productivity (µg C m-2 s-1).
+
+        If a post-hoc GPP penalty factor has been applied to the model (see
+        :meth:`apply_gpp_penalty_factor`) then the value returned is the penalised GPP.
+        """
         if self.gpp_penalty_factor is None:
             return self._gpp
 
@@ -329,8 +333,8 @@ class PModelABC(ABC):
         Some productivity models apply a post-hoc penalty factor to the predicted GPP of
         the P Model to correct for other influences on productivity. Examples included
         the soil moisture penalty factors implemented as
-        :meth:`pyrealm.pmodel.functions.calculate_soilmstress_mengoli` and
-        :meth:`pyrealm.pmodel.functions.calculate_soilmstress_stocker`.
+        :meth:`pyrealm.pmodel.functions.calc_soilmstress_mengoli` and
+        :meth:`pyrealm.pmodel.functions.calc_soilmstress_stocker`.
 
         This method allows such a factor (:math:`f 'in [0,1]`) to be applied to a fitted
         P Model instance. The `gpp` attribute of the model will then return the product

--- a/pyrealm/pmodel/pmodel.py
+++ b/pyrealm/pmodel/pmodel.py
@@ -1043,7 +1043,7 @@ class SubdailyPModel(PModelABC):
         """Average gpp values to daily means - does not apply penalty."""
 
         # Reshape gpp array by day
-        gpp_by_day = self._gpp.view()
+        gpp_by_day = self.gpp.view()
         gpp_by_day.shape = tuple(
             [
                 self.acclim_model.n_days,

--- a/tests/broadcasting/utils.py
+++ b/tests/broadcasting/utils.py
@@ -71,6 +71,10 @@ SKIP_METHODS = [
     # PModel
     "AcclimationModel.set_include",
     "PModel._get_daily_gpp",
+    # The following two take an array that needs to be congruent with the existing
+    # PModel.env shape.
+    "PModel.apply_gpp_penalty_factor",
+    "SubdailyPModel.apply_gpp_penalty_factor",
     # Demography - mostly 1d arrays (dataframes)
     "CohortMethods.drop_cohort_data",
     "StemTraits",

--- a/tests/regression/phenology/test_phenology_faparlimitation.py
+++ b/tests/regression/phenology/test_phenology_faparlimitation.py
@@ -171,7 +171,6 @@ def test_fapar_limitiation_frompmodel_to_phenology(
         )
         # Define datetimes of observations - no GPP penalty
         fl_datetimes = pmodel_inputs["time"]
-        gpp_penalty_factor = None
 
     else:
         # Set up the datetimes of the observations and set the acclimation window
@@ -195,10 +194,10 @@ def test_fapar_limitiation_frompmodel_to_phenology(
         # FaparLimitation uses the datetimes from pmodel.acclim_model and uses a soil
         # moisture stress penalty
         fl_datetimes = None
-        gpp_penalty_factor = pmodel_inputs["soilm_stress"]
+        pmodel.apply_gpp_penalty_factor(pmodel_inputs["soilm_stress"])
 
-    # Check the GPP predictions
-    assert_allclose(pmodel.gpp, pmodel_outputs["gpp"], rtol=1e-7)
+    # Check the GPP predictions - use _gpp here to check the unpenalized values
+    assert_allclose(pmodel._gpp, pmodel_outputs["gpp"], rtol=1e-7)
     assert_allclose(pmodel.optchi.ci, pmodel_outputs["ci"], rtol=1e-7)
     assert_allclose(pmodel.optchi.chi, pmodel_outputs["chi"], rtol=1e-7)
 
@@ -210,7 +209,6 @@ def test_fapar_limitiation_frompmodel_to_phenology(
         datetimes=fl_datetimes,
         precip=pmodel_inputs["precip_molar"],
         aridity_index=site_data["AI_from_cruts"],
-        gpp_penalty_factor=gpp_penalty_factor,
     )
 
     assert_allclose(

--- a/tests/unit/pmodel/test_gpp.py
+++ b/tests/unit/pmodel/test_gpp.py
@@ -82,7 +82,7 @@ def test_pmodel_get_daily_gpp(
 ):
     """Tests that the interpolation to daily gpp from PModel gpp works correctly."""
 
-    test_pmodel.gpp = gpp_in
+    test_pmodel._gpp = gpp_in
     days, daily_gpp = test_pmodel._get_daily_gpp(np.array(datetimes))
     # Testing equality in time series is annoying because assert_allclose assumes floats
     # and all of the np.datetime64 dtypes are integer under the hood. So, explicitly
@@ -118,7 +118,7 @@ def test_subdailypmodel_get_daily_gpp(
 ):
     """Tests that the averaging from subdaily gpp to daily gpp works correctly."""
 
-    test_subdailypmodel.gpp = gpp_in
+    test_subdailypmodel._gpp = gpp_in
     test_subdailypmodel.acclim_model.n_days = 31
     test_subdailypmodel.acclim_model.n_obs = 4
     days, daily_gpp = test_subdailypmodel._get_daily_gpp()

--- a/tests/unit/pmodel/test_pmodel.py
+++ b/tests/unit/pmodel/test_pmodel.py
@@ -4,6 +4,8 @@ from contextlib import nullcontext as does_not_raise
 from itertools import product
 
 import numpy as np
+import pytest
+from numpy.testing import assert_allclose
 
 
 def test_pmodel_method_combination_checking():
@@ -103,3 +105,48 @@ def test_pmodel_method_combination_checking():
                 method_kphio=phi0_meth,
                 method_jmaxlim=jmax_meth,
             )
+
+
+@pytest.mark.parametrize(argnames="pmodel_type", argvalues=("standard", "subdaily"))
+def test_PModel_gpp_penalty_factor(capsys, be_vie_data_components, pmodel_type):
+    """Test the apply_gpp_penalty_factor mechanisms work as expected."""
+    from pyrealm.pmodel import AcclimationModel, PModel, SubdailyPModel
+
+    env, datetime, _ = be_vie_data_components.get()
+
+    if pmodel_type == "standard":
+        # Test the methods on a standard PModel
+        pmodel = PModel(env)
+    else:
+        acclim = AcclimationModel(datetimes=datetime, allow_holdover=True)
+        acclim.set_window(
+            window_center=np.timedelta64(12, "h"), half_width=np.timedelta64(1, "h")
+        )
+        pmodel = SubdailyPModel(env=env, acclim_model=acclim)
+
+    # Record raw GPP values
+    raw_gpp = pmodel.gpp
+
+    # Apply a penalty factor
+    pmodel.apply_gpp_penalty_factor(penalty_factor=np.array([0.5]))
+
+    # Check the gpp attribute is halved as expected
+    assert_allclose(raw_gpp / 2, pmodel.gpp)
+
+    # Check the __repr__ and summarize() methods are extended
+    assert "penalized" in repr(pmodel)
+    pmodel.summarize()
+    out = capsys.readouterr().out
+    assert "gpp_penalty_factor" in out
+
+    # Revert to unpenalised prediction
+    pmodel.remove_gpp_penalty_factor()
+
+    # Values are back to original
+    assert_allclose(raw_gpp, pmodel.gpp)
+
+    # Check the __repr__ and summarize() methods are extended
+    assert "penalized" not in repr(pmodel)
+    pmodel.summarize()
+    out = capsys.readouterr().out
+    assert "gpp_penalty_factor" not in out


### PR DESCRIPTION
# Description

This PR updates PModelABC to provide the `apply_gpp_penalty_factor` method. This is primarily aimed at allowing penalised GPP predictions to be used more easily in downstream methods that take a PModel as an input, rather than having to propagate penalty factors through the signatures of those downstream methods.

I've added simple tests of the methods and updated the current `fapar_limitation` code to remove the `gpp_penalty_factor` arguments.

Once this is in `develop`, I'm going to pull it up into #600 and adopt it through the incoming new phenology code in that feature branch.

Fixes #612

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
