### PR TITLE
Xarray inputs for other modules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -197,6 +197,7 @@ intersphinx_mapping = {
     "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
     "marshmallow": ("https://marshmallow.readthedocs.io/en/stable/", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -224,6 +224,14 @@ autodoc_type_aliases = {
     "ArrayType": "pyrealm.core.xarray.ArrayType",
 }
 
+# TypeAliasForwardRef doesn't seem to support subscripting, resulting in
+# get_type_hints() failing on ArrayType[np.floating] in modules using `from __future__
+# import annotations`. This patch solves this by ignoring the type parameter, allowing
+# other arguments to resolve correctly.
+from sphinx.util.inspect import TypeAliasForwardRef  # noqa: E402
+
+TypeAliasForwardRef.__getitem__ = lambda self, item: self
+
 # Autodoc configuration:
 # - Suppress signature expansion of arguments
 autodoc_preserve_defaults = True

--- a/docs/source/users/array_inputs.md
+++ b/docs/source/users/array_inputs.md
@@ -23,6 +23,10 @@ language_info:
 
 # Using arrays in `pyrealm`
 
+```{note}
+The below information does not apply to the `demography` module.
+```
+
 Most of the functionality in `pyrealm` is designed to work with data arrays that can
 have multiple dimensions. The input data can be single scalar values - representing a
 point estimate - or multi-dimensional inputs - such as a time-series on a spatial grid.
@@ -123,10 +127,6 @@ env = PModelEnvironment(tc=temp, co2=co2, patm=patm, vpd=vpd, fapar=fapar, ppfd=
 ```
 
 ## Xarray inputs
-
-```{note}
-This is currently limited to `pmodel` module only.
-```
 
 Array inputs to functions will also accept `xarray.DataArray` inputs. These are mostly
 equivalent to `numpy` arrays but with the addition of named dimensions. `pyrealm` will

--- a/docs/source/users/splash.md
+++ b/docs/source/users/splash.md
@@ -163,29 +163,25 @@ Before calculating water balances, you need to create a
 the solar and evaporative calculations for the time series - none of these calculations
 rely on the soil moisture and so are calculated once when the `SplashModel` is created.
 
+```{code-cell} ipython3
+# Fit the model
+splash = SplashModel(
+    lat=data.lat,
+    elv=data.elev,
+    dates=Calendar(data.time),
+    sf=data.sf,
+    tc=data.tmp,
+    pn=data.pre,
+)
+```
+
 The data for the sunshine fraction (`sf`), temperature (`tc`) and precipitation (`pn`)
 are three dimensional arrays providing values along time, latitude and longitude axes.
 The latitude (`lat`) values obviously only add coordinates along the latitude axis and
-the elevation (`elv`) is constant through time. So before the model can be fitted, we
-need to make these arrays compatible (see the [array inputs](../users/array_inputs.md)
-documentation) by making them use the same dimensions.
-
-```{code-cell} ipython3
-# Convert latitude from (Y) to (1, Y, 1)
-lat = data.lat.to_numpy()[np.newaxis, :, np.newaxis]
-# Convert elevation from (Y, X) to (1, Y, X)
-elv = data.elev.to_numpy()[np.newaxis, :, :]
-
-# Fit the model
-splash = SplashModel(
-    lat=lat,
-    elv=elv,
-    dates=Calendar(data.time.to_numpy()),
-    sf=data.sf.to_numpy(),
-    tc=data.tmp.to_numpy(),
-    pn=data.pre.to_numpy(),
-)
-```
+the elevation (`elv`) is constant through time. If these were being provided as numpy
+arrays we would first need to make these arrays compatible (see the [array
+inputs](../users/array_inputs.md) documentation) by making them use the same dimensions.
+However, here we are using xarray inputs so this is not required.
 
 ### Estimating initial soil moisture
 

--- a/pyrealm/core/bounds.py
+++ b/pyrealm/core/bounds.py
@@ -6,19 +6,19 @@ real problem and to adjust input data if needed.
 
 The ``bounds`` module:
 
-* Defines a {class}`~pyrealm.core.bounds.Bounds` dataclass used to define bounds for a
+* Defines a :class:`~pyrealm.core.bounds.Bounds` dataclass used to define bounds for a
   particular variable.
-* Defines a {class}`~pyrealm.core.bounds.BoundsChecker` class with default bounds for
+* Defines a :class:`~pyrealm.core.bounds.BoundsChecker` class with default bounds for
   core variables that acts as a library for bounds checking.
 * The main use case is e.g. ``BoundsChecker().check("tc", np.array([10, 1000])``, which
   will check that the alleged temperature data in °C fall within the configured bounds.
 
 A ``BoundsChecker`` class instance is created with a predefined internal dictionary of
 default variables and appropriate bounds. However, users can use the
-{meth}`~pyrealm.core.bounds.BoundsChecker.update` method to override defaults or add new
+:meth:`~pyrealm.core.bounds.BoundsChecker.update` method to override defaults or add new
 variables by providing a new ``Bounds`` instance.
 
-The {meth}`~pyrealm.core.bounds.BoundsChecker.check` method can then be used to validate
+The :meth:`~pyrealm.core.bounds.BoundsChecker.check` method can then be used to validate
 a set of values against the configured bounds for a given variable name. The ``check``
 method returns the input variables, to allow values to be checked while being assigned
 to an attribute.
@@ -59,9 +59,9 @@ class Bounds:
 class BoundsChecker:
     """A bounds checker for input variables.
 
-    The class provides a library of  {class}`~pyrealm.core.bounds.Bounds` instances for
+    The class provides a library of  :class:`~pyrealm.core.bounds.Bounds` instances for
     core variables, keyed by the
-    {attr}`Bounds.var_name<pyrealm.core.bounds.Bounds.var_name>` attribute. The table is
+    :attr:`Bounds.var_name<pyrealm.core.bounds.Bounds.var_name>` attribute. The table is
     populated from default values when a ``BoundsChecker`` instance is created but can
     be updated and extended by assigning new ``Bounds`` instances to existing or new
     variable name keys using the ``update`` method.
@@ -109,7 +109,7 @@ class BoundsChecker:
     def update(self, bounds: Bounds) -> None:
         """Update or add bounds data.
 
-        The {attr}`Bounds.var_name<pyrealm.core.bounds.Bounds.var_name>` attribute of
+        The :attr:`Bounds.var_name<pyrealm.core.bounds.Bounds.var_name>` attribute of
         the provided ``Bounds`` instance is used to update an existing entry for the
         name or add checking for a new name.
 

--- a/pyrealm/core/bounds.py
+++ b/pyrealm/core/bounds.py
@@ -31,6 +31,8 @@ from warnings import warn
 import numpy as np
 from numpy.typing import NDArray
 
+from pyrealm.core.xarray import ArrayType, xarray_inputs
+
 
 @dataclass
 class Bounds:
@@ -120,7 +122,7 @@ class BoundsChecker:
         self._data[bounds.var_name] = bounds
 
     def check(
-        self, var_name: str, values: NDArray[np.floating]
+        self, var_name: str, values: ArrayType[np.floating]
     ) -> NDArray[np.floating]:
         r"""Check inputs fall within bounds.
 
@@ -144,6 +146,8 @@ class BoundsChecker:
             >>> bounds_checker.check("temp", vals)
             array([-15.,  20.,  30., 124.])
         """
+
+        values = xarray_inputs(values)
 
         var_bounds = self._data.get(var_name)
 

--- a/pyrealm/core/calendar.py
+++ b/pyrealm/core/calendar.py
@@ -11,11 +11,13 @@ xarray data structures.
 """
 
 from collections.abc import Generator, Sized
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
+
+from pyrealm.core.xarray import ArrayType, get_common_dims, xarray_inputs
 
 
 @dataclass
@@ -48,7 +50,7 @@ class CalendarDay:
         )
 
 
-@dataclass
+@dataclass(init=False)
 class Calendar(Sized):
     """The Calendar class.
 
@@ -80,15 +82,19 @@ class Calendar(Sized):
 
     dates: NDArray[np.datetime64]
     """A numpy array containing :class:`numpy.datetime64` values."""
-    year: NDArray[np.int_] = field(init=False)
+    year: NDArray[np.int_]
     """A numpy array giving the year of each datetime."""
-    julian_day: NDArray[np.int_] = field(init=False)
+    julian_day: NDArray[np.int_]
     """A numpy array giving the julian day of each datetime."""
-    days_in_year: NDArray[np.int_] = field(init=False)
+    days_in_year: NDArray[np.int_]
     """A numpy array giving the number of days in the year for each datetime."""
 
-    def __post_init__(self) -> None:
+    def __init__(self, dates: ArrayType[np.datetime64]) -> None:
         """Calculate year, julian day and days in year from dates."""
+        # If using xarray input, store the dimension name and convert to numpy
+        self.dims = get_common_dims(dates)
+        self.dates = xarray_inputs(dates, dims=self.dims)
+
         dateyear = self.dates.astype("datetime64[Y]")
         startnext = (dateyear + 1).astype("datetime64[D]")
         dateday = self.dates.astype("datetime64[D]")

--- a/pyrealm/core/hygro.py
+++ b/pyrealm/core/hygro.py
@@ -12,10 +12,11 @@ from numpy.typing import NDArray
 from pyrealm.constants import CoreConst
 from pyrealm.core.bounds import BoundsChecker
 from pyrealm.core.utilities import evaluate_horner_polynomial
+from pyrealm.core.xarray import ArrayType, xarray_inputs
 
 
 def calculate_vp_sat(
-    ta: NDArray[np.floating], core_const: CoreConst = CoreConst()
+    ta: ArrayType[np.floating], core_const: CoreConst = CoreConst()
 ) -> NDArray[np.floating]:
     r"""Calculate vapour pressure of saturated air.
 
@@ -52,6 +53,8 @@ def calculate_vp_sat(
         array([2.481888])
     """
 
+    ta = xarray_inputs(ta)
+
     # Magnus equation and conversion to kPa
     cf = core_const.magnus_coef
     vp_sat = cf[0] * np.exp((cf[1] * ta) / (cf[2] + ta)) / 1000
@@ -60,8 +63,8 @@ def calculate_vp_sat(
 
 
 def convert_vp_to_vpd(
-    vp: NDArray[np.floating],
-    ta: NDArray[np.floating],
+    vp: ArrayType[np.floating],
+    ta: ArrayType[np.floating],
     core_const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     """Convert vapour pressure to vapour pressure deficit.
@@ -86,14 +89,16 @@ def convert_vp_to_vpd(
         >>> convert_vp_to_vpd(vp, temp, core_const=allen).round(7)
         array([0.5870054])
     """
+
+    vp, ta = xarray_inputs(vp, ta)
     vp_sat = calculate_vp_sat(ta, core_const=core_const)
 
     return vp_sat - vp
 
 
 def convert_rh_to_vpd(
-    rh: NDArray[np.floating],
-    ta: NDArray[np.floating],
+    rh: ArrayType[np.floating],
+    ta: ArrayType[np.floating],
     core_const: CoreConst = CoreConst(),
     bounds_checker: BoundsChecker = BoundsChecker(),
 ) -> NDArray[np.floating]:
@@ -122,6 +127,7 @@ def convert_rh_to_vpd(
         array([0.7461016])
     """
 
+    rh, ta = xarray_inputs(rh, ta)
     rh = bounds_checker.check("rh", rh)
 
     vp_sat = calculate_vp_sat(ta, core_const=core_const)
@@ -130,8 +136,8 @@ def convert_rh_to_vpd(
 
 
 def convert_sh_to_vp(
-    sh: NDArray[np.floating],
-    patm: NDArray[np.floating],
+    sh: ArrayType[np.floating],
+    patm: ArrayType[np.floating],
     core_const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     """Convert specific humidity to vapour pressure.
@@ -153,13 +159,14 @@ def convert_sh_to_vp(
         array([0.9517451])
     """
 
+    sh, patm = xarray_inputs(sh, patm)
     return sh * patm / ((1.0 - core_const.mwr) * sh + core_const.mwr)
 
 
 def convert_sh_to_vpd(
-    sh: NDArray[np.floating],
-    ta: NDArray[np.floating],
-    patm: NDArray[np.floating],
+    sh: ArrayType[np.floating],
+    ta: ArrayType[np.floating],
+    patm: ArrayType[np.floating],
     core_const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     """Convert specific humidity to vapour pressure deficit.
@@ -187,6 +194,7 @@ def convert_sh_to_vpd(
         array([1.53526])
     """
 
+    sh, ta, patm = xarray_inputs(sh, ta, patm)
     vp_sat = calculate_vp_sat(ta, core_const=core_const)
     vp = convert_sh_to_vp(sh, patm, core_const=core_const)
 
@@ -197,7 +205,7 @@ def convert_sh_to_vpd(
 
 
 def calculate_saturation_vapour_pressure_slope(
-    tc: NDArray[np.floating],
+    tc: ArrayType[np.floating],
 ) -> NDArray[np.floating]:
     """Calculate the slope of the saturation vapour pressure curve.
 
@@ -211,6 +219,8 @@ def calculate_saturation_vapour_pressure_slope(
         The calculated slope in kPa °C-1.
     """
 
+    tc = xarray_inputs(tc)
+
     # TODO move these coefficients into constants?
     return (
         17.269
@@ -220,7 +230,7 @@ def calculate_saturation_vapour_pressure_slope(
     )
 
 
-def calculate_enthalpy_vaporisation(tc: NDArray[np.floating]) -> NDArray[np.floating]:
+def calculate_enthalpy_vaporisation(tc: ArrayType[np.floating]) -> NDArray[np.floating]:
     """Calculate the enthalpy of vaporization.
 
     Calculates the latent heat of vaporization of water as a function of
@@ -233,11 +243,13 @@ def calculate_enthalpy_vaporisation(tc: NDArray[np.floating]) -> NDArray[np.floa
         Calculated latent heat of vaporisation (J/Kg).
     """
 
+    tc = xarray_inputs(tc)
+
     # TODO move these coefficients into constants?
     return 1.91846e6 * ((tc + 273.15) / (tc + 273.15 - 33.91)) ** 2
 
 
-def calculate_specific_heat(tc: NDArray[np.floating]) -> NDArray[np.floating]:
+def calculate_specific_heat(tc: ArrayType[np.floating]) -> NDArray[np.floating]:
     """Calculate the specific heat of air.
 
     Calculates the specific heat of air at a constant pressure (:math:`c_{pm}`, J/kg/K)
@@ -250,6 +262,8 @@ def calculate_specific_heat(tc: NDArray[np.floating]) -> NDArray[np.floating]:
     Returns:
         The specific heat of air values.
     """
+
+    tc = xarray_inputs(tc)
 
     # TODO move these coefficients into constants?
 
@@ -270,8 +284,8 @@ def calculate_specific_heat(tc: NDArray[np.floating]) -> NDArray[np.floating]:
 
 
 def calculate_psychrometric_constant(
-    tc: NDArray[np.floating],
-    p: NDArray[np.floating],
+    tc: ArrayType[np.floating],
+    p: ArrayType[np.floating],
     core_const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     r"""Calculate the psychrometric constant.
@@ -289,6 +303,8 @@ def calculate_psychrometric_constant(
     Returns:
         The calculated psychrometric constant
     """
+
+    tc, p = xarray_inputs(tc, p)
 
     # Calculate the specific heat capacity of water, J/kg/K
     cp = calculate_specific_heat(tc)

--- a/pyrealm/core/pressure.py
+++ b/pyrealm/core/pressure.py
@@ -6,10 +6,11 @@ import numpy as np
 from numpy.typing import NDArray
 
 from pyrealm.constants import CoreConst
+from pyrealm.core.xarray import ArrayType, xarray_inputs
 
 
 def calculate_patm(
-    elv: NDArray[np.floating], core_const: CoreConst = CoreConst()
+    elv: ArrayType[np.floating], core_const: CoreConst = CoreConst()
 ) -> NDArray[np.floating]:
     r"""Calculate atmospheric pressure from elevation.
 
@@ -34,6 +35,8 @@ def calculate_patm(
         >>> round(calculate_patm(1000), 2)
         90241.54
     """
+
+    elv = xarray_inputs(elv)
 
     # Convert elevation to pressure, Pa.
     return core_const.k_Po * (1.0 - core_const.k_L * elv / core_const.k_To) ** (

--- a/pyrealm/core/solar.py
+++ b/pyrealm/core/solar.py
@@ -18,10 +18,12 @@ from numpy.typing import NDArray
 
 from pyrealm.constants import CoreConst
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.core.xarray import ArrayType, get_common_dims, xarray_inputs
 
 
 def calculate_distance_factor(
-    nu: NDArray[np.floating], solar_eccentricity: float = CoreConst().solar_eccentricity
+    nu: ArrayType[np.floating],
+    solar_eccentricity: float = CoreConst().solar_eccentricity,
 ) -> NDArray[np.floating]:
     r"""Calculates distance factor.
 
@@ -45,6 +47,8 @@ def calculate_distance_factor(
         An array of distance factors
     """
 
+    nu = xarray_inputs(nu)
+
     return (
         1.0
         / (
@@ -55,7 +59,7 @@ def calculate_distance_factor(
 
 
 def calculate_solar_declination_angle(
-    lambda_: NDArray[np.floating],
+    lambda_: ArrayType[np.floating],
     solar_obliquity: float = CoreConst().solar_obliquity,
 ) -> NDArray[np.floating]:
     r"""Calculate the solar declination angle.
@@ -76,13 +80,15 @@ def calculate_solar_declination_angle(
         An array of solar declination angle delta
     """
 
+    lambda_ = xarray_inputs(lambda_)
+
     return np.rad2deg(
         np.arcsin(np.sin(np.deg2rad(lambda_)) * np.sin(np.deg2rad(solar_obliquity)))
     )
 
 
 def calculate_ru_rv_intermediates(
-    declination: NDArray[np.floating], latitude: NDArray[np.floating]
+    declination: ArrayType[np.floating], latitude: ArrayType[np.floating]
 ) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
     r"""Calculates intermediate values for use in solar radiation calcs.
 
@@ -107,6 +113,8 @@ def calculate_ru_rv_intermediates(
     Returns:
         A tuple of :math:`r_u` and :math:`r_v`.
     """
+
+    declination, latitude = xarray_inputs(declination, latitude)
     ru = np.sin(np.deg2rad(declination)) * np.sin(np.deg2rad(latitude))
     rv = np.cos(np.deg2rad(declination)) * np.cos(np.deg2rad(latitude))
 
@@ -114,7 +122,7 @@ def calculate_ru_rv_intermediates(
 
 
 def calculate_sunset_hour_angle(
-    declination: NDArray[np.floating], latitude: NDArray[np.floating]
+    declination: ArrayType[np.floating], latitude: ArrayType[np.floating]
 ) -> NDArray[np.floating]:
     r"""Calculate the sunset hour angle.
 
@@ -137,14 +145,15 @@ def calculate_sunset_hour_angle(
         An array of local hour angle, degrees
     """
 
+    declination, latitude = xarray_inputs(declination, latitude)
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
 
     return _calculate_sunset_hour_angle(ru, rv)
 
 
 def _calculate_sunset_hour_angle(
-    ru: NDArray[np.floating],
-    rv: NDArray[np.floating],
+    ru: ArrayType[np.floating],
+    rv: ArrayType[np.floating],
 ) -> NDArray[np.floating]:
     """Calculate sunset hour angle from intermediates.
 
@@ -160,14 +169,15 @@ def _calculate_sunset_hour_angle(
         An array of local hour angle, degrees
     """
 
+    ru, rv = xarray_inputs(ru, rv)
     return np.rad2deg(np.arccos(-1.0 * np.clip(ru / rv, -1.0, 1.0)))
 
 
 def calculate_daily_solar_radiation(
-    distance_factor: NDArray[np.floating],
-    sunset_hour_angle: NDArray[np.floating],
-    declination: NDArray[np.floating],
-    latitude: NDArray[np.floating],
+    distance_factor: ArrayType[np.floating],
+    sunset_hour_angle: ArrayType[np.floating],
+    declination: ArrayType[np.floating],
+    latitude: ArrayType[np.floating],
     day_seconds: float = CoreConst().day_seconds,
     solar_constant: float = CoreConst().solar_constant,
 ) -> NDArray[np.floating]:
@@ -201,6 +211,9 @@ def calculate_daily_solar_radiation(
         An array of daily solar radiation, J/m^2
     """
 
+    distance_factor, sunset_hour_angle, declination, latitude = xarray_inputs(
+        distance_factor, sunset_hour_angle, declination, latitude
+    )
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
 
     return _calculate_daily_solar_radiation(
@@ -214,10 +227,10 @@ def calculate_daily_solar_radiation(
 
 
 def _calculate_daily_solar_radiation(
-    ru: NDArray[np.floating],
-    rv: NDArray[np.floating],
-    distance_factor: NDArray[np.floating],
-    sunset_hour_angle: NDArray[np.floating],
+    ru: ArrayType[np.floating],
+    rv: ArrayType[np.floating],
+    distance_factor: ArrayType[np.floating],
+    sunset_hour_angle: ArrayType[np.floating],
     day_seconds: float = CoreConst().day_seconds,
     solar_constant: float = CoreConst().solar_constant,
 ) -> NDArray[np.floating]:
@@ -242,6 +255,9 @@ def _calculate_daily_solar_radiation(
         An array of daily solar radiation, J/m^2
     """
 
+    ru, rv, distance_factor, sunset_hour_angle = xarray_inputs(
+        ru, rv, distance_factor, sunset_hour_angle
+    )
     return (
         (day_seconds / np.pi)
         * solar_constant
@@ -254,8 +270,8 @@ def _calculate_daily_solar_radiation(
 
 
 def calculate_transmissivity(
-    sunshine_fraction: NDArray[np.floating],
-    elevation: NDArray[np.floating],
+    sunshine_fraction: ArrayType[np.floating],
+    elevation: ArrayType[np.floating],
     coef: tuple[float, ...] = CoreConst.transmissivity_coef,
 ) -> NDArray[np.floating]:
     r"""Calculate atmospheric transmissivity.
@@ -277,13 +293,14 @@ def calculate_transmissivity(
     Returns:
         An array of bulk transmissivity
     """
+    sunshine_fraction, elevation = xarray_inputs(sunshine_fraction, elevation)
     c, d, f = coef
     return (c + d * sunshine_fraction) * (1.0 + f * elevation)
 
 
 def calculate_ppfd_from_tau_rd(
-    transmissivity: NDArray[np.floating],
-    daily_solar_radiation: NDArray[np.floating],
+    transmissivity: ArrayType[np.floating],
+    daily_solar_radiation: ArrayType[np.floating],
     visible_light_albedo: float = CoreConst().visible_light_albedo,
     swdown_to_ppfd_factor: float = CoreConst().swdown_to_ppfd_factor,
 ) -> NDArray[np.floating]:
@@ -310,6 +327,10 @@ def calculate_ppfd_from_tau_rd(
         An array of photosynthetic photon flux density, µmol m-2 s-1.
     """
 
+    transmissivity, daily_solar_radiation = xarray_inputs(
+        transmissivity, daily_solar_radiation
+    )
+
     ppfd = (
         (1.0e-6)
         * swdown_to_ppfd_factor
@@ -322,11 +343,11 @@ def calculate_ppfd_from_tau_rd(
 
 
 def calculate_ppfd(
-    sunshine_fraction: NDArray[np.floating],
-    elevation: NDArray[np.floating],
-    latitude: NDArray[np.floating],
-    ordinal_date: NDArray[np.int_],
-    n_days: NDArray[np.int_],
+    sunshine_fraction: ArrayType[np.floating],
+    elevation: ArrayType[np.floating],
+    latitude: ArrayType[np.floating],
+    ordinal_date: ArrayType[np.int_],
+    n_days: ArrayType[np.int_],
     const: CoreConst = CoreConst(),
 ) -> NDArray[np.floating]:
     r"""Calculates photosynthetic photon flux density (PPFD).
@@ -361,8 +382,16 @@ def calculate_ppfd(
         array([62.04230021])
     """
 
+    # Convert any xarray inputs. Use separate calls since the dtypes differ
+    dims = get_common_dims(sunshine_fraction, elevation, latitude, ordinal_date, n_days)
+    sunshine_fraction = xarray_inputs(sunshine_fraction, dims=dims)
+    elevation = xarray_inputs(elevation, dims=dims)
+    latitude = xarray_inputs(latitude, dims=dims)
+    ordinal_date = xarray_inputs(ordinal_date, dims=dims)
+    n_days = xarray_inputs(n_days, dims=dims)
+
     # Validate the inputs
-    _ = check_input_shapes(latitude, elevation, sunshine_fraction, ordinal_date, n_days)
+    _ = check_input_shapes(sunshine_fraction, elevation, latitude, ordinal_date, n_days)
 
     # Calculate intermediate values
 
@@ -411,8 +440,8 @@ def calculate_ppfd(
 
 
 def calculate_net_longwave_radiation(
-    sunshine_fraction: NDArray[np.floating],
-    temperature: NDArray[np.floating],
+    sunshine_fraction: ArrayType[np.floating],
+    temperature: ArrayType[np.floating],
     coef: tuple[float, float] = CoreConst().net_longwave_radiation_coef,
 ) -> NDArray[np.floating]:
     r"""Calculate net longwave radiation.
@@ -433,13 +462,14 @@ def calculate_net_longwave_radiation(
     Returns:
         An array of net longwave radiation.
     """
+    sunshine_fraction, temperature = xarray_inputs(sunshine_fraction, temperature)
     b, A = coef
     return (b + (1.0 - b) * sunshine_fraction) * (A - temperature)
 
 
 def calculate_rw_intermediate(
-    transmissivity: NDArray[np.floating],
-    distance_factor: NDArray[np.floating],
+    transmissivity: ArrayType[np.floating],
+    distance_factor: ArrayType[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
 ) -> NDArray[np.floating]:
@@ -464,15 +494,16 @@ def calculate_rw_intermediate(
         An array of the intermediate variable :math:`r_w` in W m-2.
     """
 
+    transmissivity, distance_factor = xarray_inputs(transmissivity, distance_factor)
     return (1.0 - shortwave_albedo) * transmissivity * solar_constant * distance_factor
 
 
 def calculate_net_radiation_crossover_hour_angle(
-    net_longwave_radiation: NDArray[np.floating],
-    transmissivity: NDArray[np.floating],
-    distance_factor: NDArray[np.floating],
-    declination: NDArray[np.floating],
-    latitude: NDArray[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
+    transmissivity: ArrayType[np.floating],
+    distance_factor: ArrayType[np.floating],
+    declination: ArrayType[np.floating],
+    latitude: ArrayType[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
 ) -> NDArray[np.floating]:
@@ -504,6 +535,20 @@ def calculate_net_radiation_crossover_hour_angle(
         The net radiation crossover hour angle.
     """
 
+    (
+        net_longwave_radiation,
+        transmissivity,
+        distance_factor,
+        declination,
+        latitude,
+    ) = xarray_inputs(
+        net_longwave_radiation,
+        transmissivity,
+        distance_factor,
+        declination,
+        latitude,
+    )
+
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
     rw = calculate_rw_intermediate(
         transmissivity=transmissivity,
@@ -521,10 +566,10 @@ def calculate_net_radiation_crossover_hour_angle(
 
 
 def _calculate_net_radiation_crossover_hour_angle(
-    net_longwave_radiation: NDArray[np.floating],
-    rw: NDArray[np.floating],
-    ru: NDArray[np.floating],
-    rv: NDArray[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
+    rw: ArrayType[np.floating],
+    ru: ArrayType[np.floating],
+    rv: ArrayType[np.floating],
 ) -> NDArray[np.floating]:
     """Calculate net radiation crossover hour angle using intermediate values.
 
@@ -542,18 +587,22 @@ def _calculate_net_radiation_crossover_hour_angle(
         An array of net radiation crossover hour angle, degrees
     """
 
+    net_longwave_radiation, rw, ru, rv = xarray_inputs(
+        net_longwave_radiation, rw, ru, rv
+    )
+
     return np.rad2deg(
         np.arccos(np.clip((net_longwave_radiation - rw * ru) / (rw * rv), -1.0, 1.0))
     )
 
 
 def calculate_daytime_net_radiation(
-    net_longwave_radiation: NDArray[np.floating],
-    crossover_hour_angle: NDArray[np.floating],
-    declination: NDArray[np.floating],
-    latitude: NDArray[np.floating],
-    transmissivity: NDArray[np.floating],
-    distance_factor: NDArray[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
+    crossover_hour_angle: ArrayType[np.floating],
+    declination: ArrayType[np.floating],
+    latitude: ArrayType[np.floating],
+    transmissivity: ArrayType[np.floating],
+    distance_factor: ArrayType[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
     day_seconds: float = CoreConst().day_seconds,
@@ -588,6 +637,23 @@ def calculate_daytime_net_radiation(
     Result:
         An array of daily net radiation.
     """  # codespell:ignore nd
+
+    (
+        net_longwave_radiation,
+        crossover_hour_angle,
+        declination,
+        latitude,
+        transmissivity,
+        distance_factor,
+    ) = xarray_inputs(
+        net_longwave_radiation,
+        crossover_hour_angle,
+        declination,
+        latitude,
+        transmissivity,
+        distance_factor,
+    )
+
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
     rw = calculate_rw_intermediate(
         transmissivity=transmissivity,
@@ -607,11 +673,11 @@ def calculate_daytime_net_radiation(
 
 
 def _calculate_daytime_net_radiation(
-    rw: NDArray[np.floating],
-    rv: NDArray[np.floating],
-    ru: NDArray[np.floating],
-    crossover_hour_angle: NDArray[np.floating],
-    net_longwave_radiation: NDArray[np.floating],
+    rw: ArrayType[np.floating],
+    rv: ArrayType[np.floating],
+    ru: ArrayType[np.floating],
+    crossover_hour_angle: ArrayType[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
     day_seconds: float = CoreConst().day_seconds,
 ) -> NDArray[np.floating]:
     """Calculates daily net radiation using precalculated intermediates.
@@ -633,6 +699,10 @@ def _calculate_daytime_net_radiation(
         An array of daily net radiation, J m-2
     """
 
+    rw, rv, ru, crossover_hour_angle, net_longwave_radiation = xarray_inputs(
+        rw, rv, ru, crossover_hour_angle, net_longwave_radiation
+    )
+
     rn_d = (day_seconds / np.pi) * (
         np.deg2rad(crossover_hour_angle) * (rw * ru - net_longwave_radiation)
         + rw * rv * np.sin(np.deg2rad(crossover_hour_angle))
@@ -642,13 +712,13 @@ def _calculate_daytime_net_radiation(
 
 
 def calculate_nighttime_net_radiation(
-    net_longwave_radiation: NDArray[np.floating],
-    crossover_hour_angle: NDArray[np.floating],
-    sunset_hour_angle: NDArray[np.floating],
-    declination: NDArray[np.floating],
-    latitude: NDArray[np.floating],
-    transmissivity: NDArray[np.floating],
-    distance_factor: NDArray[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
+    crossover_hour_angle: ArrayType[np.floating],
+    sunset_hour_angle: ArrayType[np.floating],
+    declination: ArrayType[np.floating],
+    latitude: ArrayType[np.floating],
+    transmissivity: ArrayType[np.floating],
+    distance_factor: ArrayType[np.floating],
     shortwave_albedo: float = CoreConst().shortwave_albedo,
     solar_constant: float = CoreConst().solar_constant,
     day_seconds: float = CoreConst().day_seconds,
@@ -687,6 +757,25 @@ def calculate_nighttime_net_radiation(
     Returns:
         An array of nighttime net radiation in J m-2
     """
+
+    (
+        net_longwave_radiation,
+        crossover_hour_angle,
+        sunset_hour_angle,
+        declination,
+        latitude,
+        transmissivity,
+        distance_factor,
+    ) = xarray_inputs(
+        net_longwave_radiation,
+        crossover_hour_angle,
+        sunset_hour_angle,
+        declination,
+        latitude,
+        transmissivity,
+        distance_factor,
+    )
+
     ru, rv = calculate_ru_rv_intermediates(declination=declination, latitude=latitude)
     rw = calculate_rw_intermediate(
         transmissivity=transmissivity,
@@ -707,12 +796,12 @@ def calculate_nighttime_net_radiation(
 
 
 def _calculate_nighttime_net_radiation(
-    rw: NDArray[np.floating],
-    rv: NDArray[np.floating],
-    ru: NDArray[np.floating],
-    sunset_hour_angle: NDArray[np.floating],
-    crossover_hour_angle: NDArray[np.floating],
-    net_longwave_radiation: NDArray[np.floating],
+    rw: ArrayType[np.floating],
+    rv: ArrayType[np.floating],
+    ru: ArrayType[np.floating],
+    sunset_hour_angle: ArrayType[np.floating],
+    crossover_hour_angle: ArrayType[np.floating],
+    net_longwave_radiation: ArrayType[np.floating],
     day_seconds: float = CoreConst().day_seconds,
 ) -> NDArray[np.floating]:
     """Calculates nighttime net radiation using precalculated intermediates.
@@ -735,6 +824,22 @@ def _calculate_nighttime_net_radiation(
         An array of nighttime net radiation, :math:`J/m^2`
     """
 
+    (
+        rw,
+        rv,
+        ru,
+        sunset_hour_angle,
+        crossover_hour_angle,
+        net_longwave_radiation,
+    ) = xarray_inputs(
+        rw,
+        rv,
+        ru,
+        sunset_hour_angle,
+        crossover_hour_angle,
+        net_longwave_radiation,
+    )
+
     return (
         (
             rw
@@ -750,8 +855,8 @@ def _calculate_nighttime_net_radiation(
 
 
 def calculate_heliocentric_longitudes(
-    ordinal_date: NDArray[np.int_],
-    n_days: NDArray[np.int_],
+    ordinal_date: ArrayType[np.int_],
+    n_days: ArrayType[np.int_],
     solar_eccentricity: float = CoreConst().solar_eccentricity,
     solar_perihelion: float = CoreConst().solar_perihelion,
 ) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
@@ -773,6 +878,8 @@ def calculate_heliocentric_longitudes(
     Returns:
         A tuple of NDArrays containing ``nu`` and ``lambda_``.
     """
+
+    ordinal_date, n_days = xarray_inputs(ordinal_date, n_days)
 
     # TODO - a lot of wildly unnecessary unit changing here. Can we just work in radians
     #        from the constants up?
@@ -830,9 +937,9 @@ def calculate_heliocentric_longitudes(
 
 
 def calculate_solar_elevation(
-    latitude: NDArray[np.floating],
-    declination: NDArray[np.floating],
-    hour_angle: NDArray[np.floating],
+    latitude: ArrayType[np.floating],
+    declination: ArrayType[np.floating],
+    hour_angle: ArrayType[np.floating],
 ) -> NDArray[np.floating]:
     r"""Calculate the solar elevation angle.
 
@@ -853,6 +960,8 @@ def calculate_solar_elevation(
         Solar elevation angles in radians.
     """
 
+    latitude, declination, hour_angle = xarray_inputs(latitude, declination, hour_angle)
+
     return np.arcsin(
         np.sin(latitude) * np.sin(declination)
         + np.cos(latitude) * np.cos(declination) * np.cos(hour_angle)
@@ -860,7 +969,7 @@ def calculate_solar_elevation(
 
 
 def calculate_solar_declination(
-    ordinal_date: NDArray[np.int_],
+    ordinal_date: ArrayType[np.int_],
 ) -> NDArray[np.floating]:
     r"""Calculate solar declination angle.
 
@@ -878,11 +987,12 @@ def calculate_solar_declination(
         Solar declination angles in radians.
     """
 
+    ordinal_date = xarray_inputs(ordinal_date)
     return -23.4 * (np.pi / 180) * np.cos((2 * np.pi * (ordinal_date + 10)) / 365)
 
 
 def calculate_local_hour_angle(
-    current_time: NDArray[np.floating], solar_noon: NDArray[np.floating]
+    current_time: ArrayType[np.floating], solar_noon: ArrayType[np.floating]
 ) -> NDArray[np.floating]:
     r"""Calculate the local hour angle.
 
@@ -903,13 +1013,14 @@ def calculate_local_hour_angle(
 
     """
 
+    current_time, solar_noon = xarray_inputs(current_time, solar_noon)
     return np.pi * (current_time - solar_noon) / 12
 
 
 def calculate_solar_noon(
-    longitude: NDArray[np.floating],
-    equation_of_time: NDArray[np.floating],
-    standard_longitude: NDArray[np.floating] = np.array([0]),
+    longitude: ArrayType[np.floating],
+    equation_of_time: ArrayType[np.floating],
+    standard_longitude: ArrayType[np.floating] = np.array([0]),
 ) -> NDArray[np.floating]:
     r"""Calculate the solar noon  for a given location.
 
@@ -935,11 +1046,15 @@ def calculate_solar_noon(
 
     """
 
+    longitude, equation_of_time, standard_longitude = xarray_inputs(
+        longitude, equation_of_time, standard_longitude
+    )
+
     return 12 + (4 * -(longitude - standard_longitude) - equation_of_time) / 60
 
 
 def calculate_equation_of_time(
-    day_angle: NDArray[np.floating],
+    day_angle: ArrayType[np.floating],
     coef: tuple[float, ...] = CoreConst.equation_of_time_coef,
 ) -> NDArray[np.floating]:
     r"""Calculate the equation of time.
@@ -968,6 +1083,8 @@ def calculate_equation_of_time(
         An array of equation of time values (minutes)
     """
 
+    day_angle = xarray_inputs(day_angle)
+
     a, b, c, d, e, f = coef
 
     return (
@@ -979,7 +1096,7 @@ def calculate_equation_of_time(
     ) * f
 
 
-def calculate_day_angle(ordinal_date: NDArray[np.int_]) -> NDArray[np.floating]:
+def calculate_day_angle(ordinal_date: ArrayType[np.int_]) -> NDArray[np.floating]:
     r"""Calculate the solar day angle.
 
     Calculates the solar day angle (:math:`\Gamma`, radians) for ordinal dates
@@ -996,7 +1113,7 @@ def calculate_day_angle(ordinal_date: NDArray[np.int_]) -> NDArray[np.floating]:
         An array of solar day angles in radians.
     """
 
-    return 2 * np.pi * (ordinal_date - 1) / 365
+    return 2 * np.pi * (xarray_inputs(ordinal_date) - 1) / 365
 
 
 @dataclass

--- a/pyrealm/core/time_series.py
+++ b/pyrealm/core/time_series.py
@@ -9,6 +9,7 @@ from itertools import pairwise
 import numpy as np
 from numpy.typing import NDArray
 
+from pyrealm.core.xarray import ArrayType, xarray_inputs
 from pyrealm.pmodel import AcclimationModel
 
 
@@ -351,7 +352,7 @@ class AnnualValueCalculator:
 
     def get_annual_means(
         self,
-        values: NDArray[np.floating],
+        values: ArrayType[np.floating],
         within_subset: bool = False,
     ) -> NDArray[np.floating]:
         """Get annual means from an array of values.
@@ -400,6 +401,8 @@ class AnnualValueCalculator:
             within_subset: Should the mean only include values within the subset mask.
         """
 
+        values = xarray_inputs(values)
+
         # Enforce shape
         if values.shape != self.shape:
             raise ValueError(
@@ -432,7 +435,7 @@ class AnnualValueCalculator:
 
     def get_annual_totals(
         self,
-        values: NDArray[np.floating],
+        values: ArrayType[np.floating],
         within_subset: bool = False,
     ) -> NDArray[np.floating]:
         """Get annual totals from an array of values.
@@ -485,6 +488,8 @@ class AnnualValueCalculator:
             values: The data to summarize by year
             within_subset: Should the mean only include values within the subset mask.
         """
+
+        values = xarray_inputs(values)
 
         # Enforce shape
         if values.shape != self.shape:

--- a/pyrealm/core/xarray.py
+++ b/pyrealm/core/xarray.py
@@ -22,7 +22,10 @@ def is_arraytype(var: Any) -> TypeGuard[ArrayType]:
     return True
 
 
-def get_common_dims(*arrays: NDArray | xr.DataArray) -> list[Hashable]:
+def get_common_dims(
+    *arrays: NDArray | xr.DataArray,
+    init_dims: list[Hashable] | None = None,
+) -> list[Hashable]:
     """Get the full list of dimensions across all DataArray arguments.
 
     This needs to be called when there are arrays with multiple dtypes that cannot be
@@ -30,6 +33,7 @@ def get_common_dims(*arrays: NDArray | xr.DataArray) -> list[Hashable]:
 
     Args:
         *arrays: The variables to convert into numpy arrays.
+        init_dims: An optional list of dims to start with.
 
     Returns:
         A list of dimension names.
@@ -39,9 +43,11 @@ def get_common_dims(*arrays: NDArray | xr.DataArray) -> list[Hashable]:
         >>> input_2 = xr.DataArray([[]], dims=["b", "a"])
         >>> get_common_dims(input_1, input_2)
         ['a', 'b']
+        >>> get_common_dims(input_1, input_2, init_dims=["c"])
+        ['c', 'a', 'b']
     """
 
-    dims = []
+    dims = init_dims or []
     for array in arrays:
         if isinstance(array, xr.DataArray):
             dims.extend([d for d in array.dims if d not in dims])
@@ -67,6 +73,7 @@ def xarray_inputs[T: np.generic](
     *,
     kwargs: None = ...,
     dims: list[Hashable] | None = ...,
+    dims_full: bool = ...,
 ) -> NDArray[T]: ...
 
 
@@ -79,6 +86,7 @@ def xarray_inputs[T: np.generic](
     *other_arrays: ArrayType[T],
     kwargs: None = ...,
     dims: list[Hashable] | None = ...,
+    dims_full: bool = ...,
 ) -> tuple[NDArray[T], ...]: ...
 
 
@@ -88,6 +96,7 @@ def xarray_inputs[T: np.generic](
     *arrays: ArrayType[T],
     kwargs: dict[str, ArrayType[T]],
     dims: list[Hashable] | None = ...,
+    dims_full: bool = ...,
 ) -> tuple[tuple[NDArray[T], ...], dict[str, NDArray[T]]]: ...
 
 
@@ -95,6 +104,7 @@ def xarray_inputs[T: np.generic](
     *arrays: ArrayType[T],
     kwargs: dict[str, ArrayType[T]] | None = None,
     dims: list[Hashable] | None = None,
+    dims_full: bool = True,
 ) -> (
     NDArray[T]
     | tuple[NDArray[T], ...]
@@ -116,6 +126,8 @@ def xarray_inputs[T: np.generic](
         *arrays: The variables to convert into numpy arrays.
         kwargs: An optional dictionary of variables to convert to numpy arrays.
         dims: An optional list of dimension names to expand DataArrays to.
+        dims_full: If `dims` is provided this indicates whether this is the full list of
+            dimensions (True) or can be added to by `arrays` (default: True).
 
     Returns:
         The stripped array(s). As a tuple if more than one is provided. As (tuple, dict)
@@ -132,6 +144,8 @@ def xarray_inputs[T: np.generic](
 
     if dims is None:
         dims = get_common_dims(*arrays, *(kwargs or {}).values())
+    elif not dims_full:
+        dims = get_common_dims(*arrays, *(kwargs or {}).values(), init_dims=dims)
 
     # 1 value - return scalar
     if len(arrays) == 1 and not kwargs:

--- a/pyrealm/demography/crown.py
+++ b/pyrealm/demography/crown.py
@@ -402,7 +402,7 @@ def get_crown_xy(
     The data are returned as a list with one entry per stem. The default value for each
     entry a tuple of two arrays (height, attribute values) but the `as_xy=True` option
     will return an `(N, 2)` dimensioned XY array suitable for use with
-    {class}`~matplotlib.patches.Polygon`.
+    :class:`matplotlib.patches.Polygon`.
 
     Args:
         crown_profile: A crown profile instance

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.special import lambertw  # type: ignore[import-untyped]
 
-from pyrealm.constants import PhenologyConst
+from pyrealm import constants
 from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.time_series import AnnualValueCalculator
 from pyrealm.core.utilities import (
@@ -123,7 +123,7 @@ class FaparLimitation:
         annual_growing_season_length: ArrayType[np.floating],
         aridity_index: ArrayType[np.floating],
         years: NDArray[np.datetime64],
-        phenology_const: PhenologyConst = PhenologyConst(),
+        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
     ) -> None:
         # Experimental class
         warn_experimental("FaparLimitation")
@@ -266,7 +266,7 @@ class FaparLimitation:
         precip: ArrayType[np.floating],
         aridity_index: ArrayType[np.floating],
         datetimes: NDArray[np.datetime64] | None = None,
-        phenology_const: PhenologyConst = PhenologyConst(),
+        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
     ) -> FaparLimitation:
         r"""Create a FaparLimitation instance from a P Model and other inputs.
 
@@ -410,7 +410,7 @@ class Phenology:
         datetimes: NDArray[np.datetime64],
         fapar_limitation: FaparLimitation,
         alpha: float = 1 / 15,
-        phenology_const: PhenologyConst = PhenologyConst(),
+        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
     ):
         # Experimental class
         warn_experimental(self.__class__.__name__)

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -344,13 +344,27 @@ class FaparLimitation:
                     "Observation datetimes are required with PModel inputs."
                 )
 
+        else:
+            raise TypeError("Invalid PModel class")
+
+        # Ensure data_shape includes the full time dimension
+        n_time = len(datetimes) if pmodel.shape[0] == 1 else pmodel.shape[0]
+        data_shape = (n_time, *pmodel.shape[1:])
+
         # Create the annual value calculator
         # - the code above guards against datetimes being None
         avc = AnnualValueCalculator(
-            data_shape=pmodel.shape,
+            data_shape=data_shape,
             timing=datetimes,  # type: ignore [arg-type]
             subset_mask=growing_season,
         )
+
+        # Inputs to avc.get_annual_means/totals need the full shapes, so first broadcast
+        gpp = np.broadcast_to(pmodel.gpp, data_shape)
+        ca = np.broadcast_to(pmodel.env.ca, data_shape)
+        chi = np.broadcast_to(pmodel.optchi.chi, data_shape)
+        vpd = np.broadcast_to(pmodel.env.vpd, data_shape)
+        precip = np.broadcast_to(precip, data_shape)
 
         # Get the total GPP for each observation
         # - also need to handle missing values, easier to take _mean_ annual value
@@ -359,15 +373,15 @@ class FaparLimitation:
         #   partial years (or at least warn about it)
 
         # Calculate annual mean potential GPP and scale up to the year
-        annual_mean_potential_gpp = avc.get_annual_means(pmodel.gpp)
+        annual_mean_potential_gpp = avc.get_annual_means(gpp)
         annual_total_potential_gpp = (
             annual_mean_potential_gpp * (avc.year_n_days) * 86400 * 1e-6
         ) / pmodel.core_const.k_c_molmass
 
         # Calculate annual mean ca, chi and VPD within growing season
-        annual_mean_ca = avc.get_annual_means(pmodel.env.ca, within_subset=True)
-        annual_mean_chi = avc.get_annual_means(pmodel.optchi.chi, within_subset=True)
-        annual_mean_vpd = avc.get_annual_means(pmodel.env.vpd, within_subset=True)
+        annual_mean_ca = avc.get_annual_means(ca, within_subset=True)
+        annual_mean_chi = avc.get_annual_means(chi, within_subset=True)
+        annual_mean_vpd = avc.get_annual_means(vpd, within_subset=True)
 
         # Calculate total annual precipitation
         annual_total_precip = avc.get_annual_totals(precip)

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -25,7 +25,7 @@ import numpy as np
 from numpy.typing import NDArray
 from scipy.special import lambertw  # type: ignore[import-untyped]
 
-from pyrealm import constants
+from pyrealm.constants import PhenologyConst
 from pyrealm.core.experimental import warn_experimental
 from pyrealm.core.time_series import AnnualValueCalculator
 from pyrealm.core.utilities import (
@@ -123,7 +123,7 @@ class FaparLimitation:
         annual_growing_season_length: ArrayType[np.floating],
         aridity_index: ArrayType[np.floating],
         years: NDArray[np.datetime64],
-        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
+        phenology_const: PhenologyConst = PhenologyConst(),
     ) -> None:
         # Experimental class
         warn_experimental("FaparLimitation")
@@ -266,7 +266,7 @@ class FaparLimitation:
         precip: ArrayType[np.floating],
         aridity_index: ArrayType[np.floating],
         datetimes: NDArray[np.datetime64] | None = None,
-        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
+        phenology_const: PhenologyConst = PhenologyConst(),
     ) -> FaparLimitation:
         r"""Create a FaparLimitation instance from a P Model and other inputs.
 
@@ -410,7 +410,7 @@ class Phenology:
         datetimes: NDArray[np.datetime64],
         fapar_limitation: FaparLimitation,
         alpha: float = 1 / 15,
-        phenology_const: constants.PhenologyConst = constants.PhenologyConst(),
+        phenology_const: PhenologyConst = PhenologyConst(),
     ):
         # Experimental class
         warn_experimental(self.__class__.__name__)

--- a/pyrealm/phenology/fapar_limitation.py
+++ b/pyrealm/phenology/fapar_limitation.py
@@ -33,6 +33,7 @@ from pyrealm.core.utilities import (
     exponential_moving_average,
     summarize_attrs,
 )
+from pyrealm.core.xarray import ArrayType, xarray_inputs
 from pyrealm.pmodel.pmodel import PModel, PModelABC, SubdailyPModel
 
 
@@ -105,7 +106,7 @@ class FaparLimitation:
         aridity_index: A climatological estimate of the local aridity index, calculated
             as the long term (typically 20 years) total PET over total precipitation
             (:math:`AI`, unitless).
-        years: An array of year datetimes for the observations.
+        years: A 1D array of year datetimes for the observations.
         phenology_const: An instance of
             :class:`~pyrealm.constants.phenology_const.PhenologyConst`
     """
@@ -114,18 +115,37 @@ class FaparLimitation:
 
     def __init__(
         self,
-        annual_total_potential_gpp: NDArray[np.floating],
-        annual_mean_ca: NDArray[np.floating],
-        annual_mean_chi: NDArray[np.floating],
-        annual_mean_vpd: NDArray[np.floating],
-        annual_total_precip: NDArray[np.floating],
-        annual_growing_season_length: NDArray[np.floating],
-        aridity_index: NDArray[np.floating],
+        annual_total_potential_gpp: ArrayType[np.floating],
+        annual_mean_ca: ArrayType[np.floating],
+        annual_mean_chi: ArrayType[np.floating],
+        annual_mean_vpd: ArrayType[np.floating],
+        annual_total_precip: ArrayType[np.floating],
+        annual_growing_season_length: ArrayType[np.floating],
+        aridity_index: ArrayType[np.floating],
         years: NDArray[np.datetime64],
         phenology_const: PhenologyConst = PhenologyConst(),
     ) -> None:
         # Experimental class
         warn_experimental("FaparLimitation")
+
+        # Convert arrays to numpy
+        (
+            annual_total_potential_gpp,
+            annual_mean_ca,
+            annual_mean_chi,
+            annual_mean_vpd,
+            annual_total_precip,
+            annual_growing_season_length,
+            aridity_index,
+        ) = xarray_inputs(
+            annual_total_potential_gpp,
+            annual_mean_ca,
+            annual_mean_chi,
+            annual_mean_vpd,
+            annual_total_precip,
+            annual_growing_season_length,
+            aridity_index,
+        )
 
         # Validate the input shapes.
         self.shape: tuple[int, ...] = check_input_shapes(
@@ -242,9 +262,9 @@ class FaparLimitation:
     def from_pmodel(
         cls,
         pmodel: PModelABC,
-        growing_season: NDArray[np.bool],
-        precip: NDArray[np.floating],
-        aridity_index: NDArray[np.floating],
+        growing_season: ArrayType[np.bool],
+        precip: ArrayType[np.floating],
+        aridity_index: ArrayType[np.floating],
         datetimes: NDArray[np.datetime64] | None = None,
         phenology_const: PhenologyConst = PhenologyConst(),
     ) -> FaparLimitation:
@@ -294,7 +314,7 @@ class FaparLimitation:
             pmodel: A :class:`pyrealm.pmodel.pmodel.PModel` or
                 :class:`pyrealm.pmodel.pmodel.SubdailyPModel` instance, fitted with
                 ``fapar`` fixed at one.
-            datetimes: An array giving the datetimes of observations.
+            datetimes: A 1D array giving the datetimes of observations.
             growing_season: A boolean array indicating which observations are to be
                 considered as part of the growing season.
             precip: An array of precipitation for each observation.
@@ -302,6 +322,11 @@ class FaparLimitation:
             phenology_const: An instance of
                 :class:`~pyrealm.constants.phenology_const.PhenologyConst`
         """
+
+        # Convert array inputs to numpy
+        precip = xarray_inputs(precip, dims=pmodel.env.dims)
+        aridity_index = xarray_inputs(aridity_index, dims=pmodel.env.dims)
+        growing_season = xarray_inputs(growing_season, dims=pmodel.env.dims)
 
         # Check the datetimes - should they be taken from the AcclimationModel of the
         # SubdailyPModel or are they required for standard PModels?

--- a/pyrealm/splash/evap.py
+++ b/pyrealm/splash/evap.py
@@ -16,6 +16,7 @@ from pyrealm.core.hygro import (
 from pyrealm.core.time_series import broadcast_time
 from pyrealm.core.utilities import check_input_shapes
 from pyrealm.core.water import calculate_density_h2o
+from pyrealm.core.xarray import ArrayType, xarray_inputs
 from pyrealm.splash.solar import DailySolarFluxes
 
 
@@ -48,9 +49,9 @@ class DailyEvapFluxes:
     """
 
     solar: DailySolarFluxes
-    pa: InitVar[NDArray[np.floating]]
-    tc: InitVar[NDArray[np.floating]]
-    kWm: NDArray[np.floating] = field(default_factory=lambda: np.array([150.0]))
+    pa: InitVar[ArrayType[np.floating]]
+    tc: InitVar[ArrayType[np.floating]]
+    kWm: ArrayType[np.floating] = field(default_factory=lambda: np.array([150.0]))
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
 
     sat: NDArray[np.floating] = field(init=False)
@@ -72,7 +73,9 @@ class DailyEvapFluxes:
     rx: NDArray[np.floating] = field(init=False)
     """Variable substitute, (mm/hr)/(W/m^2)"""
 
-    def __post_init__(self, pa: NDArray[np.floating], tc: NDArray[np.floating]) -> None:
+    def __post_init__(
+        self, pa: ArrayType[np.floating], tc: ArrayType[np.floating]
+    ) -> None:
         """Calculate invariant components of evapotranspiration.
 
         The post_init method calculates the components of the evaporative fluxes that
@@ -80,8 +83,12 @@ class DailyEvapFluxes:
         state when iterating over time.
         """
 
+        pa, tc, self.kWm = xarray_inputs(pa, tc, self.kWm, dims=self.solar.dims)
+
         try:
-            self.shape: tuple = check_input_shapes(pa, tc, shape=self.solar.shape)
+            self.shape: tuple = check_input_shapes(
+                pa, tc, self.kWm, shape=self.solar.shape
+            )
             """The array shape of the input variables"""
         except ValueError:
             msg = (
@@ -123,7 +130,7 @@ class DailyEvapFluxes:
 
     def estimate_aet(
         self,
-        wn: NDArray[np.floating],
+        wn: ArrayType[np.floating],
         day_idx: int | None = None,
         only_aet: bool = True,
     ) -> (
@@ -156,11 +163,15 @@ class DailyEvapFluxes:
         # subset the calculations to particular request days or use the entire array of
         # soil moisture. The slice here is used to programmatically select `array[:]`.
         if day_idx is None:
+            splash_dims = self.solar.dims
             splash_shape = self.shape
             didx: int | slice = slice(self.shape[0])
         else:
+            splash_dims = self.solar.dims[1:]
             splash_shape = self.shape[1:]
             didx = day_idx
+
+        wn = xarray_inputs(wn, dims=splash_dims)
         try:
             check_input_shapes(wn, shape=splash_shape)
         except ValueError:

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -25,6 +25,7 @@ from pyrealm.core.solar import (
     calculate_transmissivity,
 )
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.core.xarray import ArrayType, get_common_dims, xarray_inputs
 
 
 @dataclass
@@ -44,11 +45,11 @@ class DailySolarFluxes:
         temperature: Daily temperature of observations (°C)
     """
 
-    latitude: InitVar[NDArray[np.floating]]
-    elevation: InitVar[NDArray[np.floating]]
+    latitude: InitVar[ArrayType[np.floating]]
+    elevation: InitVar[ArrayType[np.floating]]
     dates: Calendar
-    sunshine_fraction: InitVar[NDArray[np.floating]]
-    temperature: InitVar[NDArray[np.floating]]
+    sunshine_fraction: InitVar[ArrayType[np.floating]]
+    temperature: InitVar[ArrayType[np.floating]]
     core_const: CoreConst = field(default_factory=lambda: CoreConst())
 
     nu: NDArray[np.floating] = field(init=False)
@@ -84,17 +85,21 @@ class DailySolarFluxes:
 
     def __post_init__(
         self,
-        latitude: NDArray[np.floating],
-        elevation: NDArray[np.floating],
-        sunshine_fraction: NDArray[np.floating],
-        temperature: NDArray[np.floating],
+        latitude: ArrayType[np.floating],
+        elevation: ArrayType[np.floating],
+        sunshine_fraction: ArrayType[np.floating],
+        temperature: ArrayType[np.floating],
     ) -> None:
         """Populates key fluxes from input variables."""
 
+        # Convert inputs
+        inputs = latitude, elevation, sunshine_fraction, temperature
+        self.dims = get_common_dims(*inputs)
+        inputs_np = xarray_inputs(*inputs, dims=self.dims)
+        latitude, elevation, sunshine_fraction, temperature = inputs_np
+
         # Validate the inputs
-        self.shape: tuple = check_input_shapes(
-            latitude, elevation, sunshine_fraction, temperature
-        )
+        self.shape: tuple = check_input_shapes(*inputs_np)
         """The array shape of the input variables"""
 
         if self.shape[0] == 1:

--- a/pyrealm/splash/solar.py
+++ b/pyrealm/splash/solar.py
@@ -37,6 +37,10 @@ class DailySolarFluxes:
     given a Calendar object providing the Julian day of the observations and the year
     and number of days in the year.
 
+    The first dimension for the array inputs should correspond to time. If xarray inputs
+    are used, ``dates`` should also be initialised using xarray inputs to
+    ensure this. Alternatively, ``latitude`` can include time as the first dimension.
+
     Args:
         latitude: The Latitude of observations (degrees)
         elevation: Elevation of observations (metres)
@@ -92,9 +96,10 @@ class DailySolarFluxes:
     ) -> None:
         """Populates key fluxes from input variables."""
 
-        # Convert inputs
+        # Convert inputs to numpy
         inputs = latitude, elevation, sunshine_fraction, temperature
-        self.dims = get_common_dims(*inputs)
+        # Ensure first dimension is time if dates is also initialised with xarray
+        self.dims = get_common_dims(*inputs, init_dims=self.dates.dims)
         inputs_np = xarray_inputs(*inputs, dims=self.dims)
         latitude, elevation, sunshine_fraction, temperature = inputs_np
 

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -29,10 +29,14 @@ class SplashModel:
     attributes as instances of :class:`~pyrealm.splash.solar.DailySolarFluxes` and
     :class:`~pyrealm.splash.evap.DailyEvapFluxes`.
 
-    The inputs to a SplashModel are expected to be numpy arrays with time varying along
-    the first dimension. Other dimensions represent observations at sites on a
-    particular date.  The ``dates`` argument is expected to be a Calendar object with
-    the same length as the first dimension.
+    The inputs to a SplashModel are expected to be arrays with time varying along the
+    first dimension. Other dimensions represent observations at sites on a particular
+    date.  The ``dates`` argument is expected to be a Calendar object with the same
+    length as the first dimension.
+
+    If xarray inputs are used, ``dates`` should also be initialised using xarray inputs
+    to ensure that the time dimension is set correctly. Alternatively, ``lat`` can
+    include time as the first dimension.
 
     The main use of the SplashModel object is then to calculate the expected actual
     evapotranspiration (AET), soil moisture and runoff across the time series:
@@ -72,7 +76,8 @@ class SplashModel:
     ):
         # Convert array inputs to numpy
         inputs = elv, lat, sf, tc, pn
-        self.dims = get_common_dims(*inputs)
+        # Ensure first dimension is time if dates is also initialised with xarray
+        self.dims = get_common_dims(*inputs, init_dims=dates.dims)
         inputs_np = xarray_inputs(*inputs, dims=self.dims)
         elv, lat, sf, tc, pn = inputs_np
 

--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -14,6 +14,7 @@ from pyrealm.core.calendar import Calendar
 from pyrealm.core.pressure import calculate_patm
 from pyrealm.core.time_series import broadcast_time
 from pyrealm.core.utilities import check_input_shapes
+from pyrealm.core.xarray import ArrayType, get_common_dims, xarray_inputs
 from pyrealm.splash.evap import DailyEvapFluxes
 from pyrealm.splash.solar import DailySolarFluxes
 
@@ -59,20 +60,24 @@ class SplashModel:
 
     def __init__(
         self,
-        lat: NDArray[np.floating],
-        elv: NDArray[np.floating],
-        sf: NDArray[np.floating],
-        tc: NDArray[np.floating],
-        pn: NDArray[np.floating],
+        lat: ArrayType[np.floating],
+        elv: ArrayType[np.floating],
+        sf: ArrayType[np.floating],
+        tc: ArrayType[np.floating],
+        pn: ArrayType[np.floating],
         dates: Calendar,
-        kWm: NDArray[np.floating] = np.array([150.0]),
+        kWm: ArrayType[np.floating] = np.array([150.0]),
         core_const: CoreConst = CoreConst(),
         bounds_checker: BoundsChecker = BoundsChecker(),
     ):
+        # Convert array inputs to numpy
+        inputs = elv, lat, sf, tc, pn
+        self.dims = get_common_dims(*inputs)
+        inputs_np = xarray_inputs(*inputs, dims=self.dims)
+        elv, lat, sf, tc, pn = inputs_np
+
         # Check input sizes are congurent
-        # TODO - xarray would be good here for identifying axes and
-        #        checking congruence more widely.
-        self.shape: tuple = check_input_shapes(elv, lat, sf, tc, pn)
+        self.shape: tuple = check_input_shapes(*inputs_np)
         """The array shape of the input variables"""
 
         if self.shape[0] == 1:
@@ -128,7 +133,7 @@ class SplashModel:
 
     def estimate_initial_soil_moisture(
         self,
-        wn_init: NDArray[np.floating] | None = None,
+        wn_init: ArrayType[np.floating] | None = None,
         max_iter: int = 10,
         max_diff: float = 1.0,
         return_convergence: bool = False,
@@ -177,6 +182,7 @@ class SplashModel:
         wn_ret = []
 
         if wn_init is not None:
+            wn_init = xarray_inputs(wn_init, dims=self.dims[1:])
             # Check the shape is the same as the shape of a slice along axis 0
             if wn_init.shape != self.shape[1:]:
                 raise ValueError("Incorrect shape in wn_init")
@@ -241,7 +247,7 @@ class SplashModel:
             return wn_start
 
     def estimate_daily_water_balance(
-        self, previous_wn: NDArray[np.floating], day_idx: int | None = None
+        self, previous_wn: ArrayType[np.floating], day_idx: int | None = None
     ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
         r"""Estimate the daily water balance.
 
@@ -279,11 +285,15 @@ class SplashModel:
         # Check day_idx inputs to map either the single time index given in day_idx or
         # the whole dataset.
         if day_idx is None:
+            splash_dims = self.dims
             splash_shape = self.shape
             didx: int | slice = slice(self.shape[0])
         else:
+            splash_dims = self.dims[1:]
             splash_shape = self.shape[1:]
             didx = day_idx
+
+        previous_wn = xarray_inputs(previous_wn, dims=splash_dims)
         try:
             check_input_shapes(previous_wn, shape=splash_shape)
         except ValueError:
@@ -312,7 +322,7 @@ class SplashModel:
 
     def calculate_soil_moisture(
         self,
-        wn_init: NDArray[np.floating],
+        wn_init: ArrayType[np.floating],
     ) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
         """Calculate the soil moisture, AET and runoff from a SplashModel.
 
@@ -330,6 +340,7 @@ class SplashModel:
             A tuple of numpy arrays containing predicted AET, soil moisture and runoff.
         """
 
+        wn_init = xarray_inputs(wn_init, dims=self.dims[1:])
         try:
             check_input_shapes(wn_init, shape=self.shape[1:])
         except ValueError:

--- a/tests/array_inputs/overrides.py
+++ b/tests/array_inputs/overrides.py
@@ -388,10 +388,16 @@ def _(ctx):
 
 ## Phenology module
 
-_PHENOLOGY_N_TIMES = 48
+_PHENOLOGY_N_TIMES = 2
 
 register_args("FaparLimitation")(
     lambda ctx: {"years": np.ones(ctx.bcast_shape[0], dtype="datetime64[Y]")}
+)
+register_args("FaparLimitation.from_pmodel")(
+    lambda ctx: {
+        "datetimes": np.arange(0, _PHENOLOGY_N_TIMES, dtype="datetime64[D]"),
+        "aridity_index": np.ones(_set_time_len(1, ctx)),  # Time: constant or years (1)
+    }
 )
 register_args("Phenology")(
     lambda _: {

--- a/tests/array_inputs/overrides.py
+++ b/tests/array_inputs/overrides.py
@@ -26,10 +26,11 @@ from math import ceil
 
 import numpy as np
 
+from pyrealm.constants import PhenologyConst
 from pyrealm.core.calendar import Calendar
 from pyrealm.core.xarray import ArrayType
 from pyrealm.demography.flora import PlantFunctionalType
-from pyrealm.phenology.fapar_limitation import FaparLimitation, PhenologyConst
+from pyrealm.phenology.fapar_limitation import FaparLimitation
 from tests.array_inputs.context import Context
 
 # These methods are not relevant or are incompatible without additional work

--- a/tests/array_inputs/overrides.py
+++ b/tests/array_inputs/overrides.py
@@ -223,6 +223,15 @@ def _set_time_len(n_time: int, ctx: Context, allow_one: bool = True) -> tuple[in
     return tuple(shape)
 
 
+def _del_time_dim(ctx: Context) -> tuple[int, ...]:
+    """Return the shape with the time dimension removed."""
+    shape = list(ctx.shape)
+    time_dim = _get_time_dim(ctx)
+    if time_dim is not None:
+        del shape[time_dim]
+    return tuple(shape)
+
+
 ## Core module
 
 register_args("broadcast_time")(lambda ctx: {"shape": ctx.bcast_shape})
@@ -314,15 +323,15 @@ register_args("AcclimationModel.set_nearest")(
 
 
 ## Splash module
-# The size of the first dimension needs to match the number of dates in the Calendar
+# The size of the time dimension needs to match the number of dates in the Calendar
 _SPLASH_N_DATES = 10
 
 register_args("SplashModel.estimate_daily_water_balance")(
-    lambda ctx: {"previous_wn": np.full((_SPLASH_N_DATES, *ctx.shape[1:]), 10)}
+    lambda ctx: {"previous_wn": np.full(_set_time_len(_SPLASH_N_DATES, ctx), 10)}
 )
-# wn_init should not include the first dimension of the shape
+# wn_init should not include the time dimension of the shape
 register_args("SplashModel.calculate_soil_moisture")(
-    lambda ctx: {"wn_init": np.full(ctx.shape[1:], 10)}
+    lambda ctx: {"wn_init": np.full(_del_time_dim(ctx), 10)}
 )
 
 

--- a/tests/array_inputs/test_xarray.py
+++ b/tests/array_inputs/test_xarray.py
@@ -44,7 +44,13 @@ DEPENDENT_LIST: list[str] = [
     "SplashModel.calculate_soil_moisture",
     "DailyEvapFluxes",
     "DailyEvapFluxes.estimate_aet",
+    # phenology
+    "FaparLimitation.from_pmodel",
 ]
+
+# Check all dependent functions are used
+unused: set[str] = set(DEPENDENT_LIST) - {m[0] for m in METHOD_LIST}
+assert not unused, f"Dependent functions not in METHOD_LIST: {unused}"
 
 
 def shapes_xarray(

--- a/tests/array_inputs/test_xarray.py
+++ b/tests/array_inputs/test_xarray.py
@@ -38,6 +38,12 @@ DEPENDENT_LIST: list[str] = [
     "OptimalChiLavergne20C4.estimate_chi",
     "OptimalChiC4NoGamma.estimate_chi",
     "OptimalChiC4NoGammaRootzoneStress.estimate_chi",
+    # splash
+    "SplashModel.estimate_initial_soil_moisture",
+    "SplashModel.estimate_daily_water_balance",
+    "SplashModel.calculate_soil_moisture",
+    "DailyEvapFluxes",
+    "DailyEvapFluxes.estimate_aet",
 ]
 
 

--- a/tests/array_inputs/utils.py
+++ b/tests/array_inputs/utils.py
@@ -441,7 +441,6 @@ def generate_args(method: Callable, ctx: Context) -> dict[str, Any]:
 
     # Print the arguments if in debug mode
     if config.DEBUG:
-        np.set_printoptions(threshold=1)
         print(f"\n{ctx.name}\nParents: {ctx.parents}\nArguments:")
         for param_name, (_, _, approach) in params.items():
             print(f"\t{param_name}: ({approach})")

--- a/tests/array_inputs/utils.py
+++ b/tests/array_inputs/utils.py
@@ -52,6 +52,7 @@ from pyrealm.demography.flora import (
     PlantFunctionalTypeStrict,
     StemTraits,
 )
+from pyrealm.pmodel import PModel
 from tests.array_inputs.context import Context
 from tests.array_inputs.overrides import (
     ADDITIONAL_INIT_METHODS,
@@ -108,10 +109,15 @@ def _get_module_callables(
     for name, obj in getmembers(module):
         if getattr(obj, "__module__", None) != module.__name__:
             continue
+
         if isfunction(obj) or ismethod(obj):
             yield name, obj, None
+
         elif isclass(obj):
-            for mname, method in getmembers(obj, predicate=isfunction):
+            # Get the class methods
+            for mname, method in getmembers(
+                obj, predicate=lambda m: isfunction(m) or ismethod(m)
+            ):
                 if mname in ["__init__", "__post_init__"]:
                     full_name = name
                 else:
@@ -369,6 +375,8 @@ def _initialise_type_default(typ: Any, ctx: Context) -> Any:
         return 1
     elif typ is Any:
         return None
+    elif typ.__name__ == "PModelABC":
+        return _initialise_type_default(PModel, ctx.new("PModel"))
     elif typ is PlantFunctionalTypeStrict:
         return PlantFunctionalType(name=f"default.{randint(1, 10000)}")
     elif typ is Flora:

--- a/tests/unit/core/test_xarray.py
+++ b/tests/unit/core/test_xarray.py
@@ -36,6 +36,13 @@ def test_get_common_dims():
     assert dims == ["a", "b"]
 
 
+def test_get_common_dims_init():
+    """Test get_common_dims gives expected outputs using `init_dims`."""
+    input_1 = xr.DataArray([[]], dims=["c", "d"])
+    dims = get_common_dims(input_1, init_dims=["a", "b"])
+    assert dims == ["a", "b", "c", "d"]
+
+
 @pytest.fixture
 def dataset() -> xr.Dataset:
     """Fixture to load the pmodel_global dataset for testing inputs."""

--- a/tests/unit/core/test_xarray.py
+++ b/tests/unit/core/test_xarray.py
@@ -158,5 +158,5 @@ def test_xarray_pmodel_environment(dataset: xr.Dataset):
     tc = dataset["temp"]
     vpd = dataset["VPD"]
     co2 = dataset["CO2"]
-    patm = calculate_patm(dataset["elevation"].isel(Time=0))
+    patm = calculate_patm(dataset["elevation"].isel(Time=[0]))  # Need to keep time dim
     PModelEnvironment(tc=tc, vpd=vpd, co2=co2, patm=patm)


### PR DESCRIPTION
# Description

This branches off #644 so should be only be merged after that.

Adds xarray inputs to modules other than just pmodel.
- [x] Fixes some cross references in the docs (d504a0d).
- [x] Xarray inputs to core module (cbba03d).
- [x] Xarray inputs to splash module (2150c6d, 49c9f04).
- [x] Xarray inputs to phenology module ([8888338 - 05161e0](https://github.com/ImperialCollegeLondon/pyrealm/pull/643/changes/2150c6d418115001832d75b7cdc2dd4f2b816ba0..05161e0a9777dd10459c2d340f2364f18dd0ebeb)).
- [x] Update the SplashModel worked example to not use `to_numpy()` (1cec4f7)

In `SplashModel` and `DailySolarFluxes` the first dimension should be time, but under the xarray dimension rules the first dimension would be set by the first argument which is latitude. To avoid this issue I have:
- Add a `init_dims` argument to allow a list of initial dimensions to `get_common_dimensions` (which gives the dimensions for expanding xarray inputs) (07d38bc).
- Converted `Calendar` to also accept xarray inputs and store the dimension(s) (49c9f04). (I resolved the issue with mypy not recognising the narrowing of the dataclass attribute types in `__post_init__` by using an `__init__` function. I think this is also neater.)
- Using both of the above in `SplashModel` and `DailySolarFluxes` to set the initial dimension to be the time dimension when the `Calendar` argument is initialised using xarray.
- Added to the docstrings that the `Calendar` arguments should be initialised with xarray (or that latitude should include the time dimension).

~~There is also an issue with sphinx autodoc not identifying the correct cross-reference target for `PhenologyConst` in `phenology/fapar_limitation.py` as a result of duplicates of each of the constants classes in [the constants page of the docs](https://pyrealm.readthedocs.io/en/latest/api/constants_api.html). I'm not really sure why this just started turning up and only for `PhenologyConst`, but I have resolved it by using `constants.Phenology` in the file instead. I had tried removing the duplicates from the `constants_api.md` file (either from the `pyrealm.constants` module or the submodules) but this just caused sphinx to break in more places.~~

The sphinx issue is instead due to failing on `ArrayType[np.floating]` which then causes issues with the cross referencing of other arguments in the same functions. I added a patch in sphinx's `conf.py` to resolve this (11bef37)

Fixes #631

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
