### PR TITLE
Fix `SplashModel.calculate_soil_moisture` for 1D inputs

### DIFF
--- a/pyrealm/splash/splash.py
+++ b/pyrealm/splash/splash.py
@@ -353,6 +353,12 @@ class SplashModel:
                 curr_wn, day_idx=day_idx
             )
 
+            # Convert the outputs to scalars if there is only a time axis
+            if len(self.shape) == 1:
+                aet = aet.squeeze()
+                curr_wn = curr_wn.squeeze()
+                ro = ro.squeeze()
+
             # Store the outputs to return
             aet_out[day_idx] = aet
             wn_out[day_idx] = curr_wn

--- a/tests/unit/splash/test_splash_model.py
+++ b/tests/unit/splash/test_splash_model.py
@@ -162,3 +162,27 @@ def test_calculate_soil_moisture(splash_model):
         equal_nan=True,
         rtol=1e-6,
     )
+
+
+def test_calculate_soil_moisture_1D(calendar):
+    """Test for correct assignment in calculate_soil_moisture method for 1D inputs."""
+
+    from pyrealm.splash.splash import SplashModel
+
+    n_days = calendar.n_dates
+
+    lat = np.zeros(n_days)
+    elv = np.zeros(n_days)
+    sf = np.zeros(n_days)
+    tc = np.zeros(n_days)
+    pn = np.zeros(n_days)
+
+    splash = SplashModel(lat=lat, elv=elv, dates=calendar, sf=sf, tc=tc, pn=pn)
+
+    # Check there is no error for (1D) scalar initial value
+    wn_init = np.array([1])
+    aet, wn, ro = splash.calculate_soil_moisture(wn_init)
+
+    assert aet.shape == (n_days,)
+    assert wn.shape == (n_days,)
+    assert ro.shape == (n_days,)


### PR DESCRIPTION
# Description

This resolves the bug for numpy >= 2.4.0 where `calculate_soil_moisture` was attempting to set array elements with size 1 1D arrays. It does this by converting these to scalars (0D arrays) if the splash model shape is 1D, i.e. time dimension only.

Fixes #626 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

## Key checklist

- [x] Make sure you've run the `pre-commit` checks: `$ pre-commit run -a`
- [x] All tests pass: `$ poetry run pytest`

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works