### PR TITLE
Partition allocation to foliage growth

### DIFF
--- a/pyrealm/demography/tmodel.py
+++ b/pyrealm/demography/tmodel.py
@@ -852,7 +852,12 @@ def calculate_growth_increments(
     dbh: NDArray[np.floating],
     stem_height: NDArray[np.floating],
     validate: bool = True,
-) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
+) -> tuple[
+    NDArray[np.floating],
+    NDArray[np.floating],
+    NDArray[np.floating],
+    NDArray[np.floating],
+]:
     r"""Calculate growth increments.
 
     Given an estimate of net primary productivity (NPP, :math:`P_{net}`), less
@@ -860,17 +865,19 @@ def calculate_growth_increments(
     to growth and hence estimate resulting increments :cite:`Li:2014bc` in:
     
     * the stem diameter (:math:`\Delta D`),
-    * the stem mass (:math:`\Delta W_s`), and 
-    * the foliar mass (:math:`\Delta W_f`). 
-        
+    * the stem mass (:math:`\Delta W_s`), 
+    * the foliar mass (:math:`\Delta W_f`), and
+    * the fine root mass (:math:`\Delta W_r`).
+    
     The stem diameter increment can be calculated using the available productivity for
-    growth and the rates of change in stem (:math:`\textrm{d}W_s / \textrm{d}t`) and
-    foliar masses (:math:`\textrm{d}W_f / \textrm{d}t`): 
+    growth and the rates of change in stem mass (:math:`\textrm{d}W_s / \textrm{d}t`)
+    and in the combined foliage and fine root masses (:math:`\textrm{d}W_fr /
+    \textrm{d}t`):  
 
     .. math::
 
         \Delta D = \frac{P_{net} - T}{ \textrm{d}W_s / \textrm{d}t  +
-             \textrm{d}W_f / \textrm{d}t}
+             \textrm{d}W_fr / \textrm{d}t}
 
     The rates of change in stem and foliar mass can be calculated as:
 
@@ -882,7 +889,7 @@ def calculate_growth_increments(
             \textrm{d}W_s / \textrm{d}t &= \frac{\pi}{8} \rho_s D
                 \left(a D \left(1 - \frac{H}{H_{m}} + 2 H \right) \right) \\
 
-            \textrm{d}W_f / \textrm{d}t &= L \frac{\pi c}{4 a} \left(a D \left( 1 -
+            \textrm{d}W_fr / \textrm{d}t &= L \frac{\pi c}{4 a} \left(a D \left( 1 -
                 \frac{H}{H_{m}} + H \right) \right) \frac{1}{\sigma + \zeta}
         \end{align*}
       \]
@@ -905,8 +912,8 @@ def calculate_growth_increments(
     conditions, this function explicitly sets :math:`\Delta D = 0`: **stems with zero
     height cannot grow**.
 
-    The resulting incremental changes in stem mass and foliar mass can then be
-    calculated as:
+    The resulting incremental changes in stem mass and foliage plus fine root masses can
+    then be calculated as:
 
     .. math::
       :nowrap:
@@ -914,7 +921,24 @@ def calculate_growth_increments(
       \[
         \begin{align*}
         \Delta W_s &=  \textrm{d}W_s / \textrm{d}t \, \Delta D\\
-        \Delta W_f &=  \textrm{d}W_f / \textrm{d}t \, \Delta D
+        \Delta W_fr &=  \textrm{d}W_fr / \textrm{d}t \, \Delta D
+        \end{align*}
+      \]
+
+    Note that :cite:`Li:2014bc` use :math:`W_f` to denote the increment in both foliage
+    and fine root mass, as fine root mass is estimated as a function of foliage area
+    through the specific leaf area (:math:`\sigma`) and  ratio of fine root mass to leaf
+    area (:math:`\zeta`). Here we use :math:`W_fr` to indicate the combined increments
+    and partition the final increments into foliage and fine root components as:
+
+    .. math::
+      :nowrap:
+
+      \[
+        \begin{align*}
+
+        \Delta W_f &= \Delta W_fr /( 1 + \sigma \zeta)
+        \Delta W_r &= \Delta W_fr - \Delta W_f
         \end{align*}
       \]
 
@@ -924,9 +948,6 @@ def calculate_growth_increments(
         of maintaining reproductive tissue mass as a fraction of foliage mass. These
         values can be set to zero to reproduce the predictions of the original T Model
         calculations. 
-
-
-
 
     Args:
         rho_s: Wood density of the PFT
@@ -977,7 +998,7 @@ def calculate_growth_increments(
             size_args=size_args, function_name="calculate_growth_increments"
         )
 
-    # Rates of change in stem and foliar
+    # Rates of change in stem and foliage + fine root mass
     dWsdt = (
         np.pi
         / 8
@@ -986,7 +1007,10 @@ def calculate_growth_increments(
         * (a_hd * dbh * (1 - (stem_height / h_max)) + 2 * stem_height)
     )
 
-    dWfdt = (
+    # This equation includes terms for the rate of change in fine root mass, which is
+    # estimated alongside rate of change in foliage mass in the model as
+    # (1 + sigma + zeta) dWfdt (Eqn 15)
+    dWfrdt = (
         lai
         * ((np.pi * ca_ratio) / (4 * a_hd))
         * (a_hd * dbh * (1 - stem_height / h_max) + stem_height)
@@ -1000,11 +1024,17 @@ def calculate_growth_increments(
             np.where(
                 dbh == 0,
                 0,
-                (npp - turnover - reproductive_tissue_turnover) / (dWsdt + dWfdt),
+                (npp - turnover - reproductive_tissue_turnover) / (dWsdt + dWfrdt),
             )
         )
 
-    return (delta_d, dWsdt * delta_d, dWfdt * delta_d)
+    # Partition delta Wfr into delta Wf and delta Wr using (1 + sigma.zeta)
+    fine_root_foliage_factor = 1 + sla * zeta
+    delta_Wfr = dWfrdt * delta_d
+    delta_Wf = delta_Wfr / fine_root_foliage_factor
+    delta_Wr = delta_Wfr - delta_Wf
+
+    return (delta_d, dWsdt * delta_d, delta_Wf, delta_Wr)
 
 
 @dataclass
@@ -1213,6 +1243,7 @@ class StemAllocation(PandasExporter):
         "delta_dbh",
         "delta_stem_mass",
         "delta_foliage_mass",
+        "delta_fine_root_mass",
     )
 
     # Init vars
@@ -1256,6 +1287,8 @@ class StemAllocation(PandasExporter):
     """Predicted increase in stem mass from growth allocation (g C)"""
     delta_foliage_mass: NDArray[np.floating] = field(init=False)
     """Predicted increase in foliar mass from growth allocation (g C)"""
+    delta_fine_root_mass: NDArray[np.floating] = field(init=False)
+    """Predicted increase in fine root mass from growth allocation (g C)"""
 
     # Information attributes
     _n_pred: int = field(init=False)
@@ -1297,6 +1330,7 @@ class StemAllocation(PandasExporter):
         # Topslice GPP
         self.topslice_whole_crown_gpp = self.whole_crown_gpp - self.gpp_topslice
 
+        # Calculate respiration terms
         self.sapwood_respiration = calculate_sapwood_respiration(
             resp_s=stem_traits.resp_s,
             sapwood_mass=stem_allometry.sapwood_mass,
@@ -1323,6 +1357,7 @@ class StemAllocation(PandasExporter):
             validate=False,
         )
 
+        # Calculate NPP given losses to yield and respiration costs
         self.npp = calculate_net_primary_productivity(
             yld=stem_traits.yld,
             whole_crown_gpp=self.topslice_whole_crown_gpp,
@@ -1333,6 +1368,7 @@ class StemAllocation(PandasExporter):
             validate=False,
         )
 
+        # Calculate turnover costs
         self.foliage_turnover = calculate_foliage_turnover(
             tau_f=stem_traits.tau_f,
             foliage_mass=stem_allometry.foliage_mass,
@@ -1351,23 +1387,27 @@ class StemAllocation(PandasExporter):
             validate=False,
         )
 
-        (self.delta_dbh, self.delta_stem_mass, self.delta_foliage_mass) = (
-            calculate_growth_increments(
-                rho_s=stem_traits.rho_s,
-                a_hd=stem_traits.a_hd,
-                h_max=stem_traits.h_max,
-                lai=stem_traits.lai,
-                ca_ratio=stem_traits.ca_ratio,
-                sla=stem_traits.sla,
-                zeta=stem_traits.zeta,
-                npp=self.npp,
-                turnover=self.foliage_turnover + self.fine_root_turnover,
-                reproductive_tissue_turnover=self.reproductive_tissue_turnover,
-                p_foliage_for_reproductive_tissue=stem_traits.p_foliage_for_reproductive_tissue,
-                dbh=stem_allometry.dbh,
-                stem_height=stem_allometry.stem_height,
-                validate=False,
-            )
+        # Calculate resulting growth increments given NPP and turnover costs.
+        (
+            self.delta_dbh,
+            self.delta_stem_mass,
+            self.delta_foliage_mass,
+            self.delta_fine_root_mass,
+        ) = calculate_growth_increments(
+            rho_s=stem_traits.rho_s,
+            a_hd=stem_traits.a_hd,
+            h_max=stem_traits.h_max,
+            lai=stem_traits.lai,
+            ca_ratio=stem_traits.ca_ratio,
+            sla=stem_traits.sla,
+            zeta=stem_traits.zeta,
+            npp=self.npp,
+            turnover=self.foliage_turnover + self.fine_root_turnover,
+            reproductive_tissue_turnover=self.reproductive_tissue_turnover,
+            p_foliage_for_reproductive_tissue=stem_traits.p_foliage_for_reproductive_tissue,
+            dbh=stem_allometry.dbh,
+            stem_height=stem_allometry.stem_height,
+            validate=False,
         )
 
         # Set the number of observations per stem (one if dbh is 1D, otherwise size of

--- a/tests/regression/demography/test_t_model_functions_against_rtmodel.py
+++ b/tests/regression/demography/test_t_model_functions_against_rtmodel.py
@@ -349,20 +349,22 @@ def test_calculate_growth_increments(rvalues):
     )
 
     for pft, _, data in rvalues:
-        delta_dbh, delta_mass_stem, delta_mass_fine_root = calculate_growth_increments(
-            rho_s=pft["rho_s"],
-            a_hd=pft["a_hd"],
-            h_max=pft["h_max"],
-            lai=pft["lai"],
-            ca_ratio=pft["ca_ratio"],
-            sla=pft["sla"],
-            zeta=pft["zeta"],
-            npp=data["NPP"],
-            turnover=data["turnover"],
-            reproductive_tissue_turnover=np.zeros(np.shape(data["turnover"])),
-            p_foliage_for_reproductive_tissue=np.zeros(np.shape(data["turnover"])),
-            dbh=data["diameter"],
-            stem_height=data["height"],
+        delta_dbh, delta_mass_stem, delta_mass_foliage, delta_mass_fine_root = (
+            calculate_growth_increments(
+                rho_s=pft["rho_s"],
+                a_hd=pft["a_hd"],
+                h_max=pft["h_max"],
+                lai=pft["lai"],
+                ca_ratio=pft["ca_ratio"],
+                sla=pft["sla"],
+                zeta=pft["zeta"],
+                npp=data["NPP"],
+                turnover=data["turnover"],
+                reproductive_tissue_turnover=np.zeros(np.shape(data["turnover"])),
+                p_foliage_for_reproductive_tissue=np.zeros(np.shape(data["turnover"])),
+                dbh=data["diameter"],
+                stem_height=data["height"],
+            )
         )
         assert_array_almost_equal(
             delta_dbh,
@@ -375,7 +377,7 @@ def test_calculate_growth_increments(rvalues):
             decimal=8,
         )
         assert_array_almost_equal(
-            delta_mass_fine_root,
+            delta_mass_fine_root + delta_mass_foliage,
             data["delta_mass_frt"],
             decimal=8,
         )

--- a/tests/unit/demography/test_t_model_functions.py
+++ b/tests/unit/demography/test_t_model_functions.py
@@ -743,24 +743,26 @@ class TestTModel:
         )
 
         with outcome as excep:
-            delta_d, delta_mass_stm, delta_mass_frt = calculate_growth_increments(
-                rho_s=rtmodel_flora.rho_s[pft_idx],
-                a_hd=rtmodel_flora.a_hd[pft_idx],
-                h_max=rtmodel_flora.h_max[pft_idx],
-                lai=rtmodel_flora.lai[pft_idx],
-                ca_ratio=rtmodel_flora.ca_ratio[pft_idx],
-                sla=rtmodel_flora.sla[pft_idx],
-                zeta=rtmodel_flora.zeta[pft_idx],
-                npp=rtmodel_data["npp"][data_idx],
-                turnover=rtmodel_data["turnover"][data_idx],
-                reproductive_tissue_turnover=np.zeros(
-                    np.shape(rtmodel_data["turnover"][data_idx])
-                ),
-                p_foliage_for_reproductive_tissue=np.zeros(
-                    np.shape(rtmodel_data["npp"][data_idx])
-                ),
-                dbh=rtmodel_data["dbh"][data_idx],
-                stem_height=rtmodel_data["stem_height"][data_idx],
+            delta_d, delta_mass_stm, delta_mass_f, delta_mass_rt = (
+                calculate_growth_increments(
+                    rho_s=rtmodel_flora.rho_s[pft_idx],
+                    a_hd=rtmodel_flora.a_hd[pft_idx],
+                    h_max=rtmodel_flora.h_max[pft_idx],
+                    lai=rtmodel_flora.lai[pft_idx],
+                    ca_ratio=rtmodel_flora.ca_ratio[pft_idx],
+                    sla=rtmodel_flora.sla[pft_idx],
+                    zeta=rtmodel_flora.zeta[pft_idx],
+                    npp=rtmodel_data["npp"][data_idx],
+                    turnover=rtmodel_data["turnover"][data_idx],
+                    reproductive_tissue_turnover=np.zeros(
+                        np.shape(rtmodel_data["turnover"][data_idx])
+                    ),
+                    p_foliage_for_reproductive_tissue=np.zeros(
+                        np.shape(rtmodel_data["npp"][data_idx])
+                    ),
+                    dbh=rtmodel_data["dbh"][data_idx],
+                    stem_height=rtmodel_data["stem_height"][data_idx],
+                )
             )
 
             assert delta_d.shape == exp_shape
@@ -769,8 +771,12 @@ class TestTModel:
             assert delta_mass_stm.shape == exp_shape
             assert_allclose(delta_mass_stm, rtmodel_data["delta_stem_mass"][out_idx])
 
-            assert delta_mass_frt.shape == exp_shape
-            assert_allclose(delta_mass_frt, rtmodel_data["delta_foliage_mass"][out_idx])
+            assert delta_mass_f.shape == exp_shape
+            assert delta_mass_rt.shape == exp_shape
+            assert_allclose(
+                delta_mass_f + delta_mass_rt,
+                rtmodel_data["delta_foliage_mass"][out_idx],
+            )
             return
 
         assert str(excep.value).startswith(excep_msg)
@@ -1052,10 +1058,18 @@ def test_StemAllocation(rtmodel_flora, rtmodel_data):
             "fine_root_turnover",
             "reproductive_tissue_respiration",
             "reproductive_tissue_turnover",
+            "delta_foliage_mass",
+            "delta_fine_root_mass",
         ]
     )
     for var in vars_to_check:
         assert_allclose(getattr(stem_allocation, var), rtmodel_data[var])
+
+    # Separately check the partitioning into delta foliage and fine root
+    assert_allclose(
+        stem_allocation.delta_foliage_mass + stem_allocation.delta_fine_root_mass,
+        rtmodel_data["delta_foliage_mass"],
+    )
 
     # Test the inherited to_pandas method
     df = stem_allocation.to_pandas()


### PR DESCRIPTION
The description in issue #628 isn't quite correct. The `StemAllocation` object has an attribute `delta_foliage_mass` that is actually the combined increase in foliage ($f$) and fine root ($r$) masses (as the T Model calculates fine root mass as a function of canopy leaf area). 

This PR updates:
*  `calculate_growth_increment` to partition $\Delta W_{fr}$ into $\Delta W_{f}$  and $\Delta W_{r}$,
*  `StemAllocation` to store those two values in separate attributes,
*  the docstrings to explain the difference from the original implementation,
* the tests to specifically test that the sum of the two partitions still equal the single output from the reference implementation.

> [!WARNING]
> Oh damn. Made the commits to the wrong branch. Fixing

Fixes #628

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [ ] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [ ] All tests pass: `$ poetry run pytest`

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
